### PR TITLE
Add OTA failure reason reporting and extensible status details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,6 @@ jobs:
           aws-region: eu-west-1
           audience: sts.amazonaws.com
 
-      - name: Create OTA Job
-        run: |
-          ./scripts/create_ota.sh
-
       - name: Integration Tests
         uses: actions-rs/cargo@v1
         with:
@@ -130,8 +126,3 @@ jobs:
           IDENTITY_PASSWORD: ${{ secrets.IDENTITY_PASSWORD }}
           AWS_HOSTNAME: a1vq3mi5y3c6j5-ats.iot.eu-west-1.amazonaws.com
           RUST_LOG: debug
-
-      - name: Cleanup OTA Jobs
-        if: ${{ always() }}
-        run: |
-          ./scripts/cleanup_ota.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,15 @@ p256 = "0.13"
 pkcs8 = { version = "0.10", features = ["encryption", "pem"] }
 hex = { version = "0.4.3", features = ["alloc"] }
 
+aws-config = "1"
+aws-sdk-sts = "1"
+aws-sdk-s3 = "1"
+aws-sdk-iot = "1"
+aws-credential-types = "1"
+uuid = { version = "1", features = ["v4"] }
+base64 = "0.22"
+serial_test = "3"
+
 
 [features]
 default = ["ota_mqtt_data", "metric_cbor", "provision_cbor", "shadows_kv_persist"]

--- a/src/mqtt/mqttrust.rs
+++ b/src/mqtt/mqttrust.rs
@@ -44,7 +44,7 @@ impl<P: ToPayload> mqttrust::ToPayload for PayloadBridge<P> {
 }
 
 /// Convert our [`QoS`] to mqttrust's `QoS`.
