### PR TITLE
Eliminate async fn delegation overhead

### DIFF
--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -5,7 +5,7 @@ pub mod encoding;
 pub mod error;
 pub mod pal;
 
-use core::ops::DerefMut as _;
+use core::{future::Future, ops::DerefMut as _};
 
 #[cfg(feature = "ota_mqtt_data")]
 pub use data_interface::mqtt::{Encoding, Topic};
@@ -34,11 +34,10 @@ pub struct JobEventData<'a> {
 pub struct Updater;
 
 impl Updater {
-    pub async fn check_for_job<'a, C: ControlInterface>(
+    pub fn check_for_job<C: ControlInterface>(
         control: &C,
-    ) -> Result<(), error::OtaError> {
-        control.request_job().await?;
-        Ok(())
+    ) -> impl Future<Output = Result<(), error::OtaError>> + '_ {
+        control.request_job()
     }
 
     pub async fn perform_ota<'a, 'b, C: ControlInterface, D: DataInterface>(

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -36,14 +36,15 @@ pub struct Credentials<'a> {
 pub struct FleetProvisioner;
 
 impl FleetProvisioner {
-    pub async fn provision<'a, C, M: RawMutex>(
-        mqtt: &mqttrust::MqttClient<'a, M>,
-        template_name: &str,
-        parameters: Option<impl Serialize>,
-        credential_handler: &mut impl CredentialHandler,
-    ) -> Result<Option<C>, Error>
+    pub fn provision<'a, 'b, C, M: RawMutex, P: Serialize + 'b, H: CredentialHandler + 'b>(
+        mqtt: &'b mqttrust::MqttClient<'a, M>,
+        template_name: &'b str,
+        parameters: Option<P>,
+        credential_handler: &'b mut H,
+    ) -> impl Future<Output = Result<Option<C>, Error>> + 'b + use<'b, 'a, C, M, P, H>
     where
-        C: DeserializeOwned,
+        C: DeserializeOwned + 'b,
+        'a: 'b,
     {
         Self::provision_inner(
             mqtt,
@@ -53,18 +54,18 @@ impl FleetProvisioner {
             credential_handler,
             PayloadFormat::Json,
         )
-        .await
     }
 
-    pub async fn provision_csr<'a, C, M: RawMutex>(
-        mqtt: &mqttrust::MqttClient<'a, M>,
-        template_name: &str,
-        parameters: Option<impl Serialize>,
-        csr: &str,
-        credential_handler: &mut impl CredentialHandler,
-    ) -> Result<Option<C>, Error>
+    pub fn provision_csr<'a, 'b, C, M: RawMutex, P: Serialize + 'b, H: CredentialHandler + 'b>(
+        mqtt: &'b mqttrust::MqttClient<'a, M>,
+        template_name: &'b str,
+        parameters: Option<P>,
+        csr: &'b str,
+        credential_handler: &'b mut H,
+    ) -> impl Future<Output = Result<Option<C>, Error>> + 'b + use<'b, 'a, C, M, P, H>
     where
-        C: DeserializeOwned,
+        C: DeserializeOwned + 'b,
+        'a: 'b,
     {
         Self::provision_inner(
             mqtt,
@@ -74,18 +75,18 @@ impl FleetProvisioner {
             credential_handler,
             PayloadFormat::Json,
         )
-        .await
     }
 
     #[cfg(feature = "provision_cbor")]
-    pub async fn provision_cbor<'a, C, M: RawMutex>(
-        mqtt: &mqttrust::MqttClient<'a, M>,
-        template_name: &str,
-        parameters: Option<impl Serialize>,
-        credential_handler: &mut impl CredentialHandler,
-    ) -> Result<Option<C>, Error>
+    pub fn provision_cbor<'a, 'b, C, M: RawMutex, P: Serialize + 'b, H: CredentialHandler + 'b>(
+        mqtt: &'b mqttrust::MqttClient<'a, M>,
+        template_name: &'b str,
+        parameters: Option<P>,
+        credential_handler: &'b mut H,
+    ) -> impl Future<Output = Result<Option<C>, Error>> + 'b + use<'b, 'a, C, M, P, H>
     where
-        C: DeserializeOwned,
+        C: DeserializeOwned + 'b,
+        'a: 'b,
     {
         Self::provision_inner(
             mqtt,
@@ -95,19 +96,26 @@ impl FleetProvisioner {
             credential_handler,
             PayloadFormat::Cbor,
         )
-        .await
     }
 
     #[cfg(feature = "provision_cbor")]
-    pub async fn provision_csr_cbor<'a, C, M: RawMutex>(
-        mqtt: &mqttrust::MqttClient<'a, M>,
-        template_name: &str,
-        parameters: Option<impl Serialize>,
-        csr: &str,
-        credential_handler: &mut impl CredentialHandler,
-    ) -> Result<Option<C>, Error>
+    pub fn provision_csr_cbor<
+        'a,
+        'b,
+        C,
+        M: RawMutex,
+        P: Serialize + 'b,
+        H: CredentialHandler + 'b,
+    >(
+        mqtt: &'b mqttrust::MqttClient<'a, M>,
+        template_name: &'b str,
+        parameters: Option<P>,
+        csr: &'b str,
+        credential_handler: &'b mut H,
+    ) -> impl Future<Output = Result<Option<C>, Error>> + 'b + use<'b, 'a, C, M, P, H>
     where
-        C: DeserializeOwned,
+        C: DeserializeOwned + 'b,
+        'a: 'b,
     {
         Self::provision_inner(
             mqtt,
@@ -117,7 +125,6 @@ impl FleetProvisioner {
             credential_handler,
             PayloadFormat::Cbor,
         )
-        .await
     }
 
     #[cfg(feature = "provision_cbor")]

--- a/tests/provisioning.rs
+++ b/tests/provisioning.rs
@@ -95,14 +95,14 @@ async fn test_provisioning() {
     let mut credential_handler = CredentialDAO { creds: None };
 
     #[cfg(not(feature = "provision_cbor"))]
-    let provision_fut = FleetProvisioner::provision::<DeviceConfig, NoopRawMutex>(
+    let provision_fut = FleetProvisioner::provision::<DeviceConfig, NoopRawMutex, _, _>(
         &client,
         &template_name,
         Some(parameters),
         &mut credential_handler,
     );
     #[cfg(feature = "provision_cbor")]
-    let provision_fut = FleetProvisioner::provision_cbor::<DeviceConfig, NoopRawMutex>(
+    let provision_fut = FleetProvisioner::provision_cbor::<DeviceConfig, NoopRawMutex, _, _>(
         &client,
         &template_name,
         Some(parameters),


### PR DESCRIPTION
## Summary

Rust's `async fn` generates a state machine that stores all parameters twice: once as upvars in a non-overlapping prefix, and again as locals in state machine variants. For delegation functions — async fns that just `.await` a single inner call — this creates a redundant wrapper state machine around the inner future. Converting these to `fn -> impl Future` returns the inner future directly with zero wrapper overhead.

This is a known compiler limitation tracked in [rust-lang/rust#62958](https://github.com/rust-lang/rust/issues/62958). The compiler cannot currently optimize away these trivial wrapper state machines, so the workaround is to avoid generating them in the first place by not using `async fn` for pure delegation.

### Measured results (`-Z print-type-sizes`)

| Function | Wrapper (before) | Wrapper (after) | Parent future delta |
|---|---|---|---|
| `Updater::check_for_job` | 1168 bytes | **eliminated** | — |
| `ShadowHandler::create_shadow` | 1264 bytes | **eliminated** | — |
| `Shadow::delete_shadow` | not in test harness | **eliminated** | — |
| `FleetProvisioner::provision_cbor` | 2464 bytes | **eliminated** | -72 bytes |
| `FleetProvisioner::provision` | same pattern | **eliminated** | — |
| `FleetProvisioner::provision_csr` | same pattern | **eliminated** | — |
| `FleetProvisioner::provision_csr_cbor` | same pattern | **eliminated** | — |

The provisioning parent `Select<..>` future shrank by 72 bytes (3528 → 3456) because it now stores `provision_inner`'s future directly (2392 bytes) instead of the `provision_cbor` wrapper (2464 bytes). The 72-byte difference is the upvar prefix overhead that the wrapper state machine added.

## Changelog

- `Updater::check_for_job`: removed `async`, dropped unused `'a` lifetime, returns `control.request_job()` directly
- `ShadowHandler::create_shadow`: `debug!()` and `default()` execute eagerly, returns `update_shadow()` future. Named the impl block's anonymous lifetime `'m` for `use<>` bound
- `Shadow::delete_shadow`: returns `self.handler.delete_shadow()` directly
- `FleetProvisioner::provision`, `provision_csr`, `provision_cbor`, `provision_csr_cbor`: converted `impl Trait` args to named type params (`P`, `H`) to enable `use<>` precise capturing bounds. Added `'b` lifetime for all borrowed parameters with `'a: 'b`
- `tests/provisioning.rs`: added `_, _` turbofish placeholders for the new type params
- Added `core::future::Future` import to `src/ota/mod.rs` and `src/shadows/mod.rs`