### PR TITLE
Fix(async): Get shadow on startup

### DIFF
--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -69,8 +69,11 @@ where
                     )
                     .await
                     .map_err(Error::MqttError)?;
+                let delta_state = self.get_shadow().await?;
 
-                sub_ref.insert(sub)
+                sub_ref.insert(sub);
+
+                return Ok(Some(delta_state));
             }
         };
 

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -73,7 +73,7 @@ where
 
                 sub_ref.insert(sub);
 
-                return Ok(Some(delta_state));
+                return Ok(delta_state.delta);
             }
         };
 

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -416,32 +416,17 @@ where
     /// Wait delta will subscribe if not already to Updatedelta and wait for changes
     ///
     pub async fn wait_delta(&self) -> Result<(S, Option<S::PatchState>), Error> {
-        // We need this to check if reading state from flash fails.
-        // If it does we will write the default state to flash.
-        // We can't write default state to flash in the error block because it will cause a deadlock.
-        let mut read_fail = false;
+        let mut dao = self.dao.lock().await;
 
-        let mut state = match self.dao.lock().await.read().await {
+        let mut state = match dao.read().await {
             Ok(state) => state,
             Err(_) => {
                 error!("Could not read state from flash writing default");
-                read_fail = true;
-
-                S::default()
+                let state = S::default();
+                dao.write(&state).await?;
+                state
             }
         };
-
-        if read_fail {
-            self.dao
-                .lock()
-                .await
-                .write(&S::default())
-                .await
-                .unwrap_or_else(|_| {
-                    error!("Failed to write default state");
-                });
-            info!("Wrote default state to flash");
-        }
 
         let delta = self.handler.handle_delta().await?;
 


### PR DESCRIPTION
We have had some timing issues where we call "get shadow" before an update and then calling wait delta after the update. 

Now when calling wait delta for the first time we also call get_shadow to make sure have the newest version before waiting for changes  