-pub fn to_embedded_qos(qos: QoS) -> mqttrust::QoS {
+pub fn to_mqttrust_qos(qos: QoS) -> mqttrust::QoS {
     match qos {
         QoS::AtMostOnce => mqttrust::QoS::AtMostOnce,
         QoS::AtLeastOnce => mqttrust::QoS::AtLeastOnce,
@@ -53,7 +53,7 @@ pub fn to_embedded_qos(qos: QoS) -> mqttrust::QoS {
 }
 
 /// Convert mqttrust's `QoS` to our [`QoS`].
-pub fn from_embedded_qos(qos: mqttrust::QoS) -> QoS {
+pub fn from_mqttrust_qos(qos: mqttrust::QoS) -> QoS {
     match qos {
         mqttrust::QoS::AtMostOnce => QoS::AtMostOnce,
         _ => QoS::AtLeastOnce,
@@ -76,7 +76,7 @@ impl<'a, M: RawMutex, B: BufferProvider> MqttMessage for mqttrust::Message<'a, M
     }
 
     fn qos(&self) -> QoS {
-        from_embedded_qos(self.qos_pid().qos())
+        from_mqttrust_qos(self.qos_pid().qos())
     }
 
     fn dup(&self) -> bool {
@@ -130,7 +130,7 @@ impl<'a, M: RawMutex> crate::mqtt::MqttClient for mqttrust::MqttClient<'a, M> {
         let publish = mqttrust::Publish::builder()
             .topic_name(topic)
             .payload(PayloadBridge(payload))
-            .qos(to_embedded_qos(options.qos))
+            .qos(to_mqttrust_qos(options.qos))
             .retain(options.retain)
             .dup(options.dup)
             .build();
@@ -144,7 +144,7 @@ impl<'a, M: RawMutex> crate::mqtt::MqttClient for mqttrust::MqttClient<'a, M> {
         let subscribe_topics: [mqttrust::SubscribeTopic<'_>; N] = core::array::from_fn(|i| {
             mqttrust::SubscribeTopic::builder()
                 .topic_path(topics[i].0)
-                .maximum_qos(to_embedded_qos(topics[i].1))
+                .maximum_qos(to_mqttrust_qos(topics[i].1))
                 .build()
         });
 

--- a/src/ota/config.rs
+++ b/src/ota/config.rs
@@ -2,6 +2,7 @@ use embassy_time::Duration;
 
 pub struct Config {
     pub block_size: usize,
+    pub max_blocks_per_request: u32,
     pub max_request_momentum: u8,
     pub request_wait: Duration,
     pub status_update_frequency: u32,
@@ -11,10 +12,11 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            block_size: 256,
+            block_size: 4096,
+            max_blocks_per_request: 16,
             max_request_momentum: 3,
             request_wait: Duration::from_secs(5),
-            status_update_frequency: 96,
+            status_update_frequency: 24,
             self_test_timeout: None,
         }
     }

--- a/src/ota/control_interface/mod.rs
+++ b/src/ota/control_interface/mod.rs
@@ -1,4 +1,5 @@
 use crate::jobs::data_types::JobStatus;
+use crate::ota::status_details::StatusDetailsExt;
 
 use super::{
     encoding::{json::JobStatusReason, FileContext},
@@ -11,10 +12,10 @@ pub mod mqtt;
 // Interfaces required for OTA
 pub trait ControlInterface {
     async fn request_job(&self) -> Result<(), OtaError>;
-    async fn update_job_status(
+    async fn update_job_status<E: StatusDetailsExt>(
         &self,
         file_ctx: &FileContext,
-        progress: &mut ProgressState,
+        progress: &mut ProgressState<E>,
         status: JobStatus,
         reason: JobStatusReason,
     ) -> Result<(), OtaError>;

--- a/src/ota/control_interface/mqtt.rs
+++ b/src/ota/control_interface/mqtt.rs
@@ -1,5 +1,3 @@
-use core::fmt::Write;
-
 use super::ControlInterface;
 use crate::jobs::data_types::JobStatus;
 use crate::jobs::{JobTopic, Jobs, MAX_JOB_ID_LEN, MAX_THING_NAME_LEN};
@@ -30,66 +28,40 @@ impl<C: MqttClient> ControlInterface for Mqtt<&'_ C> {
         status: JobStatus,
         reason: JobStatusReason,
     ) -> Result<(), OtaError> {
-        progress_state
-            .status_details
-            .insert(
-                heapless::String::try_from("self_test").unwrap(),
-                heapless::String::try_from(reason.as_str()).unwrap(),
-            )
-            .map_err(|_| OtaError::Overflow)?;
+        // Set the self_test status field
+        progress_state.status_details.set_self_test(reason.as_str());
 
+        // Add progress tracking for in-progress updates
         if let JobStatus::InProgress | JobStatus::Succeeded = status {
-            let received_blocks = progress_state.total_blocks - progress_state.blocks_remaining;
-
             // Don't override the progress on succeeded, nor on self-test
             // active. (Cases where progress counter is lost due to device
             // restarts)
             if status != JobStatus::Succeeded && reason != JobStatusReason::SelfTestActive {
-                let mut progress = heapless::String::new();
-                progress
-                    .write_fmt(format_args!(
-                        "{}/{}",
-                        received_blocks, progress_state.total_blocks
-                    ))
-                    .map_err(|_| OtaError::Overflow)?;
-
+                let received_blocks = progress_state.total_blocks - progress_state.blocks_remaining;
                 progress_state
                     .status_details
-                    .insert(heapless::String::try_from("progress").unwrap(), progress)
-                    .map_err(|_| OtaError::Overflow)?;
+                    .set_progress(received_blocks, progress_state.total_blocks);
             }
         }
 
-        // Downgrade progress updates to QOS 0 to avoid overloading MQTT
-        // buffers during active streaming. But make sure to always send and await ack for first update and last update
-        // if status == JobStatus::InProgress
-        //     && progress_state.blocks_remaining != 0
-        //     && received_blocks != 0
-        // {
-        //     qos = QoS::AtMostOnce;
-        // }
+        // Add failure detail if present (for Rejected/Aborted reasons)
+        if let Some(detail) = reason.detail() {
+            progress_state.status_details.set_failure(detail);
+        } else {
+            // Clear any previous failure details for non-failure reasons
+            progress_state.status_details.clear_failure();
+        }
 
-        // let mut sub = self.0
-        //     .subscribe(&[
-        //         (
-        //             JobTopic::UpdateAccepted(file_ctx.job_name.as_str())
-        //                 .format::<{ MAX_THING_NAME_LEN + MAX_JOB_ID_LEN + 34 }>(
-        //                     self.0.client_id(),
-        //                 )?
-        //                 .as_str(),
-        //             QoS::AtMostOnce,
-        //         ),
-        //         (
-        //             JobTopic::UpdateRejected(file_ctx.job_name.as_str())
-        //                 .format::<{ MAX_THING_NAME_LEN + MAX_JOB_ID_LEN + 34 }>(
-        //                     self.0.client_id(),
-        //                 )?
-        //                 .as_str(),
-        //             QoS::AtMostOnce,
-        //         ),
-        //     ])
-        //     .await
-        //     .map_err(|_| OtaError::Mqtt)?;
+        // Downgrade progress updates to QoS 0 to avoid overloading MQTT
+        // buffers during active streaming. First and last updates remain QoS 1.
+        let qos = if status == JobStatus::InProgress
+            && progress_state.blocks_remaining != 0
+            && progress_state.total_blocks != progress_state.blocks_remaining
+        {
+            QoS::AtMostOnce
+        } else {
+            QoS::AtLeastOnce
+        };
 
         let topic = JobTopic::Update(file_ctx.job_name.as_str())
             .format::<{ MAX_THING_NAME_LEN + MAX_JOB_ID_LEN + 25 }>(self.0.client_id())?;

--- a/src/ota/control_interface/mqtt.rs
+++ b/src/ota/control_interface/mqtt.rs
@@ -31,8 +31,8 @@ impl<C: MqttClient> ControlInterface for Mqtt<&'_ C> {
         // Set the self_test status field
         progress_state.status_details.set_self_test(reason.as_str());
 
-        // Add progress tracking for in-progress updates
-        if let JobStatus::InProgress | JobStatus::Succeeded = status {
+        // Add progress tracking for in-progress and failed updates
+        if let JobStatus::InProgress | JobStatus::Succeeded | JobStatus::Failed = status {
             // Don't override the progress on succeeded, nor on self-test
             // active. (Cases where progress counter is lost due to device
             // restarts)

--- a/src/ota/data_interface/mod.rs
+++ b/src/ota/data_interface/mod.rs
@@ -8,6 +8,7 @@ use core::ops::DerefMut;
 use serde::Deserialize;
 
 use crate::ota::config::Config;
+use crate::ota::status_details::StatusDetailsExt;
 
 use super::{encoding::FileContext, error::OtaError, ProgressState};
 
@@ -60,10 +61,10 @@ pub trait DataInterface {
         file_ctx: &FileContext,
     ) -> Result<Self::ActiveTransfer<'_>, OtaError>;
 
-    async fn request_file_blocks(
+    async fn request_file_blocks<E: StatusDetailsExt>(
         &self,
         file_ctx: &FileContext,
-        progress_state: &mut ProgressState,
+        progress_state: &mut ProgressState<E>,
         config: &Config,
     ) -> Result<(), OtaError>;
 

--- a/src/ota/data_interface/mqtt.rs
+++ b/src/ota/data_interface/mqtt.rs
@@ -5,6 +5,7 @@ use core::str::FromStr;
 use crate::mqtt::{Mqtt, MqttClient, MqttMessage, MqttSubscription, QoS};
 
 use crate::ota::error::OtaError;
+use crate::ota::status_details::StatusDetailsExt;
 use crate::ota::ProgressState;
 use crate::{
     jobs::{MAX_STREAM_ID_LEN, MAX_THING_NAME_LEN},
@@ -172,10 +173,10 @@ impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {
     }
 
     /// Request file block by publishing to the get stream topic
-    async fn request_file_blocks(
+    async fn request_file_blocks<E: StatusDetailsExt>(
         &self,
         file_ctx: &FileContext,
-        progress_state: &mut ProgressState,
+        progress_state: &mut ProgressState<E>,
         config: &Config,
     ) -> Result<(), OtaError> {
         let blocks_available = progress_state.bitmap.len() as u32;

--- a/src/ota/encoding/mod.rs
+++ b/src/ota/encoding/mod.rs
@@ -138,7 +138,7 @@ impl FileContext {
 
             job_name: heapless::String::try_from(job_data.job_name).unwrap(),
             block_offset,
-            request_block_remaining: bitmap.len() as u32,
+            request_block_remaining: (bitmap.len() as u32).min(config.max_blocks_per_request),
             blocks_remaining: file_desc.filesize.div_ceil(config.block_size),
             stream_name: heapless::String::try_from(job_data.ota_document.streamname).unwrap(),
             bitmap,

--- a/src/ota/error.rs
+++ b/src/ota/error.rs
@@ -23,7 +23,7 @@ pub enum OtaError {
     ),
     Mqtt,
     Encoding,
-    Pal,
+    Pal(OtaPalError),
     Timeout,
 }
 
@@ -34,8 +34,8 @@ impl OtaError {
 }
 
 impl From<OtaPalError> for OtaError {
-    fn from(_e: OtaPalError) -> Self {
-        Self::Pal
+    fn from(e: OtaPalError) -> Self {
+        Self::Pal(e)
     }
 }
 

--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -271,9 +271,15 @@ impl Updater {
                 Err(error::OtaError::MomentumAbort)
             }
             Err(e) => {
-                // Signal the error status
+                // Signal the error status, preserving the failure reason if available
+                let reason = match &e {
+                    error::OtaError::Pal(pal_err) => {
+                        JobStatusReason::Aborted(Some(ImageStateReason::Pal(*pal_err)))
+                    }
+                    _ => JobStatusReason::Aborted(None),
+                };
                 job_updater
-                    .update_job_status(JobStatus::Failed, JobStatusReason::Aborted(None))
+                    .update_job_status(JobStatus::Failed, reason)
                     .await?;
 
                 pal.complete_callback(pal::OtaEvent::Fail).await?;

--- a/src/ota/pal.rs
+++ b/src/ota/pal.rs
@@ -62,7 +62,7 @@ pub enum ImageState {
     Testing(ImageStateReason),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum OtaPalError {
     SignatureCheckFailed,

--- a/src/ota/pal.rs
+++ b/src/ota/pal.rs
@@ -143,6 +143,18 @@ pub enum OtaEvent {
 pub trait OtaPal {
     type BlockWriter: NorFlash;
 
+    /// Extra status details to include in job status updates.
+    ///
+    /// Implement [`StatusDetailsExt`] on a custom struct to add
+    /// platform-specific fields (e.g. device temperature, battery level)
+    /// to every job status update sent to AWS IoT.
+    ///
+    /// Use `()` if no extra fields are needed.
+    type StatusDetails: super::StatusDetailsExt + Clone;
+
+    /// Returns a reference to the extra status details.
+    fn status_details(&self) -> &Self::StatusDetails;
+
     /// OTA abort.
     ///
     /// The user may register a callback function when initializing the OTA

--- a/src/ota/status_details.rs
+++ b/src/ota/status_details.rs
@@ -1,0 +1,221 @@
+//! OTA status details types for job status reporting.
+//!
+//! This module provides types for building status details payloads that are
+//! sent to AWS IoT Jobs when updating job execution status. The design allows
+//! users to provide additional context fields via the [`StatusDetailsExt`] trait.
+
+use core::fmt::Write;
+
+use serde::{ser::SerializeMap, Serialize, Serializer};
+
+use super::pal::ImageStateReason;
+
+/// Trait for types that can contribute fields to status details.
+///
+/// Implement this trait to add custom fields to the job status details
+/// payload. The fields are serialized at the same level as the base OTA
+/// status fields (self_test, progress, reason, error_code).
+///
+/// # Example
+///
+/// ```ignore
+/// struct MyContext {
+///     device_temp: u8,
+///     battery_level: u8,
+/// }
+///
+/// impl StatusDetailsExt for MyContext {
+///     fn serialize_into_map<S: SerializeMap>(&self, map: &mut S) -> Result<(), S::Error> {
+///         map.serialize_entry("device_temp", &self.device_temp)?;
+///         map.serialize_entry("battery_level", &self.battery_level)?;
+///         Ok(())
+///     }
+/// }
+/// ```
+pub trait StatusDetailsExt {
+    /// Serialize this type's fields into an existing map.
+    fn serialize_into_map<S: SerializeMap>(&self, map: &mut S) -> Result<(), S::Error>;
+}
+
+/// Default implementation for `()` - no extra fields.
+impl StatusDetailsExt for () {
+    fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
+        Ok(())
+    }
+}
+
+/// Base OTA status details.
+///
+/// Contains the standard OTA fields that are always available for job status
+/// reporting:
+/// - `self_test`: Current test state (receiving, ready, active, accepted, rejected, aborted)
+/// - `progress`: Download progress as "received/total" blocks
+/// - `reason`: Failure reason string for rejected/aborted states
+/// - `error_code`: Numeric error code for failures
+#[derive(Debug, Clone, Default)]
+pub struct OtaStatusDetails {
+    /// Current self-test state (e.g., "receiving", "ready", "active", "accepted")
+    pub self_test: Option<heapless::String<12>>,
+    /// Download progress as "received/total" blocks
+    pub progress: Option<heapless::String<16>>,
+    /// Failure reason string for rejected/aborted states
+    pub reason: Option<heapless::String<24>>,
+    /// Numeric error code for failures
+    pub error_code: Option<u16>,
+}
+
+impl OtaStatusDetails {
+    /// Create a new empty status details.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set the self-test status field.
+    pub fn set_self_test(&mut self, status: &str) {
+        self.self_test = heapless::String::try_from(status).ok();
+    }
+
+    /// Set the progress field from block counts.
+    pub fn set_progress(&mut self, received: usize, total: usize) {
+        let mut s = heapless::String::new();
+        let _ = write!(s, "{}/{}", received, total);
+        self.progress = Some(s);
+    }
+
+    /// Set failure details from an ImageStateReason.
+    pub fn set_failure(&mut self, reason: ImageStateReason) {
+        self.reason = heapless::String::try_from(reason.as_reason_str()).ok();
+        let code = reason.error_code();
+        if code != 0 {
+            self.error_code = Some(code);
+        }
+    }
+
+    /// Clear the failure details (reason and error_code).
+    pub fn clear_failure(&mut self) {
+        self.reason = None;
+        self.error_code = None;
+    }
+
+    /// Serialize the base OTA fields into an existing map.
+    pub fn serialize_into_map<S: SerializeMap>(&self, map: &mut S) -> Result<(), S::Error> {
+        if let Some(ref v) = self.self_test {
+            map.serialize_entry("self_test", v)?;
+        }
+        if let Some(ref v) = self.progress {
+            map.serialize_entry("progress", v)?;
+        }
+        if let Some(ref v) = self.reason {
+            map.serialize_entry("reason", v)?;
+        }
+        if let Some(ref v) = self.error_code {
+            map.serialize_entry("error_code", v)?;
+        }
+        Ok(())
+    }
+
+    /// Combine with user-provided extra context for serialization.
+    ///
+    /// Returns a type that serializes both the base OTA fields and the
+    /// extra context fields into a single flat JSON object.
+    pub fn with_extra<'a, E: StatusDetailsExt>(
+        &'a self,
+        extra: &'a E,
+    ) -> CombinedStatusDetails<'a, E> {
+        CombinedStatusDetails { base: self, extra }
+    }
+}
+
+/// Standalone serialization for OtaStatusDetails (when no extra context).
+impl Serialize for OtaStatusDetails {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        self.serialize_into_map(&mut map)?;
+        map.end()
+    }
+}
+
+/// Combined status details (base OTA fields + user context).
+///
+/// This type serializes both the base [`OtaStatusDetails`] fields and the
+/// user-provided extra context into a single flat JSON object.
+pub struct CombinedStatusDetails<'a, E: StatusDetailsExt> {
+    base: &'a OtaStatusDetails,
+    extra: &'a E,
+}
+
+impl<E: StatusDetailsExt> Serialize for CombinedStatusDetails<'_, E> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        self.base.serialize_into_map(&mut map)?;
+        self.extra.serialize_into_map(&mut map)?;
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_basic_status() {
+        let mut status = OtaStatusDetails::new();
+        status.set_self_test("receiving");
+        status.set_progress(10, 100);
+
+        let json = serde_json_core::to_string::<_, 128>(&status).unwrap();
+        assert_eq!(
+            json.as_str(),
+            r#"{"self_test":"receiving","progress":"10/100"}"#
+        );
+    }
+
+    #[test]
+    fn serialize_with_failure() {
+        let mut status = OtaStatusDetails::new();
+        status.set_self_test("rejected");
+        status.set_failure(ImageStateReason::Pal(
+            super::super::pal::OtaPalError::SignatureCheckFailed,
+        ));
+
+        let json = serde_json_core::to_string::<_, 128>(&status).unwrap();
+        assert_eq!(
+            json.as_str(),
+            r#"{"self_test":"rejected","reason":"sig_check_failed","error_code":1001}"#
+        );
+    }
+
+    struct TestContext {
+        device_temp: u8,
+    }
+
+    impl StatusDetailsExt for TestContext {
+        fn serialize_into_map<S: SerializeMap>(&self, map: &mut S) -> Result<(), S::Error> {
+            map.serialize_entry("device_temp", &self.device_temp)?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn serialize_with_extra_context() {
+        let mut status = OtaStatusDetails::new();
+        status.set_self_test("active");
+
+        let extra = TestContext { device_temp: 42 };
+        let combined = status.with_extra(&extra);
+
+        let json = serde_json_core::to_string::<_, 128>(&combined).unwrap();
+        assert_eq!(json.as_str(), r#"{"self_test":"active","device_temp":42}"#);
+    }
+
+    #[test]
+    fn serialize_with_unit_context() {
+        let mut status = OtaStatusDetails::new();
+        status.set_self_test("accepted");
+
+        let combined = status.with_extra(&());
+
+        let json = serde_json_core::to_string::<_, 128>(&combined).unwrap();
+        assert_eq!(json.as_str(), r#"{"self_test":"accepted"}"#);
+    }
+}

--- a/tests/common/aws_ota.rs
+++ b/tests/common/aws_ota.rs
@@ -1,0 +1,504 @@
+//! AWS OTA test helper — manages OTA job lifecycle for integration tests.
+//!
+//! Handles credential loading, cross-account role assumption, S3 upload,
+//! OTA job creation/cleanup, and cloud-side job status assertions.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_sdk_iot::types::JobExecutionStatus;
+
+const TARGET_ACCOUNT_ID: &str = "411974994697";
+const THING_NAME: &str = "rustot-test";
+const REGION: &str = "eu-west-1";
+const CROSS_ACCOUNT_ROLE: &str = "ExternalAccessProvisionIoT";
+const OTA_UPDATE_ROLE: &str = "IoTOTAUpdateRole";
+
+/// Context returned by [`setup`] — holds everything needed for cleanup and assertions.
+pub struct OtaTestContext {
+    /// MGMT credentials (for S3 operations)
+    mgmt_creds: SharedCredentialsProvider,
+    /// Assumed-role credentials (for IoT operations in the target account)
+    iot_creds: SharedCredentialsProvider,
+    /// The AWS IoT Job ID created by the OTA update
+    job_id: String,
+    /// S3 bucket used for the OTA file
+    s3_bucket: String,
+    /// S3 key used for the OTA file
+    s3_key: String,
+    /// The AWS region
+    region: aws_config::Region,
+}
+
+impl OtaTestContext {
+    /// Describe the job execution for the OTA update on our thing.
+    ///
+    /// Returns `(JobExecutionStatus, HashMap<String, String>)` with the status
+    /// and any status details from the job execution.
+    pub async fn describe_job_execution(
+        &self,
+    ) -> Result<(JobExecutionStatus, HashMap<String, String>), String> {
+        let iot_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(self.region.clone())
+            .credentials_provider(self.iot_creds.clone())
+            .load()
+            .await;
+        let iot_client = aws_sdk_iot::Client::new(&iot_config);
+
+        log::info!("Describing job execution for job ID: {}", self.job_id);
+
+        let execution = iot_client
+            .describe_job_execution()
+            .job_id(&self.job_id)
+            .thing_name(THING_NAME)
+            .send()
+            .await
+            .map_err(|e| format!("DescribeJobExecution failed: {e}"))?;
+
+        let exec = execution.execution().ok_or("No job execution found")?;
+
+        let status = exec.status().ok_or("No status in job execution")?.clone();
+
+        let details: HashMap<String, String> = exec
+            .status_details()
+            .and_then(|d| d.details_map())
+            .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default();
+
+        log::info!("Job execution status: {:?}, details: {:?}", status, details);
+
+        Ok((status, details))
+    }
+
+    /// Cleanup: cancel any non-terminal jobs and delete the S3 object.
+    pub async fn cleanup(&self) {
+        log::info!("Cleaning up OTA test resources...");
+
+        // Cancel any stale jobs
+        if let Err(e) = cancel_stale_jobs(&self.iot_creds, &self.region).await {
+            log::warn!("Failed to cancel stale jobs during cleanup: {}", e);
+        }
+
+        // Delete S3 object
+        let s3_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(self.region.clone())
+            .credentials_provider(self.mgmt_creds.clone())
+            .load()
+            .await;
+        let s3_client = aws_sdk_s3::Client::new(&s3_config);
+
+        match s3_client
+            .delete_object()
+            .bucket(&self.s3_bucket)
+            .key(&self.s3_key)
+            .send()
+            .await
+        {
+            Ok(_) => log::info!("Deleted S3 object s3://{}/{}", self.s3_bucket, self.s3_key),
+            Err(e) => log::warn!("Failed to delete S3 object: {}", e),
+        }
+    }
+
+    /// Assert that the cloud-side job execution has status `SUCCEEDED`.
+    #[allow(dead_code)]
+    pub async fn assert_job_succeeded(&self) {
+        let (status, details) = self
+            .describe_job_execution()
+            .await
+            .expect("Failed to describe job execution");
+        assert_eq!(
+            status,
+            JobExecutionStatus::Succeeded,
+            "Expected job status SUCCEEDED, got {:?} with details: {:?}",
+            status,
+            details
+        );
+    }
+
+    /// Assert that the cloud-side job execution has status `FAILED`.
+    #[allow(dead_code)]
+    pub async fn assert_job_failed(&self) {
+        let (status, details) = self
+            .describe_job_execution()
+            .await
+            .expect("Failed to describe job execution");
+        assert_eq!(
+            status,
+            JobExecutionStatus::Failed,
+            "Expected job status FAILED, got {:?} with details: {:?}",
+            status,
+            details
+        );
+    }
+}
+
+/// Set up AWS OTA test resources.
+///
+/// Returns `Some(OtaTestContext)` if credentials are available and role
+/// assumption succeeds, or `None` if the test should be skipped.
+pub async fn setup() -> Option<OtaTestContext> {
+    let region = aws_config::Region::new(REGION);
+
+    // Load default MGMT credentials from environment
+    let mgmt_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region.clone())
+        .load()
+        .await;
+
+    let sts_client = aws_sdk_sts::Client::new(&mgmt_config);
+
+    // Verify MGMT credentials work
+    let caller = match sts_client.get_caller_identity().send().await {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!(
+                "No valid AWS credentials available, skipping OTA test: {}",
+                e
+            );
+            return None;
+        }
+    };
+
+    let mgmt_account = caller.account().unwrap_or("unknown");
+    log::info!("MGMT account: {}", mgmt_account);
+
+    // Store MGMT credentials provider
+    let mgmt_creds = mgmt_config
+        .credentials_provider()
+        .expect("MGMT config must have credentials")
+        .clone();
+
+    // Assume role into the target IoT account
+    let role_arn = format!("arn:aws:iam::{TARGET_ACCOUNT_ID}:role/{CROSS_ACCOUNT_ROLE}");
+    let assume_result = match sts_client
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("RustotIntegration")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!(
+                "Failed to assume role {}, skipping OTA test: {}",
+                role_arn,
+                e
+            );
+            return None;
+        }
+    };
+
+    let assumed_creds = assume_result.credentials()?;
+    let expiration =
+        std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::from_millis(
+            assumed_creds.expiration().to_millis().unwrap_or(0) as u64,
+        ));
+    let iot_creds_provider = aws_credential_types::Credentials::new(
+        assumed_creds.access_key_id(),
+        assumed_creds.secret_access_key(),
+        Some(assumed_creds.session_token().to_owned()),
+        expiration,
+        "ota-test-assumed-role",
+    );
+    let iot_creds = SharedCredentialsProvider::new(iot_creds_provider);
+
+    // Verify assumed identity is in the target account
+    let iot_sts_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region.clone())
+        .credentials_provider(iot_creds.clone())
+        .load()
+        .await;
+    let iot_sts_client = aws_sdk_sts::Client::new(&iot_sts_config);
+
+    match iot_sts_client.get_caller_identity().send().await {
+        Ok(id) => {
+            let account = id.account().unwrap_or("unknown");
+            if account != TARGET_ACCOUNT_ID {
+                log::warn!(
+                    "Assumed role is in account {} but expected {}, skipping",
+                    account,
+                    TARGET_ACCOUNT_ID
+                );
+                return None;
+            }
+            log::info!("Assumed role identity: {}", id.arn().unwrap_or("unknown"));
+        }
+        Err(e) => {
+            log::warn!("Failed to verify assumed role identity: {}", e);
+            return None;
+        }
+    }
+
+    // Pre-cleanup: cancel stale jobs
+    if let Err(e) = cancel_stale_jobs(&iot_creds, &region).await {
+        log::warn!("Pre-cleanup failed (continuing anyway): {}", e);
+    }
+
+    // Upload OTA file to S3 with MGMT creds
+    let s3_bucket = format!("{}-{}-build-artifacts", mgmt_account, REGION);
+    let update_id = uuid::Uuid::new_v4().to_string();
+    let s3_key = format!("factbird-duo/test/rustot/ota/ota_file-{}", update_id);
+
+    let s3_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region.clone())
+        .credentials_provider(mgmt_creds.clone())
+        .load()
+        .await;
+    let s3_client = aws_sdk_s3::Client::new(&s3_config);
+
+    let ota_file_data =
+        std::fs::read("tests/assets/ota_file").expect("Failed to read tests/assets/ota_file");
+
+    s3_client
+        .put_object()
+        .bucket(&s3_bucket)
+        .key(&s3_key)
+        .body(ota_file_data.into())
+        .send()
+        .await
+        .expect("Failed to upload OTA file to S3");
+
+    log::info!("Uploaded OTA file to s3://{}/{}", s3_bucket, s3_key);
+
+    // Create OTA update with assumed-role creds
+    let iot_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region.clone())
+        .credentials_provider(iot_creds.clone())
+        .load()
+        .await;
+    let iot_client = aws_sdk_iot::Client::new(&iot_config);
+
+    let signature = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        b"This is my custom signature\n",
+    );
+
+    let ota_update_role_arn = format!("arn:aws:iam::{TARGET_ACCOUNT_ID}:role/{OTA_UPDATE_ROLE}");
+    let thing_arn = format!("arn:aws:iot:{REGION}:{TARGET_ACCOUNT_ID}:thing/{THING_NAME}");
+
+    let file_location = aws_sdk_iot::types::FileLocation::builder()
+        .s3_location(
+            aws_sdk_iot::types::S3Location::builder()
+                .bucket(&s3_bucket)
+                .key(&s3_key)
+                .build(),
+        )
+        .build();
+
+    let code_signing = aws_sdk_iot::types::CodeSigning::builder()
+        .custom_code_signing(
+            aws_sdk_iot::types::CustomCodeSigning::builder()
+                .signature(
+                    aws_sdk_iot::types::CodeSigningSignature::builder()
+                        .inline_document(aws_sdk_iot::primitives::Blob::new(
+                            base64::Engine::decode(
+                                &base64::engine::general_purpose::STANDARD,
+                                &signature,
+                            )
+                            .expect("Failed to decode signature"),
+                        ))
+                        .build(),
+                )
+                .certificate_chain(
+                    aws_sdk_iot::types::CodeSigningCertificateChain::builder()
+                        .certificate_name("cert")
+                        .inline_document("signCert")
+                        .build(),
+                )
+                .hash_algorithm("sha256")
+                .signature_algorithm("ecdsa")
+                .build(),
+        )
+        .build();
+
+    let ota_file = aws_sdk_iot::types::OtaUpdateFile::builder()
+        .file_name("ota_file_OTA")
+        .file_location(file_location)
+        .code_signing(code_signing)
+        .set_file_type(Some(0))
+        .build();
+
+    let create_result = iot_client
+        .create_ota_update()
+        .ota_update_id(&update_id)
+        .description("RustOT OTA integration test")
+        .targets(&thing_arn)
+        .protocols(aws_sdk_iot::types::Protocol::Mqtt)
+        .target_selection(aws_sdk_iot::types::TargetSelection::Snapshot)
+        .role_arn(&ota_update_role_arn)
+        .files(ota_file)
+        .send()
+        .await
+        .expect("Failed to create OTA update");
+
+    // The IoT Job ID follows the convention AFR_OTA-{ota_update_id}.
+    // It may not be in the CreateOtaUpdate response yet (CreatePending).
+    let job_id = format!("AFR_OTA-{update_id}");
+
+    log::info!(
+        "Created OTA update: {} (status: {:?}, job_id: {})",
+        update_id,
+        create_result.ota_update_status(),
+        job_id,
+    );
+
+    // Poll until the IoT Job execution exists for our thing (the OTA update
+    // starts as CreatePending and the job execution may not exist immediately)
+    for attempt in 1..=15 {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        match iot_client
+            .describe_job_execution()
+            .job_id(&job_id)
+            .thing_name(THING_NAME)
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                if let Some(exec) = resp.execution() {
+                    log::info!(
+                        "Job execution ready: {:?} (attempt {}/15)",
+                        exec.status(),
+                        attempt
+                    );
+                    break;
+                }
+            }
+            Err(e) => {
+                log::info!(
+                    "Job execution not ready yet (attempt {}/15): {}",
+                    attempt,
+                    e
+                );
+            }
+        }
+        if attempt == 15 {
+            panic!(
+                "Job execution for {} on {} did not appear after 30s",
+                job_id, THING_NAME
+            );
+        }
+    }
+
+    Some(OtaTestContext {
+        mgmt_creds,
+        iot_creds,
+        job_id,
+        s3_bucket,
+        s3_key,
+        region,
+    })
+}
+
+/// Cancel all QUEUED and IN_PROGRESS job executions for our thing,
+/// then wait until none remain (so the next test won't pick them up).
+async fn cancel_stale_jobs(
+    iot_creds: &SharedCredentialsProvider,
+    region: &aws_config::Region,
+) -> Result<(), String> {
+    let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region.clone())
+        .credentials_provider(iot_creds.clone())
+        .load()
+        .await;
+    let client = aws_sdk_iot::Client::new(&config);
+
+    let mut canceled_any = false;
+
+    for status in [
+        aws_sdk_iot::types::JobExecutionStatus::Queued,
+        aws_sdk_iot::types::JobExecutionStatus::InProgress,
+    ] {
+        let executions = client
+            .list_job_executions_for_thing()
+            .thing_name(THING_NAME)
+            .status(status.clone())
+            .send()
+            .await
+            .map_err(|e| format!("ListJobExecutionsForThing({:?}) failed: {}", status, e))?;
+
+        for summary in executions.execution_summaries() {
+            if let Some(job_id) = summary.job_id() {
+                log::info!("Canceling stale job: {} (status: {:?})", job_id, status);
+                match client.cancel_job().job_id(job_id).force(true).send().await {
+                    Ok(_) => {
+                        log::info!("Canceled job: {}", job_id);
+                        canceled_any = true;
+                    }
+                    Err(e) => log::warn!("Failed to cancel job {}: {}", job_id, e),
+                }
+            }
+        }
+    }
+
+    // If we canceled anything, wait until no QUEUED/IN_PROGRESS jobs remain
+    // so the next test's device won't pick up a stale job via $next
+    if canceled_any {
+        for attempt in 1..=10 {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+            let mut stale_count = 0;
+            for status in [
+                aws_sdk_iot::types::JobExecutionStatus::Queued,
+                aws_sdk_iot::types::JobExecutionStatus::InProgress,
+            ] {
+                if let Ok(resp) = client
+                    .list_job_executions_for_thing()
+                    .thing_name(THING_NAME)
+                    .status(status)
+                    .send()
+                    .await
+                {
+                    stale_count += resp.execution_summaries().len();
+                }
+            }
+
+            if stale_count == 0 {
+                log::info!("All stale jobs cleared (attempt {}/10)", attempt);
+                break;
+            }
+            log::info!(
+                "Still {} stale job(s) remaining (attempt {}/10)",
+                stale_count,
+                attempt
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Async-safe panic catcher.
+///
+/// Wraps a future so that panics during polling are caught and returned as
+/// `Err(Box<dyn Any>)` instead of unwinding the test harness. This ensures
+/// cleanup code always runs even if the test panics.
+pub async fn catch_unwind_future<F, T>(f: F) -> Result<T, Box<dyn std::any::Any + Send>>
+where
+    F: Future<Output = T>,
+{
+    CatchUnwindFuture {
+        inner: Box::pin(AssertUnwindSafe(f)),
+    }
+    .await
+}
+
+struct CatchUnwindFuture<F> {
+    inner: Pin<Box<F>>,
+}
+
+impl<F: Future> Future for CatchUnwindFuture<AssertUnwindSafe<F>> {
+    type Output = Result<F::Output, Box<dyn std::any::Any + Send>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let inner = &mut self.inner;
+        match std::panic::catch_unwind(AssertUnwindSafe(|| inner.as_mut().poll(cx))) {
+            Ok(Poll::Pending) => Poll::Pending,
+            Ok(Poll::Ready(val)) => Poll::Ready(Ok(val)),
+            Err(panic) => Poll::Ready(Err(panic)),
+        }
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#[allow(dead_code)]
+pub mod aws_ota;
 pub mod credentials;
 pub mod file_handler;
 pub mod network;

--- a/tests/ota_mqtt.rs
+++ b/tests/ota_mqtt.rs
@@ -316,7 +316,7 @@ async fn run_ota_signature_failure() -> Result<(), ota::error::OtaError> {
 
     static STATE: StaticCell<State<NoopRawMutex, 4096, { 4096 * 20 }>> = StaticCell::new();
     let state = STATE.init(State::new());
-    let (mut stack, client) = embedded_mqtt::new(state, config);
+    let (mut stack, client) = mqttrust::new(state, config);
 
     // Configure file handler to fail with SignatureCheckFailed
     let mut file_handler = FileHandler::new("tests/assets/ota_file".to_owned())


### PR DESCRIPTION
## Summary

Adds granular failure diagnostics to OTA job status updates. When an OTA operation fails, the job status now includes a human-readable `reason` string and numeric `error_code` in the status details sent to AWS IoT — enabling cloud-side root cause analysis without device log access.

Introduces the `StatusDetailsExt` trait, allowing PAL implementations to inject custom key-value pairs (device temperature, battery level, firmware version, etc.) into every job status update alongside the base OTA fields.

Also adds self-managed integration test infrastructure that automates OTA job provisioning, S3 upload, and cloud-side assertion against AWS IoT.

> **Note:** This is PR 3 of 4 in a stacked series. Depends on #83 (generic MqttClient trait).

## Design

### Failure Reason Flow

```
OtaError::Pal(pal_err)
  → ImageStateReason::Pal(OtaPalError)
    → JobStatusReason::Aborted(Some(reason))
      → OtaStatusDetails { reason: "sig_check_failed", error_code: 1001 }
        → MQTT job update with status details
```

`OtaPalError` variants map to reason strings and error codes:
- `SignatureCheckFailed` → `"sig_check_failed"` / `1001`
- `FileWriteFailed` → `"file_write_failed"` / `1002`
- `FileCloseFailed` → `"file_close_failed"` / `1003`
- `BadImageState` → `"bad_image_state"` / `1004`
- And others for each PAL failure mode

### StatusDetailsExt

PAL implementations declare an associated type:

```rust
trait OtaPal {
    type StatusDetailsExt: StatusDetailsExt + Clone;
    fn status_details(&self) -> Self::StatusDetailsExt;
}
```

Custom fields are combined with base OTA fields via `CombinedStatusDetails<E>`, which flattens both into a single JSON object during serialization. Default impl for `()` provides zero-cost opt-out.

### Integration Test Infrastructure (`tests/common/aws_ota.rs`)

- Loads management credentials from environment, assumes role into target IoT account
- Cleans up stale QUEUED/IN_PROGRESS jobs before each run
- Uploads firmware to S3, creates OTA update, polls until job execution appears
- Post-test: `describe_job_execution()` asserts cloud-side status and status details
- Guaranteed cleanup (cancel jobs + delete S3) even on test panic

## Changelog

- Add `OtaPalError` variants with `error_code()` and `as_reason_str()` methods
- Add `OtaStatusDetails` struct with `reason`, `error_code`, and `progress` fields
- Add `StatusDetailsExt` trait and `CombinedStatusDetails<E>` for extensible job status details
- Add `StatusDetailsExt` associated type to `OtaPal` trait
- Preserve `OtaPalError` through error handling chain instead of discarding to `Aborted(None)`
- Include block progress count in Failed status details
- Add self-managed OTA integration test infrastructure with AWS credential management and cleanup

Fixes #29 