### PR TITLE
fix(ota): Job document without code-signing

### DIFF
--- a/src/ota/encoding/json.rs
+++ b/src/ota/encoding/json.rs
@@ -32,7 +32,8 @@ pub struct FileDescription<'a> {
     #[serde(rename = "fileid")]
     pub fileid: u8,
     #[serde(rename = "certfile")]
-    pub certfile: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub certfile: Option<&'a str>,
     #[serde(rename = "update_data_url")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update_data_url: Option<&'a str>,
@@ -59,20 +60,20 @@ pub struct FileDescription<'a> {
 }
 
 impl<'a> FileDescription<'a> {
-    pub fn signature(&self) -> Signature {
+    pub fn signature(&self) -> Option<Signature> {
         if let Some(sig) = self.sha1_rsa {
-            return Signature::Sha1Rsa(heapless::String::try_from(sig).unwrap());
+            return Some(Signature::Sha1Rsa(heapless::String::try_from(sig).unwrap()));
         }
         if let Some(sig) = self.sha256_rsa {
-            return Signature::Sha256Rsa(heapless::String::try_from(sig).unwrap());
+            return Some(Signature::Sha256Rsa(heapless::String::try_from(sig).unwrap()));
         }
         if let Some(sig) = self.sha1_ecdsa {
-            return Signature::Sha1Ecdsa(heapless::String::try_from(sig).unwrap());
+            return Some(Signature::Sha1Ecdsa(heapless::String::try_from(sig).unwrap()));
         }
         if let Some(sig) = self.sha256_ecdsa {
-            return Signature::Sha256Ecdsa(heapless::String::try_from(sig).unwrap());
+            return Some(Signature::Sha256Ecdsa(heapless::String::try_from(sig).unwrap()));
         }
-        unreachable!()
+        None
     }
 }
 
@@ -146,5 +147,29 @@ mod tests {
                 format!("{{\"self_test\":\"{}\"}}", exp).as_str()
             );
         }
+    }
+
+    #[test]
+    fn deserializ() {
+        let data = r#"{
+    "protocols": [
+      "MQTT"
+    ],
+    "streamname": "AFR_OTA-d11032e9-38d5-4dca-8c7c-1e6f24533ede",
+    "files": [
+      {
+        "filepath": "3.8.4",
+        "filesize": 537600,
+        "fileid": 0,
+        "certfile": null,
+        "fileType": 0,
+        "update_data_url": null,
+        "auth_scheme": null,
+        "sig--": null
+      }
+    ]
+  }"#;
+
+        let job: (OtaJob, _) = serde_json_core::from_str(&data).unwrap();
     }
 }

--- a/src/ota/encoding/mod.rs
+++ b/src/ota/encoding/mod.rs
@@ -60,10 +60,10 @@ pub struct FileContext {
     pub filepath: heapless::String<64>,
     pub filesize: usize,
     pub fileid: u8,
-    pub certfile: heapless::String<64>,
+    pub certfile: Option<heapless::String<64>>,
     pub update_data_url: Option<heapless::String<64>>,
     pub auth_scheme: Option<heapless::String<64>>,
-    pub signature: Signature,
+    pub signature: Option<Signature>,
     pub file_type: Option<u32>,
     pub protocols: heapless::Vec<Protocol, 2>,
 
@@ -110,7 +110,9 @@ impl FileContext {
             filesize: file_desc.filesize,
             protocols: job_data.ota_document.protocols,
             fileid: file_desc.fileid,
-            certfile: heapless::String::try_from(file_desc.certfile).unwrap(),
+            certfile: file_desc
+                .certfile
+                .map(|cert| heapless::String::try_from(cert).unwrap()),
             update_data_url: file_desc
                 .update_data_url
                 .map(|s| heapless::String::try_from(s).unwrap()),


### PR DESCRIPTION
Make `certfile` optional in ota job document.