### PR TITLE
Refactor derive macros and add adjacently-tagged enum support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 Cargo.lock
 statemachine.svg
 planning/
+rustc-ice-*.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ bon = { version = "3.3.2", default-features = false }
 
 # std feature dependencies (for FileKVStore)
 tokio = { version = "1", features = ["fs", "io-util", "sync"], optional = true }
+serde_json = { version = "1", optional = true }
 base64 = { version = "0.22", optional = true }
 
 # MQTT client implementations (optional, feature-gated)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ std = ["serde/std", "dep:tokio", "dep:base64", "postcard/alloc"]
 
 # Field-level KV shadow persistence (SequentialKVStore, FileKVStore)
 # Enables KVStore trait, KVPersist trait, and KV-based StateStore implementations
-shadows_kv_persist = ["dep:sequential-storage", "postcard/heapless"]
+shadows_kv_persist = ["dep:sequential-storage", "rustot-derive/kv_persist", "postcard/heapless"]
 
 defmt = ["dep:defmt"]
 log = ["dep:log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ std = ["serde/std", "dep:tokio", "dep:base64", "postcard/alloc"]
 
 # Field-level KV shadow persistence (SequentialKVStore, FileKVStore)
 # Enables KVStore trait, KVPersist trait, and KV-based StateStore implementations
-shadows_kv_persist = ["dep:sequential-storage", "rustot-derive/kv_persist", "postcard/heapless"]
+shadows_kv_persist = ["dep:sequential-storage", "postcard/heapless"]
 
 defmt = ["dep:defmt"]
 log = ["dep:log"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ base64 = { version = "0.22", optional = true }
 rumqttc = { version = "0.24", optional = true }
 greengrass-ipc-rust = { git = "https://github.com/FactbirdHQ/greengrass-ipc-rust", rev = "0f0469e", optional = true }
 bytes = { version = "1", optional = true }
+futures = { version = "0.3", optional = true }
 
 [dev-dependencies]
 native-tls = { version = "0.2" }
@@ -104,7 +105,7 @@ ota_mqtt_data = ["dep:minicbor", "dep:minicbor-serde"]
 
 ota_http_data = []
 
-std = ["serde/std", "minicbor-serde?/std", "dep:tokio", "dep:serde_json", "dep:base64", "postcard/alloc", "rustot-derive/std"]
+std = ["serde/std", "minicbor-serde?/std", "dep:tokio", "dep:serde_json", "dep:base64", "postcard/alloc", "rustot-derive/std", "embassy-time/std", "embassy-time/generic-queue-8"]
 
 # Field-level KV shadow persistence (SequentialKVStore, FileKVStore)
 # Enables KVStore trait, KVPersist trait, and KV-based StateStore implementations
@@ -115,7 +116,7 @@ log = ["dep:log"]
 
 # MQTT client implementations (std/tokio)
 rumqttc = ["std", "dep:rumqttc", "tokio/time"]
-greengrass = ["std", "dep:greengrass-ipc-rust", "dep:bytes"]
+greengrass = ["std", "dep:greengrass-ipc-rust", "dep:bytes", "dep:futures"]
 
 [patch.crates-io]
 serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json-core", rev = "a435f78" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ ota_mqtt_data = ["dep:minicbor", "dep:minicbor-serde"]
 
 ota_http_data = []
 
-std = ["serde/std", "dep:tokio", "dep:base64", "postcard/alloc"]
+std = ["serde/std", "minicbor-serde?/std", "dep:tokio", "dep:serde_json", "dep:base64", "postcard/alloc", "rustot-derive/std"]
 
 # Field-level KV shadow persistence (SequentialKVStore, FileKVStore)
 # Enables KVStore trait, KVPersist trait, and KV-based StateStore implementations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ minicbor = { version = "0.25", optional = true }
 minicbor-serde = { version = "0.3.2", optional = true }
 
 # Shadow storage dependencies
-postcard = { version = "1.1", default-features = false, features = ["experimental-derive"] }
+postcard = { git = "https://github.com/jamesmunns/postcard", rev = "f8a4064", default-features = false, features = ["experimental-derive", "heapless-v0_9"] }
 
 # KV-based shadow storage (optional, enabled by shadows_kv_persist feature)
 sequential-storage = { version = "7.0", features = ["heapless-09"], optional = true }

--- a/rustot_derive/Cargo.toml
+++ b/rustot_derive/Cargo.toml
@@ -11,6 +11,11 @@ readme = "../README.md"
 [lib]
 proc-macro = true
 
+[features]
+default = []
+# When enabled, generates KVPersist trait implementations
+kv_persist = []
+
 [dependencies]
 syn = { version = "2", features = ["extra-traits"] }
 quote = "1"

--- a/rustot_derive/Cargo.toml
+++ b/rustot_derive/Cargo.toml
@@ -22,6 +22,7 @@ quote = "1"
 proc-macro2 = "1"
 proc-macro-crate = "3"
 heck = "0.5"
+darling = "0.20"
 
 [dev-dependencies]
 serde = "1"

--- a/rustot_derive/Cargo.toml
+++ b/rustot_derive/Cargo.toml
@@ -15,6 +15,8 @@ proc-macro = true
 default = []
 # When enabled, generates KVPersist trait implementations
 kv_persist = []
+# When enabled, generates std-compatible code (uses alloc instead of fixed buffers)
+std = []
 
 [dependencies]
 syn = { version = "2", features = ["extra-traits"] }

--- a/rustot_derive/Cargo.toml
+++ b/rustot_derive/Cargo.toml
@@ -11,11 +11,6 @@ readme = "../README.md"
 [lib]
 proc-macro = true
 
-[features]
-default = []
-# Enable KVPersist impl generation in derive macros
-kv_persist = []
-
 [dependencies]
 syn = { version = "2", features = ["extra-traits"] }
 quote = "1"

--- a/rustot_derive/Cargo.toml
+++ b/rustot_derive/Cargo.toml
@@ -21,6 +21,7 @@ syn = { version = "2", features = ["extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 proc-macro-crate = "3"
+heck = "0.5"
 
 [dev-dependencies]
 serde = "1"

--- a/rustot_derive/src/attr/field_attr.rs
+++ b/rustot_derive/src/attr/field_attr.rs
@@ -1,3 +1,4 @@
+use heck::{ToLowerCamelCase, ToPascalCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase, ToKebabCase};
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
@@ -284,65 +285,14 @@ pub fn apply_rename_all(name: &str, convention: &str) -> String {
     match convention {
         "lowercase" => name.to_lowercase(),
         "UPPERCASE" => name.to_uppercase(),
-        "camelCase" => to_camel_case(name),
-        "snake_case" => to_snake_case(name),
-        "SCREAMING_SNAKE_CASE" => to_snake_case(name).to_uppercase(),
-        "kebab-case" => to_snake_case(name).replace('_', "-"),
-        "SCREAMING-KEBAB-CASE" => to_snake_case(name).to_uppercase().replace('_', "-"),
-        "PascalCase" => to_pascal_case(name),
+        "camelCase" => name.to_lower_camel_case(),
+        "snake_case" => name.to_snake_case(),
+        "SCREAMING_SNAKE_CASE" => name.to_shouty_snake_case(),
+        "kebab-case" => name.to_kebab_case(),
+        "SCREAMING-KEBAB-CASE" => name.to_shouty_kebab_case(),
+        "PascalCase" => name.to_pascal_case(),
         _ => name.to_string(),
     }
-}
-
-fn to_camel_case(s: &str) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = false;
-
-    for (i, c) in s.chars().enumerate() {
-        if c == '_' {
-            capitalize_next = true;
-        } else if capitalize_next {
-            result.push(c.to_ascii_uppercase());
-            capitalize_next = false;
-        } else if i == 0 {
-            result.push(c.to_ascii_lowercase());
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if c.is_uppercase() {
-            if i > 0 {
-                result.push('_');
-            }
-            result.push(c.to_ascii_lowercase());
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
-
-fn to_pascal_case(s: &str) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = true;
-
-    for c in s.chars() {
-        if c == '_' {
-            capitalize_next = true;
-        } else if capitalize_next {
-            result.push(c.to_ascii_uppercase());
-            capitalize_next = false;
-        } else {
-            result.push(c);
-        }
-    }
-    result
 }
 
 #[cfg(test)]

--- a/rustot_derive/src/attr/field_attr.rs
+++ b/rustot_derive/src/attr/field_attr.rs
@@ -40,7 +40,8 @@ pub struct FieldAttrs {
 /// - `#[shadow_attr(opaque(max_size = 64))]` - explicit max serialized size
 #[derive(Clone, Default)]
 pub struct OpaqueSpec {
-    /// Explicit maximum serialized size in bytes (optional)
+    /// Explicit maximum serialized size in bytes (only used with kv_persist)
+    #[cfg_attr(not(feature = "kv_persist"), allow(dead_code))]
     pub max_size: Option<usize>,
 }
 
@@ -94,6 +95,7 @@ impl FieldAttrs {
     }
 
     /// Get the explicit max_size if specified, None if opaque without max_size or not opaque
+    #[cfg_attr(not(feature = "kv_persist"), allow(dead_code))]
     pub fn opaque_max_size(&self) -> Option<usize> {
         self.opaque.as_ref().and_then(|o| o.max_size)
     }

--- a/rustot_derive/src/attr/field_attr.rs
+++ b/rustot_derive/src/attr/field_attr.rs
@@ -1,4 +1,6 @@
-use heck::{ToLowerCamelCase, ToPascalCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase, ToKebabCase};
+use heck::{
+    ToKebabCase, ToLowerCamelCase, ToPascalCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
+};
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,

--- a/rustot_derive/src/attr/mod.rs
+++ b/rustot_derive/src/attr/mod.rs
@@ -1,8 +1,10 @@
 mod field_attr;
 mod shadow_attr;
 
+#[cfg(feature = "kv_persist")]
+pub use field_attr::DefaultValue;
 pub use field_attr::{
     apply_rename_all, get_serde_rename, get_serde_rename_all, get_serde_tag_content,
-    get_variant_serde_name, has_default_attr, DefaultValue, FieldAttrs,
+    get_variant_serde_name, has_default_attr, FieldAttrs,
 };
 pub use shadow_attr::{ShadowNodeParams, ShadowRootParams};

--- a/rustot_derive/src/attr/shadow_attr.rs
+++ b/rustot_derive/src/attr/shadow_attr.rs
@@ -1,158 +1,25 @@
-use syn::{
-    parse::{Parse, ParseStream},
-    Ident, LitInt, LitStr, Token,
-};
-
-// =============================================================================
-// KV-based shadow macros (Phase 8)
-// =============================================================================
+use darling::FromMeta;
 
 /// Parameters for the #[shadow_root(name = "...")] macro
 ///
 /// This macro marks a struct as a top-level shadow with KV persistence support.
 /// It implements both `ShadowRoot` and `ShadowNode` traits.
-#[derive(Default)]
+#[derive(Default, FromMeta)]
 pub struct ShadowRootParams {
     /// Shadow name (required for named shadows, None for classic)
-    pub name: Option<LitStr>,
+    #[darling(default)]
+    pub name: Option<String>,
     /// Topic prefix for MQTT topics (e.g., "$aws" for AWS IoT)
-    pub topic_prefix: Option<LitStr>,
+    #[darling(default)]
+    pub topic_prefix: Option<String>,
     /// Maximum payload size for shadow documents
-    pub max_payload_len: Option<LitInt>,
-}
-
-impl Parse for ShadowRootParams {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let mut params = Self::default();
-
-        while !input.is_empty() {
-            let ident: Ident = input.parse()?;
-            input.parse::<Token![=]>()?;
-
-            match ident.to_string().as_str() {
-                "name" => {
-                    params.name = Some(input.parse()?);
-                }
-                "topic_prefix" => {
-                    params.topic_prefix = Some(input.parse()?);
-                }
-                "max_payload_len" => {
-                    params.max_payload_len = Some(input.parse()?);
-                }
-                unknown => {
-                    return Err(syn::Error::new(
-                        ident.span(),
-                        format!("unknown shadow_root attribute: `{}`", unknown),
-                    ));
-                }
-            }
-
-            // Consume optional trailing comma
-            let _ = input.parse::<Token![,]>();
-        }
-
-        Ok(params)
-    }
+    #[darling(default)]
+    pub max_payload_len: Option<usize>,
 }
 
 /// Parameters for the #[shadow_node] macro (no parameters currently)
 ///
 /// This macro marks a struct or enum as a nested shadow type with KV persistence
 /// support. It implements the `ShadowNode` trait.
-#[derive(Default)]
+#[derive(Default, FromMeta)]
 pub struct ShadowNodeParams {}
-
-impl Parse for ShadowNodeParams {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        // Currently no parameters, but parse for future extensibility
-        if !input.is_empty() {
-            let ident: Ident = input.parse()?;
-            return Err(syn::Error::new(
-                ident.span(),
-                format!("unknown shadow_node attribute: `{}`", ident),
-            ));
-        }
-        Ok(Self::default())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_shadow_root_params_with_name() {
-        let params: ShadowRootParams = syn::parse2(quote::quote!(name = "device")).unwrap();
-        assert_eq!(params.name.unwrap().value(), "device");
-    }
-
-    #[test]
-    fn test_parse_shadow_root_params_empty() {
-        let params: ShadowRootParams = syn::parse2(quote::quote!()).unwrap();
-        assert!(params.name.is_none());
-        assert!(params.topic_prefix.is_none());
-        assert!(params.max_payload_len.is_none());
-    }
-
-    #[test]
-    fn test_parse_shadow_root_params_with_topic_prefix() {
-        let params: ShadowRootParams =
-            syn::parse2(quote::quote!(name = "device", topic_prefix = "$aws")).unwrap();
-        assert_eq!(params.name.unwrap().value(), "device");
-        assert_eq!(params.topic_prefix.unwrap().value(), "$aws");
-        assert!(params.max_payload_len.is_none());
-    }
-
-    #[test]
-    fn test_parse_shadow_root_params_with_max_payload_len() {
-        let params: ShadowRootParams =
-            syn::parse2(quote::quote!(name = "device", max_payload_len = 1024)).unwrap();
-        assert_eq!(params.name.unwrap().value(), "device");
-        assert!(params.topic_prefix.is_none());
-        assert_eq!(
-            params
-                .max_payload_len
-                .unwrap()
-                .base10_parse::<usize>()
-                .unwrap(),
-            1024
-        );
-    }
-
-    #[test]
-    fn test_parse_shadow_root_params_all() {
-        let params: ShadowRootParams = syn::parse2(quote::quote!(
-            name = "device",
-            topic_prefix = "$custom",
-            max_payload_len = 2048
-        ))
-        .unwrap();
-        assert_eq!(params.name.unwrap().value(), "device");
-        assert_eq!(params.topic_prefix.unwrap().value(), "$custom");
-        assert_eq!(
-            params
-                .max_payload_len
-                .unwrap()
-                .base10_parse::<usize>()
-                .unwrap(),
-            2048
-        );
-    }
-
-    #[test]
-    fn test_parse_shadow_node_params_empty() {
-        let params: ShadowNodeParams = syn::parse2(quote::quote!()).unwrap();
-        // No assertions - just checking it parses
-        let _ = params;
-    }
-
-    #[test]
-    fn test_shadow_node_unknown_attr_error() {
-        let result: syn::Result<ShadowNodeParams> =
-            syn::parse2(quote::quote!(unknown_attr = "value"));
-        match result {
-            Err(err) => assert!(err.to_string().contains("unknown shadow_node attribute")),
-            Ok(_) => panic!("Expected error for unknown attribute"),
-        }
-    }
-}

--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -235,7 +235,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 parse_delta_config_arms.push(quote! {
                     (Some(#variant_enum_name::#variant_ident), Some(config_bytes)) => {
                         // Build nested path for the inner type
-                        let mut nested_path: ::heapless::String<64> = ::heapless::String::new();
+                        let mut nested_path: #krate::__macro_support::heapless::String<64> = #krate::__macro_support::heapless::String::new();
                         let _ = nested_path.push_str(path);
                         if !path.is_empty() {
                             let _ = nested_path.push('/');
@@ -540,7 +540,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
             if has_data {
                 quote! {
                     Self::#ident(_) => {
-                        let mut s = ::heapless::String::<32>::new();
+                        let mut s = #krate::__macro_support::heapless::String::<32>::new();
                         let _ = s.push_str(#serde_name);
                         Some(s)
                     }
@@ -548,7 +548,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
             } else {
                 quote! {
                     Self::#ident => {
-                        let mut s = ::heapless::String::<32>::new();
+                        let mut s = #krate::__macro_support::heapless::String::<32>::new();
                         let _ = s.push_str(#serde_name);
                         Some(s)
                     }
@@ -608,7 +608,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 #config_apply_code
             }
 
-            fn variant_at_path(&self, path: &str) -> Option<::heapless::String<32>> {
+            fn variant_at_path(&self, path: &str) -> Option<#krate::__macro_support::heapless::String<32>> {
                 // Only match empty path (this level) or exact field path
                 if path.is_empty() {
                     match self {
@@ -712,7 +712,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
 
                     let prefix_ident =
                         syn::Ident::new("inner_prefix", proc_macro2::Span::call_site());
-                    let prefix_code = kv_codegen::build_key(&prefix_ident, &variant_path);
+                    let prefix_code = kv_codegen::build_key(krate, &prefix_ident, &variant_path);
                     persist_delta_config_arms.push(quote! {
                         #delta_config_name::#variant_ident(ref inner_delta) => {
                             #prefix_code
@@ -751,7 +751,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
             &persist_to_kv_variant_arms,
         );
         let collect_valid_keys_body =
-            kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
+            kv_codegen::enum_collect_valid_keys_body(krate, &collect_valid_keys_arms);
 
         quote! {
             impl #krate::shadows::KVPersist for #name {
@@ -805,7 +805,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<K::Error>>> {
                     async move {
                         // Build variant key path
-                        let mut variant_key: ::heapless::String<KEY_LEN> = ::heapless::String::new();
+                        let mut variant_key: #krate::__macro_support::heapless::String<KEY_LEN> = #krate::__macro_support::heapless::String::new();
                         let _ = variant_key.push_str(prefix);
                         let _ = variant_key.push_str(#VARIANT_KEY_PATH);
 

--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -60,7 +60,7 @@ use crate::attr::{
 };
 
 #[cfg(feature = "kv_persist")]
-use super::helpers::{build_const_max_expr, build_max_key_len_expr};
+use super::helpers::build_max_key_len_expr;
 #[cfg(feature = "kv_persist")]
 use super::kv_codegen::{self, VARIANT_KEY_PATH};
 use super::CodegenOutput;
@@ -619,7 +619,6 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
     #[cfg(feature = "kv_persist")]
     let kv_persist_impl = {
         // Collect KV-specific codegen by iterating over variants again
-        let mut max_value_len_items = Vec::new();
         let mut load_from_kv_variant_arms = Vec::new();
         let mut persist_to_kv_variant_arms = Vec::new();
         let mut persist_delta_mode_arms = Vec::new();
@@ -662,10 +661,6 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                     let inner_ty = &fields.unnamed[0].ty;
                     let variant_path = format!("/{}", serde_name);
                     let variant_path_len = variant_path.len();
-
-                    max_value_len_items.push(quote! {
-                        <#inner_ty as #krate::shadows::KVPersist>::MAX_VALUE_LEN
-                    });
 
                     max_key_len_items.push(quote! { #variant_path_len + <#inner_ty as #krate::shadows::KVPersist>::MAX_KEY_LEN });
 
@@ -721,7 +716,8 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         }
 
         // Build const expressions
-        let max_value_len_expr = build_const_max_expr(max_value_len_items, quote! { 0 });
+        // Adjacently-tagged enums use a fixed 128-byte buffer for _variant names, not ValueBuf.
+        // Inner variant types bring their own ValueBuf.
         let max_key_len_expr =
             build_max_key_len_expr(max_key_len_items, quote! { #variant_key_len });
 
@@ -739,7 +735,10 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         quote! {
             impl #krate::shadows::KVPersist for #name {
                 const MAX_KEY_LEN: usize = #max_key_len_expr;
-                const MAX_VALUE_LEN: usize = #max_value_len_expr;
+                // Adjacently-tagged enums don't directly serialize values — variant name uses
+                // fixed 128-byte buffer, inner types bring their own ValueBuf
+                type ValueBuf = [u8; 0];
+                fn zero_value_buf() -> Self::ValueBuf { [] }
 
                 fn migration_sources(_field_path: &str) -> &'static [#krate::shadows::MigrationSource] {
                     &[]

--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -276,10 +276,18 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 ));
 
                 // collect_valid_keys: delegate to inner (all variants, not just active)
-                collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(krate, &variant_path, inner_ty));
+                collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(
+                    krate,
+                    &variant_path,
+                    inner_ty,
+                ));
 
                 // collect_valid_prefixes: delegate to inner
-                collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(krate, &variant_path, inner_ty));
+                collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(
+                    krate,
+                    &variant_path,
+                    inner_ty,
+                ));
 
                 // parse_delta config arm - call parse_delta on inner type (async)
                 parse_delta_config_arms.push(quote! {
@@ -317,8 +325,10 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
 
     // Generate enum KVPersist method bodies using shared helpers
     let load_from_kv_body = kv_codegen::enum_load_from_kv_body(krate, &load_from_kv_variant_arms);
-    let persist_to_kv_body = kv_codegen::enum_persist_to_kv_body(krate, &variant_name_arms, &persist_to_kv_variant_arms);
-    let collect_valid_keys_body = kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
+    let persist_to_kv_body =
+        kv_codegen::enum_persist_to_kv_body(krate, &variant_name_arms, &persist_to_kv_variant_arms);
+    let collect_valid_keys_body =
+        kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
 
     // Build SCHEMA_HASH const
     let schema_hash_const = quote! {
@@ -597,9 +607,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         .iter()
         .zip(variant_names.iter())
         .map(|(ident, serde_name)| {
-            let has_data = variants_with_data
-                .iter()
-                .any(|(v, _)| v.ident == *ident);
+            let has_data = variants_with_data.iter().any(|(v, _)| v.ident == *ident);
             if has_data {
                 quote! {
                     Self::#ident(_) => {

--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -235,7 +235,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 parse_delta_config_arms.push(quote! {
                     (Some(#variant_enum_name::#variant_ident), Some(config_bytes)) => {
                         // Build nested path for the inner type
-                        let mut nested_path: ::heapless::String<128> = ::heapless::String::new();
+                        let mut nested_path: ::heapless::String<64> = ::heapless::String::new();
                         let _ = nested_path.push_str(path);
                         if !path.is_empty() {
                             let _ = nested_path.push('/');

--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -94,6 +94,9 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
     // Track which variants have data (for DeltaConfig enum)
     let mut variants_with_data: Vec<(&syn::Variant, String)> = Vec::new();
 
+    // For async parse_delta config arms (uses parse_delta instead of serde)
+    let mut parse_delta_config_arms: Vec<TokenStream> = Vec::new();
+
     // KVPersist-specific codegen (feature-gated)
     let mut load_from_kv_variant_arms = Vec::new();
     let mut persist_to_kv_variant_arms = Vec::new();
@@ -125,9 +128,12 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                     Self::#variant_ident => #serde_name,
                 });
 
+                // Only switch to this variant if not already in it
                 mode_switch_arms.push(quote! {
                     #variant_enum_name::#variant_ident => {
-                        *self = Self::#variant_ident;
+                        if !matches!(self, Self::#variant_ident) {
+                            *self = Self::#variant_ident;
+                        }
                     }
                 });
 
@@ -184,9 +190,12 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                     Self::#variant_ident(_) => #serde_name,
                 });
 
+                // Only switch to this variant if not already in it
                 mode_switch_arms.push(quote! {
                     #variant_enum_name::#variant_ident => {
-                        *self = Self::#variant_ident(Default::default());
+                        if !matches!(self, Self::#variant_ident(_)) {
+                            *self = Self::#variant_ident(Default::default());
+                        }
                     }
                 });
 
@@ -283,6 +292,25 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                         <#inner_ty as #krate::shadows::KVPersist>::collect_valid_prefixes::<KEY_LEN>(&inner_prefix, prefixes);
                     }
                 });
+
+                // parse_delta config arm - call parse_delta on inner type (async)
+                parse_delta_config_arms.push(quote! {
+                    (Some(#variant_enum_name::#variant_ident), Some(config_bytes)) => {
+                        // Build nested path for the inner type
+                        let mut nested_path: ::heapless::String<128> = ::heapless::String::new();
+                        let _ = nested_path.push_str(path);
+                        if !path.is_empty() {
+                            let _ = nested_path.push('/');
+                        }
+                        let _ = nested_path.push_str(#serde_name);
+                        let inner_delta = <#inner_ty as #krate::shadows::ShadowNode>::parse_delta(
+                            config_bytes,
+                            &nested_path,
+                            resolver
+                        ).await?;
+                        Some(#delta_config_name::#variant_ident(inner_delta))
+                    }
+                });
             }
             _ => {
                 return Err(syn::Error::new_spanned(
@@ -360,14 +388,36 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         TokenStream::new()
     };
 
+    // Generate FromStr match arms for variant enum
+    let from_str_arms: Vec<TokenStream> = variant_idents
+        .iter()
+        .zip(variant_names.iter())
+        .map(|(ident, serde_name)| {
+            quote! {
+                #serde_name => Ok(Self::#ident),
+            }
+        })
+        .collect();
+
     let variant_enum_type = quote! {
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, ::serde::Serialize, ::serde::Deserialize)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, ::serde::Serialize)]
         #rename_all_attr
         #vis enum #variant_enum_name {
             #(#variant_enum_variants)*
         }
 
         #variant_default_impl
+
+        impl ::core::str::FromStr for #variant_enum_name {
+            type Err = ();
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s {
+                    #(#from_str_arms)*
+                    _ => Err(()),
+                }
+            }
+        }
     };
 
     // =========================================================================
@@ -377,8 +427,9 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         // No variants with data - don't generate the config enum
         TokenStream::new()
     } else {
+        // No Deserialize - inner delta types don't have it, we use parse_delta instead
         quote! {
-            #[derive(Clone, ::serde::Serialize, ::serde::Deserialize)]
+            #[derive(Clone, ::serde::Serialize)]
             #rename_all_attr
             #vis enum #delta_config_name {
                 #(#delta_config_variants)*
@@ -398,13 +449,16 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         }
     };
 
-    // Generate Delta type
+    // NOTE: from_json method removed - parsing is now done directly in parse_delta
+    // which allows async calls to nested parse_delta methods
+
+    // Generate Delta type (no Deserialize - uses parse_delta instead)
     let delta_type = quote! {
         #variant_enum_type
 
         #delta_config_type
 
-        #[derive(Clone, Default, ::serde::Serialize, ::serde::Deserialize)]
+        #[derive(Clone, Default, ::serde::Serialize)]
         #vis struct #delta_name {
             #[serde(rename = #tag_key, skip_serializing_if = "Option::is_none")]
             pub mode: Option<#variant_enum_name>,
@@ -438,14 +492,14 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         TokenStream::new()
     };
 
-    // Build serialize match arms with null fields for inactive variants integrated
+    // Build serialize match arms - content is nested under content_key with nulls for inactive variants
     let combined_serialize_arms: Vec<TokenStream> = variant_idents
         .iter()
         .enumerate()
         .map(|(i, variant_ident)| {
             let serde_name = &variant_names[i];
 
-            // Generate null field serialization for other data variants
+            // Generate null field serialization for other data variants (used inside nested content map)
             let nulls: Vec<TokenStream> = inactive_variant_field_nulls
                 .iter()
                 .filter(|(other_ident, _)| {
@@ -456,7 +510,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                     quote! {
                         #krate::shadows::serialize_null_fields(
                             <<#inner_ty as #krate::shadows::ShadowNode>::Reported as #krate::shadows::ReportedUnionFields>::FIELD_NAMES,
-                            &mut map
+                            &mut content_map
                         )?;
                     }
                 })
@@ -468,66 +522,68 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 .any(|(v, _)| v.ident == *variant_ident);
 
             if has_data {
-                // Find the inner type for this variant
-                let inner_ty = variants_with_data
-                    .iter()
-                    .find(|(v, _)| v.ident == *variant_ident)
-                    .map(|(v, _)| {
-                        if let Fields::Unnamed(fields) = &v.fields {
-                            &fields.unnamed[0].ty
-                        } else {
-                            unreachable!()
-                        }
-                    })
-                    .unwrap();
-
+                // Variant with data - serialize mode and nested content with nulls
                 quote! {
                     Self::#variant_ident(ref config) => {
                         map.serialize_entry(#tag_key, #serde_name)?;
-                        if <<#inner_ty as #krate::shadows::ShadowNode>::Reported
-                            as #krate::shadows::ReportedUnionFields>::FIELD_NAMES.is_empty() {
-                            map.serialize_entry(#content_key, config)?;
-                        } else {
-                            config.serialize_into_map(&mut map)?;
+                        // Create nested content map using a helper that implements Serialize
+                        struct ContentWrapper<'a, C>(&'a C, core::marker::PhantomData<fn() -> ()>);
+                        impl<'a, C: #krate::shadows::ReportedUnionFields + ::serde::Serialize> ::serde::Serialize for ContentWrapper<'a, C> {
+                            fn serialize<SS>(&self, serializer: SS) -> Result<SS::Ok, SS::Error>
+                            where
+                                SS: ::serde::Serializer,
+                            {
+                                use ::serde::ser::SerializeMap;
+                                let mut content_map = serializer.serialize_map(None)?;
+                                self.0.serialize_into_map(&mut content_map)?;
+                                #(#nulls)*
+                                content_map.end()
+                            }
                         }
-                        #(#nulls)*
+                        map.serialize_entry(#content_key, &ContentWrapper(config, core::marker::PhantomData))?;
                     }
                 }
             } else {
-                // Unit variant - just serialize mode and nulls
-                quote! {
-                    Self::#variant_ident => {
-                        map.serialize_entry(#tag_key, #serde_name)?;
-                        #(#nulls)*
+                // Unit variant - serialize mode and nested content map with only nulls
+                if nulls.is_empty() {
+                    // No data variants at all - just serialize mode
+                    quote! {
+                        Self::#variant_ident => {
+                            map.serialize_entry(#tag_key, #serde_name)?;
+                        }
+                    }
+                } else {
+                    // Has other data variants - serialize mode and nested content with nulls only
+                    quote! {
+                        Self::#variant_ident => {
+                            map.serialize_entry(#tag_key, #serde_name)?;
+                            // Create nested content map with only null fields
+                            struct NullContentWrapper;
+                            impl ::serde::Serialize for NullContentWrapper {
+                                fn serialize<SS>(&self, serializer: SS) -> Result<SS::Ok, SS::Error>
+                                where
+                                    SS: ::serde::Serializer,
+                                {
+                                    use ::serde::ser::SerializeMap;
+                                    let mut content_map = serializer.serialize_map(None)?;
+                                    #(#nulls)*
+                                    content_map.end()
+                                }
+                            }
+                            map.serialize_entry(#content_key, &NullContentWrapper)?;
+                        }
                     }
                 }
             }
         })
         .collect();
 
-    // Compute total field count at compile time for serialize_map
-    let field_count_arms: Vec<TokenStream> = inactive_variant_field_nulls
-        .iter()
-        .map(|(_, inner_ty)| {
-            quote! {
-                <<#inner_ty as #krate::shadows::ShadowNode>::Reported
-                    as #krate::shadows::ReportedUnionFields>::FIELD_NAMES.len()
-            }
-        })
-        .collect();
-
-    let total_fields_expr = if field_count_arms.is_empty() {
-        quote! { 1usize } // Just the mode field
+    // Total fields is now just 1 (mode) or 2 (mode + content) since content is nested
+    let has_any_data_variants = !variants_with_data.is_empty();
+    let total_fields_expr = if has_any_data_variants {
+        quote! { 2usize } // mode + content
     } else {
-        quote! {
-            {
-                const fn sum_fields() -> usize {
-                    1 // mode field
-                    #(+ #field_count_arms)*
-                }
-                sum_fields()
-            }
-        }
+        quote! { 1usize } // just mode
     };
 
     let reported_type = quote! {
@@ -574,12 +630,72 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         }
     };
 
+    // Generate variant_at_path match arms
+    let variant_at_path_arms: Vec<TokenStream> = variant_idents
+        .iter()
+        .zip(variant_names.iter())
+        .map(|(ident, serde_name)| {
+            let has_data = variants_with_data
+                .iter()
+                .any(|(v, _)| v.ident == *ident);
+            if has_data {
+                quote! {
+                    Self::#ident(_) => {
+                        let mut s = ::heapless::String::<32>::new();
+                        let _ = s.push_str(#serde_name);
+                        Some(s)
+                    }
+                }
+            } else {
+                quote! {
+                    Self::#ident => {
+                        let mut s = ::heapless::String::<32>::new();
+                        let _ = s.push_str(#serde_name);
+                        Some(s)
+                    }
+                }
+            }
+        })
+        .collect();
+
     let shadow_node_impl = quote! {
         impl #krate::shadows::ShadowNode for #name {
             type Delta = #delta_name;
             type Reported = #reported_name;
 
             const SCHEMA_HASH: u64 = #schema_hash_const;
+
+            fn parse_delta<R: #krate::shadows::VariantResolver>(
+                json: &[u8],
+                path: &str,
+                resolver: &R,
+            ) -> impl ::core::future::Future<Output = Result<Self::Delta, #krate::shadows::ParseError>> {
+                async move {
+                    // Scan JSON for tag and content fields
+                    let scan = #krate::shadows::TaggedJsonScan::scan(json, #tag_key, #content_key)
+                        .map_err(#krate::shadows::ParseError::Scan)?;
+
+                    // Parse tag, using fallback from resolver if missing
+                    let mode = match scan.tag_str() {
+                        Some(s) => Some(s.parse::<#variant_enum_name>()
+                            .map_err(|_| #krate::shadows::ParseError::UnknownVariant)?),
+                        None => {
+                            // Try to get fallback variant from resolver
+                            resolver.resolve(path).await
+                                .and_then(|s| s.parse::<#variant_enum_name>().ok())
+                        }
+                    };
+
+                    // Parse config content using async parse_delta
+                    let config = match (mode, scan.content_bytes()) {
+                        #(#parse_delta_config_arms)*
+                        // Unit variant with content (ignore), variant without content, or no mode
+                        _ => None,
+                    };
+
+                    Ok(#delta_name { mode, config })
+                }
+            }
 
             fn apply_delta(&mut self, delta: &Self::Delta) {
                 // Handle mode (variant switch)
@@ -591,6 +707,17 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
 
                 // Handle config (variant content)
                 #config_apply_code
+            }
+
+            fn variant_at_path(&self, path: &str) -> Option<::heapless::String<32>> {
+                // Only match empty path (this level) or exact field path
+                if path.is_empty() {
+                    match self {
+                        #(#variant_at_path_arms)*
+                    }
+                } else {
+                    None
+                }
             }
 
             fn into_reported(self) -> Self::Reported {

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -65,7 +65,9 @@ use crate::attr::{
 };
 
 use super::adjacently_tagged::generate_adjacently_tagged_enum_code;
+#[cfg(feature = "kv_persist")]
 use super::helpers::{build_const_max_expr, build_max_key_len_expr};
+#[cfg(feature = "kv_persist")]
 use super::kv_codegen::{self, VARIANT_KEY_PATH};
 use super::CodegenOutput;
 
@@ -125,18 +127,6 @@ pub(crate) fn generate_simple_enum_code(
     let mut into_partial_reported_arms = Vec::new();
     let mut schema_hash_code = Vec::new();
 
-    // KVPersist-specific codegen (feature-gated)
-    let mut max_value_len_items = Vec::new();
-    let mut load_from_kv_variant_arms = Vec::new();
-    let mut persist_to_kv_variant_arms = Vec::new();
-    let mut persist_delta_arms = Vec::new();
-    let mut collect_valid_keys_arms = Vec::new();
-    let mut collect_valid_prefixes_arms = Vec::new();
-    let mut max_key_len_items = Vec::new();
-    let mut variant_name_arms = Vec::new();
-
-    let variant_key_len = VARIANT_KEY_PATH.len();
-
     for variant in variants {
         let variant_ident = &variant.ident;
 
@@ -173,38 +163,6 @@ pub(crate) fn generate_simple_enum_code(
                 let variant_bytes = serde_name.as_bytes();
                 schema_hash_code.push(quote! {
                     h = #krate::shadows::fnv1a_bytes(h, &[#(#variant_bytes),*]);
-                });
-
-                // =====================================================================
-                // KVPersist codegen for unit variant
-                // =====================================================================
-
-                variant_name_arms.push(quote! {
-                    Self::#variant_ident => #serde_name,
-                });
-
-                // load_from_kv arm: just set the variant
-                load_from_kv_variant_arms.push(quote! {
-                    #serde_name => {
-                        *self = Self::#variant_ident;
-                    }
-                });
-
-                // persist_to_kv arm: unit variants have no inner fields to persist
-                persist_to_kv_variant_arms.push(quote! {
-                    Self::#variant_ident => {
-                        // No inner fields to persist
-                    }
-                });
-
-                // persist_delta: write _variant key
-                persist_delta_arms.push(quote! {
-                    Self::Delta::#variant_ident => {
-                        let mut variant_key: ::heapless::String<KEY_LEN> = ::heapless::String::new();
-                        let _ = variant_key.push_str(prefix);
-                        let _ = variant_key.push_str(#VARIANT_KEY_PATH);
-                        kv.store(&variant_key, #serde_name.as_bytes()).await.map_err(#krate::shadows::KvError::Kv)?;
-                    }
                 });
 
                 // parse_delta arm for unit variant
@@ -269,72 +227,6 @@ pub(crate) fn generate_simple_enum_code(
                     h = #krate::shadows::fnv1a_u64(h, <#inner_ty as #krate::shadows::ShadowNode>::SCHEMA_HASH);
                 });
 
-                // =====================================================================
-                // KVPersist codegen for newtype variant
-                // =====================================================================
-                let variant_path = format!("/{}", serde_name);
-                let variant_path_len = variant_path.len();
-
-                // MAX_KEY_LEN: "/VariantName" + nested MAX_KEY_LEN
-                max_key_len_items.push(quote! { #variant_path_len + <#inner_ty as #krate::shadows::KVPersist>::MAX_KEY_LEN });
-
-                // MAX_VALUE_LEN
-                max_value_len_items.push(quote! {
-                    <#inner_ty as #krate::shadows::KVPersist>::MAX_VALUE_LEN
-                });
-
-                variant_name_arms.push(quote! {
-                    Self::#variant_ident(_) => #serde_name,
-                });
-
-                // load_from_kv arm: construct variant, delegate to inner
-                load_from_kv_variant_arms.push(kv_codegen::enum_variant_load_arm(
-                    krate,
-                    &variant_path,
-                    &serde_name,
-                    variant_ident,
-                    inner_ty,
-                ));
-
-                // persist_to_kv arm: delegate to inner
-                persist_to_kv_variant_arms.push(kv_codegen::enum_variant_persist_arm(
-                    krate,
-                    &variant_path,
-                    variant_ident,
-                    inner_ty,
-                ));
-
-                // persist_delta: write _variant key and delegate to inner
-                let variant_key_ident =
-                    syn::Ident::new("variant_key", proc_macro2::Span::call_site());
-                let variant_key_code = kv_codegen::build_key(&variant_key_ident, VARIANT_KEY_PATH);
-                let inner_prefix_ident =
-                    syn::Ident::new("inner_prefix", proc_macro2::Span::call_site());
-                let inner_prefix_code = kv_codegen::build_key(&inner_prefix_ident, &variant_path);
-                persist_delta_arms.push(quote! {
-                    Self::Delta::#variant_ident(ref inner_delta) => {
-                        #variant_key_code
-                        kv.store(&#variant_key_ident, #serde_name.as_bytes()).await.map_err(#krate::shadows::KvError::Kv)?;
-
-                        #inner_prefix_code
-                        <#inner_ty as #krate::shadows::KVPersist>::persist_delta::<K, KEY_LEN>(inner_delta, kv, &#inner_prefix_ident).await?;
-                    }
-                });
-
-                // collect_valid_keys: delegate to inner (all variants, not just active)
-                collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(
-                    krate,
-                    &variant_path,
-                    inner_ty,
-                ));
-
-                // collect_valid_prefixes: delegate to inner
-                collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(
-                    krate,
-                    &variant_path,
-                    inner_ty,
-                ));
-
                 // Mark that we have newtype variants
                 has_newtype_variants = true;
 
@@ -390,19 +282,6 @@ pub(crate) fn generate_simple_enum_code(
             }
         }
     }
-
-    // Build max_value_len const expression
-    let max_value_len_expr = build_const_max_expr(max_value_len_items, quote! { 0 });
-
-    // Build MAX_KEY_LEN const expression (max of _variant key and variant paths)
-    let max_key_len_expr = build_max_key_len_expr(max_key_len_items, quote! { #variant_key_len });
-
-    // Generate enum KVPersist method bodies using shared helpers
-    let load_from_kv_body = kv_codegen::enum_load_from_kv_body(krate, &load_from_kv_variant_arms);
-    let persist_to_kv_body =
-        kv_codegen::enum_persist_to_kv_body(krate, &variant_name_arms, &persist_to_kv_variant_arms);
-    let collect_valid_keys_body =
-        kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
 
     // Build SCHEMA_HASH const
     let schema_hash_const = quote! {
@@ -583,7 +462,7 @@ pub(crate) fn generate_simple_enum_code(
         }
     };
 
-    // Generate ShadowNode impl (always available)
+    // Generate ShadowNode impl (always generated)
     let shadow_node_impl = quote! {
         impl #krate::shadows::ShadowNode for #name {
             type Delta = #delta_name;
@@ -623,71 +502,205 @@ pub(crate) fn generate_simple_enum_code(
                 }
             }
         }
+    };
 
-        // KVPersist impl (feature-gated)
-        #[cfg(feature = "shadows_kv_persist")]
-        impl #krate::shadows::KVPersist for #name {
-            const MAX_KEY_LEN: usize = #max_key_len_expr;
-            const MAX_VALUE_LEN: usize = #max_value_len_expr;
+    // KVPersist impl (only generated when kv_persist feature is enabled)
+    #[cfg(feature = "kv_persist")]
+    let kv_persist_impl = {
+        // Collect KV-specific codegen by iterating over variants again
+        let mut max_value_len_items = Vec::new();
+        let mut load_from_kv_variant_arms = Vec::new();
+        let mut persist_to_kv_variant_arms = Vec::new();
+        let mut persist_delta_arms = Vec::new();
+        let mut collect_valid_keys_arms = Vec::new();
+        let mut collect_valid_prefixes_arms = Vec::new();
+        let mut max_key_len_items = Vec::new();
+        let mut variant_name_arms = Vec::new();
 
-            fn migration_sources(_field_path: &str) -> &'static [#krate::shadows::MigrationSource] {
-                &[]
-            }
+        let variant_key_len = VARIANT_KEY_PATH.len();
 
-            fn all_migration_keys() -> impl Iterator<Item = &'static str> {
-                core::iter::empty()
-            }
+        for (variant, serde_name) in variants.iter().zip(variant_names.iter()) {
+            let variant_ident = &variant.ident;
 
-            fn apply_field_default(&mut self, _field_path: &str) -> bool {
-                false
-            }
+            match &variant.fields {
+                Fields::Unit => {
+                    variant_name_arms.push(quote! {
+                        Self::#variant_ident => #serde_name,
+                    });
 
-            fn load_from_kv<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
-                &mut self,
-                prefix: &str,
-                kv: &K,
-            ) -> impl ::core::future::Future<Output = Result<#krate::shadows::LoadFieldResult, #krate::shadows::KvError<K::Error>>> {
-                #load_from_kv_body
-            }
+                    load_from_kv_variant_arms.push(quote! {
+                        #serde_name => {
+                            *self = Self::#variant_ident;
+                        }
+                    });
 
-            fn load_from_kv_with_migration<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
-                &mut self,
-                prefix: &str,
-                kv: &K,
-            ) -> impl ::core::future::Future<Output = Result<#krate::shadows::LoadFieldResult, #krate::shadows::KvError<K::Error>>> {
-                // Enums don't have migration support at this level
-                self.load_from_kv::<K, KEY_LEN>(prefix, kv)
-            }
+                    persist_to_kv_variant_arms.push(quote! {
+                        Self::#variant_ident => {
+                            // No inner fields to persist
+                        }
+                    });
 
-            fn persist_to_kv<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
-                &self,
-                prefix: &str,
-                kv: &K,
-            ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<K::Error>>> {
-                #persist_to_kv_body
-            }
-
-            fn persist_delta<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
-                delta: &Self::Delta,
-                kv: &K,
-                prefix: &str,
-            ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<K::Error>>> {
-                async move {
-                    match delta {
-                        #(#persist_delta_arms)*
-                    }
-                    Ok(())
+                    persist_delta_arms.push(quote! {
+                        Self::Delta::#variant_ident => {
+                            let mut variant_key: ::heapless::String<KEY_LEN> = ::heapless::String::new();
+                            let _ = variant_key.push_str(prefix);
+                            let _ = variant_key.push_str(#VARIANT_KEY_PATH);
+                            kv.store(&variant_key, #serde_name.as_bytes()).await.map_err(#krate::shadows::KvError::Kv)?;
+                        }
+                    });
                 }
-            }
+                Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+                    let inner_ty = &fields.unnamed[0].ty;
+                    let variant_path = format!("/{}", serde_name);
+                    let variant_path_len = variant_path.len();
 
-            fn collect_valid_keys<const KEY_LEN: usize>(prefix: &str, keys: &mut impl FnMut(&str)) {
-                #collect_valid_keys_body
-            }
+                    max_key_len_items.push(quote! { #variant_path_len + <#inner_ty as #krate::shadows::KVPersist>::MAX_KEY_LEN });
+                    max_value_len_items.push(quote! {
+                        <#inner_ty as #krate::shadows::KVPersist>::MAX_VALUE_LEN
+                    });
 
-            fn collect_valid_prefixes<const KEY_LEN: usize>(prefix: &str, prefixes: &mut impl FnMut(&str)) {
-                #(#collect_valid_prefixes_arms)*
+                    variant_name_arms.push(quote! {
+                        Self::#variant_ident(_) => #serde_name,
+                    });
+
+                    load_from_kv_variant_arms.push(kv_codegen::enum_variant_load_arm(
+                        krate,
+                        &variant_path,
+                        serde_name,
+                        variant_ident,
+                        inner_ty,
+                    ));
+
+                    persist_to_kv_variant_arms.push(kv_codegen::enum_variant_persist_arm(
+                        krate,
+                        &variant_path,
+                        variant_ident,
+                        inner_ty,
+                    ));
+
+                    let variant_key_ident =
+                        syn::Ident::new("variant_key", proc_macro2::Span::call_site());
+                    let variant_key_code =
+                        kv_codegen::build_key(&variant_key_ident, VARIANT_KEY_PATH);
+                    let inner_prefix_ident =
+                        syn::Ident::new("inner_prefix", proc_macro2::Span::call_site());
+                    let inner_prefix_code =
+                        kv_codegen::build_key(&inner_prefix_ident, &variant_path);
+                    persist_delta_arms.push(quote! {
+                        Self::Delta::#variant_ident(ref inner_delta) => {
+                            #variant_key_code
+                            kv.store(&#variant_key_ident, #serde_name.as_bytes()).await.map_err(#krate::shadows::KvError::Kv)?;
+
+                            #inner_prefix_code
+                            <#inner_ty as #krate::shadows::KVPersist>::persist_delta::<K, KEY_LEN>(inner_delta, kv, &#inner_prefix_ident).await?;
+                        }
+                    });
+
+                    collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(
+                        krate,
+                        &variant_path,
+                        inner_ty,
+                    ));
+
+                    collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(
+                        krate,
+                        &variant_path,
+                        inner_ty,
+                    ));
+                }
+                _ => {}
             }
         }
+
+        // Build const expressions
+        let max_value_len_expr = build_const_max_expr(max_value_len_items, quote! { 0 });
+        let max_key_len_expr =
+            build_max_key_len_expr(max_key_len_items, quote! { #variant_key_len });
+
+        // Generate method bodies using shared helpers
+        let load_from_kv_body =
+            kv_codegen::enum_load_from_kv_body(krate, &load_from_kv_variant_arms);
+        let persist_to_kv_body = kv_codegen::enum_persist_to_kv_body(
+            krate,
+            &variant_name_arms,
+            &persist_to_kv_variant_arms,
+        );
+        let collect_valid_keys_body =
+            kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
+
+        quote! {
+            impl #krate::shadows::KVPersist for #name {
+                const MAX_KEY_LEN: usize = #max_key_len_expr;
+                const MAX_VALUE_LEN: usize = #max_value_len_expr;
+
+                fn migration_sources(_field_path: &str) -> &'static [#krate::shadows::MigrationSource] {
+                    &[]
+                }
+
+                fn all_migration_keys() -> impl Iterator<Item = &'static str> {
+                    core::iter::empty()
+                }
+
+                fn apply_field_default(&mut self, _field_path: &str) -> bool {
+                    false
+                }
+
+                fn load_from_kv<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
+                    &mut self,
+                    prefix: &str,
+                    kv: &K,
+                ) -> impl ::core::future::Future<Output = Result<#krate::shadows::LoadFieldResult, #krate::shadows::KvError<K::Error>>> {
+                    #load_from_kv_body
+                }
+
+                fn load_from_kv_with_migration<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
+                    &mut self,
+                    prefix: &str,
+                    kv: &K,
+                ) -> impl ::core::future::Future<Output = Result<#krate::shadows::LoadFieldResult, #krate::shadows::KvError<K::Error>>> {
+                    // Enums don't have migration support at this level
+                    self.load_from_kv::<K, KEY_LEN>(prefix, kv)
+                }
+
+                fn persist_to_kv<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
+                    &self,
+                    prefix: &str,
+                    kv: &K,
+                ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<K::Error>>> {
+                    #persist_to_kv_body
+                }
+
+                fn persist_delta<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
+                    delta: &Self::Delta,
+                    kv: &K,
+                    prefix: &str,
+                ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<K::Error>>> {
+                    async move {
+                        match delta {
+                            #(#persist_delta_arms)*
+                        }
+                        Ok(())
+                    }
+                }
+
+                fn collect_valid_keys<const KEY_LEN: usize>(prefix: &str, keys: &mut impl FnMut(&str)) {
+                    #collect_valid_keys_body
+                }
+
+                fn collect_valid_prefixes<const KEY_LEN: usize>(prefix: &str, prefixes: &mut impl FnMut(&str)) {
+                    #(#collect_valid_prefixes_arms)*
+                }
+            }
+        }
+    };
+
+    #[cfg(not(feature = "kv_persist"))]
+    let kv_persist_impl = quote! {};
+
+    // Combine ShadowNode and KVPersist impls
+    let shadow_node_impl = quote! {
+        #shadow_node_impl
+        #kv_persist_impl
     };
 
     // Generate ReportedUnionFields impl for enum

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -5,7 +5,8 @@ use quote::quote;
 use syn::{Data, DeriveInput, Fields, Ident};
 
 use crate::attr::{
-    apply_rename_all, get_serde_rename, get_serde_rename_all, get_serde_tag_content, has_default_attr,
+    apply_rename_all, get_serde_rename, get_serde_rename_all, get_serde_tag_content,
+    has_default_attr,
 };
 
 use super::adjacently_tagged::generate_adjacently_tagged_enum_code;
@@ -246,9 +247,11 @@ pub(crate) fn generate_simple_enum_code(
                 ));
 
                 // persist_delta: write _variant key and delegate to inner
-                let variant_key_ident = syn::Ident::new("variant_key", proc_macro2::Span::call_site());
+                let variant_key_ident =
+                    syn::Ident::new("variant_key", proc_macro2::Span::call_site());
                 let variant_key_code = kv_codegen::build_key(&variant_key_ident, "/_variant");
-                let inner_prefix_ident = syn::Ident::new("inner_prefix", proc_macro2::Span::call_site());
+                let inner_prefix_ident =
+                    syn::Ident::new("inner_prefix", proc_macro2::Span::call_site());
                 let inner_prefix_code = kv_codegen::build_key(&inner_prefix_ident, &variant_path);
                 persist_delta_arms.push(quote! {
                     Self::Delta::#variant_ident(ref inner_delta) => {
@@ -261,10 +264,18 @@ pub(crate) fn generate_simple_enum_code(
                 });
 
                 // collect_valid_keys: delegate to inner (all variants, not just active)
-                collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(krate, &variant_path, inner_ty));
+                collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(
+                    krate,
+                    &variant_path,
+                    inner_ty,
+                ));
 
                 // collect_valid_prefixes: delegate to inner
-                collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(krate, &variant_path, inner_ty));
+                collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(
+                    krate,
+                    &variant_path,
+                    inner_ty,
+                ));
 
                 // Mark that we have newtype variants
                 has_newtype_variants = true;
@@ -330,8 +341,10 @@ pub(crate) fn generate_simple_enum_code(
 
     // Generate enum KVPersist method bodies using shared helpers
     let load_from_kv_body = kv_codegen::enum_load_from_kv_body(krate, &load_from_kv_variant_arms);
-    let persist_to_kv_body = kv_codegen::enum_persist_to_kv_body(krate, &variant_name_arms, &persist_to_kv_variant_arms);
-    let collect_valid_keys_body = kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
+    let persist_to_kv_body =
+        kv_codegen::enum_persist_to_kv_body(krate, &variant_name_arms, &persist_to_kv_variant_arms);
+    let collect_valid_keys_body =
+        kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
 
     // Build SCHEMA_HASH const
     let schema_hash_const = quote! {

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -250,7 +250,7 @@ pub(crate) fn generate_simple_enum_code(
                     parse_delta_arms.push(quote! {
                         #serde_name => {
                             // Build nested path for the inner type
-                            let mut nested_path: ::heapless::String<64> = ::heapless::String::new();
+                            let mut nested_path: #krate::__macro_support::heapless::String<64> = #krate::__macro_support::heapless::String::new();
                             let _ = nested_path.push_str(path);
                             if !path.is_empty() {
                                 let _ = nested_path.push('/');
@@ -271,7 +271,7 @@ pub(crate) fn generate_simple_enum_code(
                     parse_delta_arms.push(quote! {
                         if let Some(content_bytes) = scanner.field_bytes(#serde_name) {
                             // Build nested path for the inner type
-                            let mut nested_path: ::heapless::String<64> = ::heapless::String::new();
+                            let mut nested_path: #krate::__macro_support::heapless::String<64> = #krate::__macro_support::heapless::String::new();
                             let _ = nested_path.push_str(path);
                             if !path.is_empty() {
                                 let _ = nested_path.push('/');
@@ -416,7 +416,7 @@ pub(crate) fn generate_simple_enum_code(
             if has_data {
                 quote! {
                     Self::#variant_ident(_) => {
-                        let mut s = ::heapless::String::<32>::new();
+                        let mut s = #krate::__macro_support::heapless::String::<32>::new();
                         let _ = s.push_str(#serde_name);
                         Some(s)
                     }
@@ -424,7 +424,7 @@ pub(crate) fn generate_simple_enum_code(
             } else {
                 quote! {
                     Self::#variant_ident => {
-                        let mut s = ::heapless::String::<32>::new();
+                        let mut s = #krate::__macro_support::heapless::String::<32>::new();
                         let _ = s.push_str(#serde_name);
                         Some(s)
                     }
@@ -469,7 +469,7 @@ pub(crate) fn generate_simple_enum_code(
     } else {
         // Simple enums (unit variants only) use serde directly
         quote! {
-            ::serde_json_core::from_slice(json)
+            #krate::__macro_support::serde_json_core::from_slice(json)
                 .map(|(v, _)| v)
                 .map_err(|_| #krate::shadows::ParseError::Deserialize)
         }
@@ -499,7 +499,7 @@ pub(crate) fn generate_simple_enum_code(
                 }
             }
 
-            fn variant_at_path(&self, path: &str) -> Option<::heapless::String<32>> {
+            fn variant_at_path(&self, path: &str) -> Option<#krate::__macro_support::heapless::String<32>> {
                 if path.is_empty() {
                     match self {
                         #(#variant_at_path_arms)*
@@ -560,7 +560,7 @@ pub(crate) fn generate_simple_enum_code(
 
                     persist_delta_arms.push(quote! {
                         Self::Delta::#variant_ident => {
-                            let mut variant_key: ::heapless::String<KEY_LEN> = ::heapless::String::new();
+                            let mut variant_key: #krate::__macro_support::heapless::String<KEY_LEN> = #krate::__macro_support::heapless::String::new();
                             let _ = variant_key.push_str(prefix);
                             let _ = variant_key.push_str(#VARIANT_KEY_PATH);
                             kv.store(&variant_key, #serde_name.as_bytes()).await.map_err(#krate::shadows::KvError::Kv)?;
@@ -596,11 +596,11 @@ pub(crate) fn generate_simple_enum_code(
                     let variant_key_ident =
                         syn::Ident::new("variant_key", proc_macro2::Span::call_site());
                     let variant_key_code =
-                        kv_codegen::build_key(&variant_key_ident, VARIANT_KEY_PATH);
+                        kv_codegen::build_key(krate, &variant_key_ident, VARIANT_KEY_PATH);
                     let inner_prefix_ident =
                         syn::Ident::new("inner_prefix", proc_macro2::Span::call_site());
                     let inner_prefix_code =
-                        kv_codegen::build_key(&inner_prefix_ident, &variant_path);
+                        kv_codegen::build_key(krate, &inner_prefix_ident, &variant_path);
                     persist_delta_arms.push(quote! {
                         Self::Delta::#variant_ident(ref inner_delta) => {
                             #variant_key_code
@@ -642,7 +642,7 @@ pub(crate) fn generate_simple_enum_code(
             &persist_to_kv_variant_arms,
         );
         let collect_valid_keys_body =
-            kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
+            kv_codegen::enum_collect_valid_keys_body(krate, &collect_valid_keys_arms);
 
         quote! {
             impl #krate::shadows::KVPersist for #name {

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -250,7 +250,7 @@ pub(crate) fn generate_simple_enum_code(
                     parse_delta_arms.push(quote! {
                         #serde_name => {
                             // Build nested path for the inner type
-                            let mut nested_path: ::heapless::String<128> = ::heapless::String::new();
+                            let mut nested_path: ::heapless::String<64> = ::heapless::String::new();
                             let _ = nested_path.push_str(path);
                             if !path.is_empty() {
                                 let _ = nested_path.push('/');
@@ -271,7 +271,7 @@ pub(crate) fn generate_simple_enum_code(
                     parse_delta_arms.push(quote! {
                         if let Some(content_bytes) = scanner.field_bytes(#serde_name) {
                             // Build nested path for the inner type
-                            let mut nested_path: ::heapless::String<128> = ::heapless::String::new();
+                            let mut nested_path: ::heapless::String<64> = ::heapless::String::new();
                             let _ = nested_path.push_str(path);
                             if !path.is_empty() {
                                 let _ = nested_path.push('/');

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -9,6 +9,8 @@ use crate::attr::{
 };
 
 use super::adjacently_tagged::generate_adjacently_tagged_enum_code;
+use super::helpers::{build_const_max_expr, build_max_key_len_expr};
+use super::kv_codegen;
 
 /// Generate code for an enum type
 pub(crate) fn generate_enum_code(
@@ -266,24 +268,10 @@ pub(crate) fn generate_simple_enum_code(
                 });
 
                 // collect_valid_keys: delegate to inner (all variants, not just active)
-                collect_valid_keys_arms.push(quote! {
-                    {
-                        let mut inner_prefix: ::heapless::String<KEY_LEN> = ::heapless::String::new();
-                        let _ = inner_prefix.push_str(prefix);
-                        let _ = inner_prefix.push_str(#variant_path);
-                        <#inner_ty as #krate::shadows::KVPersist>::collect_valid_keys::<KEY_LEN>(&inner_prefix, keys);
-                    }
-                });
+                collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(krate, &variant_path, inner_ty));
 
                 // collect_valid_prefixes: delegate to inner
-                collect_valid_prefixes_arms.push(quote! {
-                    {
-                        let mut inner_prefix: ::heapless::String<KEY_LEN> = ::heapless::String::new();
-                        let _ = inner_prefix.push_str(prefix);
-                        let _ = inner_prefix.push_str(#variant_path);
-                        <#inner_ty as #krate::shadows::KVPersist>::collect_valid_prefixes::<KEY_LEN>(&inner_prefix, prefixes);
-                    }
-                });
+                collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(krate, &variant_path, inner_ty));
 
                 // Mark that we have newtype variants
                 has_newtype_variants = true;
@@ -342,41 +330,10 @@ pub(crate) fn generate_simple_enum_code(
     }
 
     // Build max_value_len const expression
-    let max_value_len_expr = if max_value_len_items.is_empty() {
-        quote! { 0 }
-    } else {
-        let mut expr = max_value_len_items[0].clone();
-        for item in &max_value_len_items[1..] {
-            expr = quote! { const_max(#expr, #item) };
-        }
-        quote! {
-            {
-                const fn const_max(a: usize, b: usize) -> usize {
-                    if a > b { a } else { b }
-                }
-                #expr
-            }
-        }
-    };
+    let max_value_len_expr = build_const_max_expr(max_value_len_items, quote! { 0 });
 
     // Build MAX_KEY_LEN const expression (max of _variant key and variant paths)
-    let max_key_len_expr = if max_key_len_items.is_empty() {
-        // Just the _variant key
-        quote! { #variant_key_len }
-    } else {
-        let mut expr = max_key_len_items[0].clone();
-        for item in &max_key_len_items[1..] {
-            expr = quote! { const_max(#expr, #item) };
-        }
-        quote! {
-            {
-                const fn const_max(a: usize, b: usize) -> usize {
-                    if a > b { a } else { b }
-                }
-                const_max(#variant_key_len, #expr)
-            }
-        }
-    };
+    let max_key_len_expr = build_max_key_len_expr(max_key_len_items, quote! { #variant_key_len });
 
     // Build SCHEMA_HASH const
     let schema_hash_const = quote! {

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -328,6 +328,11 @@ pub(crate) fn generate_simple_enum_code(
     // Build MAX_KEY_LEN const expression (max of _variant key and variant paths)
     let max_key_len_expr = build_max_key_len_expr(max_key_len_items, quote! { #variant_key_len });
 
+    // Generate enum KVPersist method bodies using shared helpers
+    let load_from_kv_body = kv_codegen::enum_load_from_kv_body(krate, &load_from_kv_variant_arms);
+    let persist_to_kv_body = kv_codegen::enum_persist_to_kv_body(krate, &variant_name_arms, &persist_to_kv_variant_arms);
+    let collect_valid_keys_body = kv_codegen::enum_collect_valid_keys_body(&collect_valid_keys_arms);
+
     // Build SCHEMA_HASH const
     let schema_hash_const = quote! {
         {
@@ -571,30 +576,7 @@ pub(crate) fn generate_simple_enum_code(
                 prefix: &str,
                 kv: &K,
             ) -> impl ::core::future::Future<Output = Result<#krate::shadows::LoadFieldResult, #krate::shadows::KvError<K::Error>>> {
-                async move {
-                    let mut result = #krate::shadows::LoadFieldResult::default();
-
-                    // Read _variant key (variant names are short, 128 bytes is plenty)
-                    let mut variant_key: ::heapless::String<KEY_LEN> = ::heapless::String::new();
-                    let _ = variant_key.push_str(prefix);
-                    let _ = variant_key.push_str("/_variant");
-
-                    let mut __vbuf = [0u8; 128];
-                    let variant_name = match kv.fetch(&variant_key, &mut __vbuf).await.map_err(#krate::shadows::KvError::Kv)? {
-                        Some(data) => core::str::from_utf8(data).map_err(|_| #krate::shadows::KvError::InvalidVariant)?,
-                        None => {
-                            *self = Self::default();
-                            return Ok(result);
-                        }
-                    };
-
-                    match variant_name {
-                        #(#load_from_kv_variant_arms)*
-                        _ => return Err(#krate::shadows::KvError::UnknownVariant),
-                    }
-
-                    Ok(result)
-                }
+                #load_from_kv_body
             }
 
             fn load_from_kv_with_migration<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
@@ -611,25 +593,7 @@ pub(crate) fn generate_simple_enum_code(
                 prefix: &str,
                 kv: &K,
             ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<K::Error>>> {
-                async move {
-                    // Write _variant key
-                    let mut variant_key: ::heapless::String<KEY_LEN> = ::heapless::String::new();
-                    let _ = variant_key.push_str(prefix);
-                    let _ = variant_key.push_str("/_variant");
-
-                    // Write variant name
-                    let variant_name: &str = match self {
-                        #(#variant_name_arms)*
-                    };
-                    kv.store(&variant_key, variant_name.as_bytes()).await.map_err(#krate::shadows::KvError::Kv)?;
-
-                    // Persist inner fields
-                    match self {
-                        #(#persist_to_kv_variant_arms)*
-                    }
-
-                    Ok(())
-                }
+                #persist_to_kv_body
             }
 
             fn persist_delta<K: #krate::shadows::KVStore, const KEY_LEN: usize>(
@@ -646,14 +610,7 @@ pub(crate) fn generate_simple_enum_code(
             }
 
             fn collect_valid_keys<const KEY_LEN: usize>(prefix: &str, keys: &mut impl FnMut(&str)) {
-                // Add _variant key
-                let mut variant_key: ::heapless::String<KEY_LEN> = ::heapless::String::new();
-                let _ = variant_key.push_str(prefix);
-                let _ = variant_key.push_str("/_variant");
-                keys(&variant_key);
-
-                // Collect from all variants (not just active)
-                #(#collect_valid_keys_arms)*
+                #collect_valid_keys_body
             }
 
             fn collect_valid_prefixes<const KEY_LEN: usize>(prefix: &str, prefixes: &mut impl FnMut(&str)) {

--- a/rustot_derive/src/codegen/helpers.rs
+++ b/rustot_derive/src/codegen/helpers.rs
@@ -48,29 +48,16 @@ pub fn build_const_max_expr(
 ///
 /// This is a convenience wrapper around `build_const_max_expr` that handles
 /// the common pattern of `const_max(base, max(items...))`.
+///
+/// Equivalent to `build_const_max_expr([base].into_iter().chain(items), fallback)`,
+/// but uses `base` as the fallback when `items` is empty.
 pub fn build_max_key_len_expr(
     items: impl IntoIterator<Item = TokenStream>,
     base: TokenStream,
 ) -> TokenStream {
-    let items: Vec<_> = items.into_iter().collect();
-
-    if items.is_empty() {
-        return base;
-    }
-
-    let mut expr = items[0].clone();
-    for item in &items[1..] {
-        expr = quote! { const_max(#expr, #item) };
-    }
-
-    quote! {
-        {
-            const fn const_max(a: usize, b: usize) -> usize {
-                if a > b { a } else { b }
-            }
-            const_max(#base, #expr)
-        }
-    }
+    // Prepend base to items and compute max of all
+    let all_items = std::iter::once(base.clone()).chain(items);
+    build_const_max_expr(all_items, base)
 }
 
 #[cfg(test)]

--- a/rustot_derive/src/codegen/helpers.rs
+++ b/rustot_derive/src/codegen/helpers.rs
@@ -1,0 +1,103 @@
+//! Shared helper functions for code generation
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Build a const expression that computes the maximum of multiple values at compile time.
+///
+/// Takes an iterator of token streams (each representing a `usize` expression) and produces
+/// a single const expression that evaluates to their maximum.
+///
+/// If the iterator is empty, returns a fallback value (typically `0` or a base value).
+///
+/// # Example output
+/// ```ignore
+/// {
+///     const fn const_max(a: usize, b: usize) -> usize {
+///         if a > b { a } else { b }
+///     }
+///     const_max(const_max(A, B), C)
+/// }
+/// ```
+pub fn build_const_max_expr(
+    items: impl IntoIterator<Item = TokenStream>,
+    fallback: TokenStream,
+) -> TokenStream {
+    let items: Vec<_> = items.into_iter().collect();
+
+    if items.is_empty() {
+        return fallback;
+    }
+
+    let mut expr = items[0].clone();
+    for item in &items[1..] {
+        expr = quote! { const_max(#expr, #item) };
+    }
+
+    quote! {
+        {
+            const fn const_max(a: usize, b: usize) -> usize {
+                if a > b { a } else { b }
+            }
+            #expr
+        }
+    }
+}
+
+/// Build a const expression for MAX_KEY_LEN that includes a base value.
+///
+/// This is a convenience wrapper around `build_const_max_expr` that handles
+/// the common pattern of `const_max(base, max(items...))`.
+pub fn build_max_key_len_expr(
+    items: impl IntoIterator<Item = TokenStream>,
+    base: TokenStream,
+) -> TokenStream {
+    let items: Vec<_> = items.into_iter().collect();
+
+    if items.is_empty() {
+        return base;
+    }
+
+    let mut expr = items[0].clone();
+    for item in &items[1..] {
+        expr = quote! { const_max(#expr, #item) };
+    }
+
+    quote! {
+        {
+            const fn const_max(a: usize, b: usize) -> usize {
+                if a > b { a } else { b }
+            }
+            const_max(#base, #expr)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_const_max_expr_empty() {
+        let result = build_const_max_expr(std::iter::empty(), quote! { 0 });
+        assert_eq!(result.to_string(), "0");
+    }
+
+    #[test]
+    fn test_build_const_max_expr_single() {
+        let items = vec![quote! { 42 }];
+        let result = build_const_max_expr(items, quote! { 0 });
+        // Should wrap single item in const_max block
+        assert!(result.to_string().contains("const fn const_max"));
+        assert!(result.to_string().contains("42"));
+    }
+
+    #[test]
+    fn test_build_const_max_expr_multiple() {
+        let items = vec![quote! { A }, quote! { B }, quote! { C }];
+        let result = build_const_max_expr(items, quote! { 0 });
+        let s = result.to_string();
+        assert!(s.contains("const fn const_max"));
+        assert!(s.contains("const_max (const_max (A , B) , C)"));
+    }
+}

--- a/rustot_derive/src/codegen/kv_codegen.rs
+++ b/rustot_derive/src/codegen/kv_codegen.rs
@@ -334,7 +334,11 @@ pub fn nested_persist_delta(
 }
 
 /// Generates code for collecting keys from a nested ShadowNode field.
-pub fn nested_collect_keys(krate: &TokenStream, field_path: &str, field_ty: &syn::Type) -> TokenStream {
+pub fn nested_collect_keys(
+    krate: &TokenStream,
+    field_path: &str,
+    field_ty: &syn::Type,
+) -> TokenStream {
     let prefix_ident = syn::Ident::new("nested_prefix", proc_macro2::Span::call_site());
     let prefix_code = build_key(&prefix_ident, field_path);
 

--- a/rustot_derive/src/codegen/kv_codegen.rs
+++ b/rustot_derive/src/codegen/kv_codegen.rs
@@ -491,7 +491,10 @@ pub fn enum_persist_to_kv_body(
 /// Generates the body of `collect_valid_keys` for enum types.
 ///
 /// This is shared between simple enums and adjacently-tagged enums.
-pub fn enum_collect_valid_keys_body(krate: &TokenStream, collect_keys_arms: &[TokenStream]) -> TokenStream {
+pub fn enum_collect_valid_keys_body(
+    krate: &TokenStream,
+    collect_keys_arms: &[TokenStream],
+) -> TokenStream {
     let variant_key_ident = syn::Ident::new("variant_key", proc_macro2::Span::call_site());
     let variant_key_code = build_key(krate, &variant_key_ident, VARIANT_KEY_PATH);
 

--- a/rustot_derive/src/codegen/kv_codegen.rs
+++ b/rustot_derive/src/codegen/kv_codegen.rs
@@ -1,0 +1,364 @@
+//! KV persistence code generation helpers
+//!
+//! This module provides reusable code generation patterns for KVPersist trait implementations.
+//! These helpers eliminate duplication between struct, enum, and adjacently-tagged enum codegen.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Generates code to build a heapless::String key from a prefix and path.
+///
+/// # Generated code pattern
+/// ```ignore
+/// let mut #var_name: ::heapless::String<KEY_LEN> = ::heapless::String::new();
+/// let _ = #var_name.push_str(prefix);
+/// let _ = #var_name.push_str(#path);
+/// ```
+pub fn build_key(var_name: &syn::Ident, path: &str) -> TokenStream {
+    quote! {
+        let mut #var_name: ::heapless::String<KEY_LEN> = ::heapless::String::new();
+        let _ = #var_name.push_str(prefix);
+        let _ = #var_name.push_str(#path);
+    }
+}
+
+/// Generates code for loading a leaf field from KV storage.
+///
+/// Handles both std and no_std environments with appropriate buffer management.
+pub fn leaf_load(
+    krate: &TokenStream,
+    field_path: &str,
+    field_access: TokenStream,
+    on_missing: TokenStream,
+) -> TokenStream {
+    let key_ident = syn::Ident::new("full_key", proc_macro2::Span::call_site());
+    let key_code = build_key(&key_ident, field_path);
+
+    quote! {
+        {
+            #key_code
+            #[cfg(not(feature = "std"))]
+            {
+                let mut __fetch_buf = [0u8; <Self as #krate::shadows::KVPersist>::MAX_VALUE_LEN];
+                if let Some(data) = kv.fetch(&#key_ident, &mut __fetch_buf).await.map_err(#krate::shadows::KvError::Kv)? {
+                    #field_access = ::postcard::from_bytes(data).map_err(|_| #krate::shadows::KvError::Serialization)?;
+                    result.loaded += 1;
+                } else {
+                    #on_missing
+                }
+            }
+            #[cfg(feature = "std")]
+            {
+                if let Some(data) = kv.fetch_to_vec(&#key_ident).await.map_err(#krate::shadows::KvError::Kv)? {
+                    #field_access = ::postcard::from_bytes(&data).map_err(|_| #krate::shadows::KvError::Serialization)?;
+                    result.loaded += 1;
+                } else {
+                    #on_missing
+                }
+            }
+        }
+    }
+}
+
+/// Generates code for loading a leaf field with migration support.
+///
+/// Tries to load from the primary key first, falls back to migration sources if:
+/// - The key doesn't exist, or
+/// - Deserialization fails (schema changed)
+pub fn leaf_load_with_migration(
+    krate: &TokenStream,
+    field_path: &str,
+    field_access: TokenStream,
+    migration_code: TokenStream,
+) -> TokenStream {
+    let key_ident = syn::Ident::new("full_key", proc_macro2::Span::call_site());
+    let key_code = build_key(&key_ident, field_path);
+
+    quote! {
+        {
+            #key_code
+            #[cfg(not(feature = "std"))]
+            {
+                let mut __fetch_buf = [0u8; <Self as #krate::shadows::KVPersist>::MAX_VALUE_LEN];
+                if let Some(data) = kv.fetch(&#key_ident, &mut __fetch_buf).await.map_err(#krate::shadows::KvError::Kv)? {
+                    match ::postcard::from_bytes(data) {
+                        Ok(val) => {
+                            #field_access = val;
+                            result.loaded += 1;
+                        }
+                        Err(_) => {
+                            #migration_code
+                        }
+                    }
+                } else {
+                    #migration_code
+                }
+            }
+            #[cfg(feature = "std")]
+            {
+                if let Some(data) = kv.fetch_to_vec(&#key_ident).await.map_err(#krate::shadows::KvError::Kv)? {
+                    match ::postcard::from_bytes(&data) {
+                        Ok(val) => {
+                            #field_access = val;
+                            result.loaded += 1;
+                        }
+                        Err(_) => {
+                            #migration_code
+                        }
+                    }
+                } else {
+                    #migration_code
+                }
+            }
+        }
+    }
+}
+
+/// Generates the migration fallback code that tries old keys and applies conversion.
+pub fn migration_fallback(
+    krate: &TokenStream,
+    field_path: &str,
+    field_access: TokenStream,
+    migrate_from_keys: &[&String],
+    migrate_convert: Option<&syn::Path>,
+) -> TokenStream {
+    if migrate_from_keys.is_empty() {
+        // No migration sources, just apply default
+        return quote! {
+            <Self as #krate::shadows::KVPersist>::apply_field_default(self, #field_path);
+            result.defaulted += 1;
+        };
+    }
+
+    let convert_expr = match migrate_convert {
+        Some(convert) => quote! { Some(#convert) },
+        None => quote! { None },
+    };
+
+    quote! {
+        // Try migration sources
+        let mut migrated = false;
+        let sources: &[#krate::shadows::MigrationSource] = &[
+            #(#krate::shadows::MigrationSource {
+                key: #migrate_from_keys,
+                convert: #convert_expr,
+            }),*
+        ];
+        for source in sources {
+            let mut old_key: ::heapless::String<KEY_LEN> = ::heapless::String::new();
+            let _ = old_key.push_str(prefix);
+            let _ = old_key.push_str(source.key);
+            #[cfg(not(feature = "std"))]
+            {
+                let mut fetch_buf = [0u8; <Self as #krate::shadows::KVPersist>::MAX_VALUE_LEN];
+                if let Some(old_data) = kv.fetch(&old_key, &mut fetch_buf).await.map_err(#krate::shadows::KvError::Kv)? {
+                    let value_bytes = if let Some(convert_fn) = source.convert {
+                        let mut convert_buf = [0u8; <Self as #krate::shadows::KVPersist>::MAX_VALUE_LEN];
+                        let new_len = convert_fn(old_data, &mut convert_buf).map_err(#krate::shadows::KvError::Migration)?;
+                        fetch_buf[..new_len].copy_from_slice(&convert_buf[..new_len]);
+                        &fetch_buf[..new_len]
+                    } else {
+                        old_data
+                    };
+                    #field_access = ::postcard::from_bytes(value_bytes).map_err(|_| #krate::shadows::KvError::Serialization)?;
+                    kv.store(&full_key, value_bytes).await.map_err(#krate::shadows::KvError::Kv)?;
+                    result.migrated += 1;
+                    migrated = true;
+                    break;
+                }
+            }
+            #[cfg(feature = "std")]
+            {
+                if let Some(old_data) = kv.fetch_to_vec(&old_key).await.map_err(#krate::shadows::KvError::Kv)? {
+                    let value_bytes: ::std::vec::Vec<u8> = if let Some(convert_fn) = source.convert {
+                        let mut convert_buf = vec![0u8; old_data.len() * 2 + 64];
+                        let new_len = convert_fn(&old_data, &mut convert_buf).map_err(#krate::shadows::KvError::Migration)?;
+                        convert_buf[..new_len].to_vec()
+                    } else {
+                        old_data
+                    };
+                    #field_access = ::postcard::from_bytes(&value_bytes).map_err(|_| #krate::shadows::KvError::Serialization)?;
+                    kv.store(&full_key, &value_bytes).await.map_err(#krate::shadows::KvError::Kv)?;
+                    result.migrated += 1;
+                    migrated = true;
+                    break;
+                }
+            }
+        }
+        if !migrated {
+            <Self as #krate::shadows::KVPersist>::apply_field_default(self, #field_path);
+            result.defaulted += 1;
+        }
+    }
+}
+
+/// Generates code for persisting a leaf field to KV storage.
+pub fn leaf_persist(krate: &TokenStream, field_path: &str, value_expr: TokenStream) -> TokenStream {
+    let key_ident = syn::Ident::new("full_key", proc_macro2::Span::call_site());
+    let key_code = build_key(&key_ident, field_path);
+
+    quote! {
+        {
+            #key_code
+            #[cfg(not(feature = "std"))]
+            {
+                let mut __ser_buf = [0u8; <Self as #krate::shadows::KVPersist>::MAX_VALUE_LEN];
+                let bytes = ::postcard::to_slice(&#value_expr, &mut __ser_buf)
+                    .map_err(|_| #krate::shadows::KvError::Serialization)?;
+                kv.store(&#key_ident, bytes).await.map_err(#krate::shadows::KvError::Kv)?;
+            }
+            #[cfg(feature = "std")]
+            {
+                let bytes = ::postcard::to_allocvec(&#value_expr)
+                    .map_err(|_| #krate::shadows::KvError::Serialization)?;
+                kv.store(&#key_ident, &bytes).await.map_err(#krate::shadows::KvError::Kv)?;
+            }
+        }
+    }
+}
+
+/// Generates code for persisting a delta field (only if Some).
+pub fn leaf_persist_delta(
+    krate: &TokenStream,
+    field_path: &str,
+    field_name: &syn::Ident,
+) -> TokenStream {
+    let key_ident = syn::Ident::new("full_key", proc_macro2::Span::call_site());
+    let key_code = build_key(&key_ident, field_path);
+
+    quote! {
+        if let Some(ref val) = delta.#field_name {
+            #key_code
+            #[cfg(not(feature = "std"))]
+            {
+                let mut __ser_buf = [0u8; <Self as #krate::shadows::KVPersist>::MAX_VALUE_LEN];
+                let bytes = ::postcard::to_slice(val, &mut __ser_buf)
+                    .map_err(|_| #krate::shadows::KvError::Serialization)?;
+                kv.store(&#key_ident, bytes).await.map_err(#krate::shadows::KvError::Kv)?;
+            }
+            #[cfg(feature = "std")]
+            {
+                let bytes = ::postcard::to_allocvec(val)
+                    .map_err(|_| #krate::shadows::KvError::Serialization)?;
+                kv.store(&#key_ident, &bytes).await.map_err(#krate::shadows::KvError::Kv)?;
+            }
+        }
+    }
+}
+
+/// Generates code for collecting a leaf field's key.
+pub fn leaf_collect_keys(field_path: &str) -> TokenStream {
+    let key_ident = syn::Ident::new("key", proc_macro2::Span::call_site());
+    let key_code = build_key(&key_ident, field_path);
+
+    quote! {
+        {
+            #key_code
+            keys(&#key_ident);
+        }
+    }
+}
+
+/// Generates code for loading a nested ShadowNode field from KV storage.
+pub fn nested_load(
+    krate: &TokenStream,
+    field_path: &str,
+    field_ty: &syn::Type,
+    field_access: TokenStream,
+) -> TokenStream {
+    let prefix_ident = syn::Ident::new("nested_prefix", proc_macro2::Span::call_site());
+    let prefix_code = build_key(&prefix_ident, field_path);
+
+    quote! {
+        {
+            #prefix_code
+            let inner = <#field_ty as #krate::shadows::KVPersist>::load_from_kv::<K, KEY_LEN>(#field_access, &#prefix_ident, kv).await?;
+            result.merge(inner);
+        }
+    }
+}
+
+/// Generates code for loading a nested ShadowNode field with migration support.
+pub fn nested_load_with_migration(
+    krate: &TokenStream,
+    field_path: &str,
+    field_ty: &syn::Type,
+    field_access: TokenStream,
+) -> TokenStream {
+    let prefix_ident = syn::Ident::new("nested_prefix", proc_macro2::Span::call_site());
+    let prefix_code = build_key(&prefix_ident, field_path);
+
+    quote! {
+        {
+            #prefix_code
+            let inner = <#field_ty as #krate::shadows::KVPersist>::load_from_kv_with_migration::<K, KEY_LEN>(#field_access, &#prefix_ident, kv).await?;
+            result.merge(inner);
+        }
+    }
+}
+
+/// Generates code for persisting a nested ShadowNode field to KV storage.
+pub fn nested_persist(
+    krate: &TokenStream,
+    field_path: &str,
+    field_ty: &syn::Type,
+    field_access: TokenStream,
+) -> TokenStream {
+    let prefix_ident = syn::Ident::new("nested_prefix", proc_macro2::Span::call_site());
+    let prefix_code = build_key(&prefix_ident, field_path);
+
+    quote! {
+        {
+            #prefix_code
+            <#field_ty as #krate::shadows::KVPersist>::persist_to_kv::<K, KEY_LEN>(#field_access, &#prefix_ident, kv).await?;
+        }
+    }
+}
+
+/// Generates code for persisting a nested delta field.
+pub fn nested_persist_delta(
+    krate: &TokenStream,
+    field_path: &str,
+    field_ty: &syn::Type,
+    field_name: &syn::Ident,
+) -> TokenStream {
+    let prefix_ident = syn::Ident::new("nested_prefix", proc_macro2::Span::call_site());
+    let prefix_code = build_key(&prefix_ident, field_path);
+
+    quote! {
+        if let Some(ref inner_delta) = delta.#field_name {
+            #prefix_code
+            <#field_ty as #krate::shadows::KVPersist>::persist_delta::<K, KEY_LEN>(inner_delta, kv, &#prefix_ident).await?;
+        }
+    }
+}
+
+/// Generates code for collecting keys from a nested ShadowNode field.
+pub fn nested_collect_keys(krate: &TokenStream, field_path: &str, field_ty: &syn::Type) -> TokenStream {
+    let prefix_ident = syn::Ident::new("nested_prefix", proc_macro2::Span::call_site());
+    let prefix_code = build_key(&prefix_ident, field_path);
+
+    quote! {
+        {
+            #prefix_code
+            <#field_ty as #krate::shadows::KVPersist>::collect_valid_keys::<KEY_LEN>(&#prefix_ident, keys);
+        }
+    }
+}
+
+/// Generates code for collecting prefixes from a nested ShadowNode field.
+pub fn nested_collect_prefixes(
+    krate: &TokenStream,
+    field_path: &str,
+    field_ty: &syn::Type,
+) -> TokenStream {
+    let prefix_ident = syn::Ident::new("nested_prefix", proc_macro2::Span::call_site());
+    let prefix_code = build_key(&prefix_ident, field_path);
+
+    quote! {
+        {
+            #prefix_code
+            <#field_ty as #krate::shadows::KVPersist>::collect_valid_prefixes::<KEY_LEN>(&#prefix_ident, prefixes);
+        }
+    }
+}

--- a/rustot_derive/src/codegen/mod.rs
+++ b/rustot_derive/src/codegen/mod.rs
@@ -18,7 +18,22 @@ use proc_macro_crate::{crate_name, FoundCrate};
 use quote::{format_ident, quote};
 use syn::{Data, DeriveInput, Ident};
 
-use crate::attr::get_serde_tag_content;
+use crate::attr::{get_serde_tag_content, ShadowRootParams};
+
+/// Output of code generation for a struct or enum type.
+///
+/// This struct captures all the generated code fragments that need to be
+/// emitted together with the original type definition.
+pub(crate) struct CodegenOutput {
+    /// The Delta type definition (e.g., `struct DeltaFoo { ... }`)
+    pub delta_type: TokenStream,
+    /// The Reported type definition (e.g., `struct ReportedFoo { ... }`)
+    pub reported_type: TokenStream,
+    /// The `ShadowNode` trait implementation (includes `KVPersist` when feature-enabled)
+    pub shadow_node_impl: TokenStream,
+    /// The `ReportedUnionFields` trait implementation
+    pub reported_union_fields_impl: TokenStream,
+}
 
 /// Get the path to the rustot crate, handling both internal and external usage.
 pub(crate) fn rustot_crate_path() -> TokenStream {
@@ -35,22 +50,16 @@ pub(crate) fn rustot_crate_path() -> TokenStream {
     }
 }
 
-/// Configuration for shadow node code generation
-pub struct ShadowNodeConfig {
-    /// Whether this is a root type (implements ShadowRoot)
-    pub is_root: bool,
-    /// The shadow name (for ShadowRoot types)
-    pub name: Option<String>,
-    /// Topic prefix for MQTT topics (e.g., "$aws" for AWS IoT)
-    pub topic_prefix: Option<String>,
-    /// Maximum payload size for shadow documents
-    pub max_payload_len: Option<usize>,
-}
-
-/// Generate all code for a shadow node type
+/// Generate all code for a shadow node type.
+///
+/// # Arguments
+///
+/// * `input` - The parsed derive input
+/// * `root_params` - If `Some`, this is a root type and will implement `ShadowRoot`.
+///   If `None`, only `ShadowNode` is implemented.
 pub fn generate_shadow_node(
     input: &DeriveInput,
-    config: &ShadowNodeConfig,
+    root_params: Option<&ShadowRootParams>,
 ) -> syn::Result<TokenStream> {
     let name = &input.ident;
     let delta_name = format_ident!("Delta{}", name);
@@ -65,7 +74,7 @@ pub fn generate_shadow_node(
     let is_adjacently_tagged = tag_key.is_some() && content_key.is_some();
 
     // Generate code based on struct vs enum
-    let (delta_type, reported_type, shadow_node_impl, reported_union_fields_impl) = if is_enum {
+    let output = if is_enum {
         enum_codegen::generate_enum_code(
             input,
             &delta_name,
@@ -78,17 +87,17 @@ pub fn generate_shadow_node(
     };
 
     // Generate ShadowRoot impl if this is a root type
-    let shadow_root_impl = if config.is_root {
-        let name_value = match &config.name {
+    let shadow_root_impl = if let Some(params) = root_params {
+        let name_value = match &params.name {
             Some(n) => quote! { Some(#n) },
             None => quote! { None },
         };
 
-        let prefix_const = config.topic_prefix.as_ref().map(|p| {
+        let prefix_const = params.topic_prefix.as_ref().map(|p| {
             quote! { const PREFIX: &'static str = #p; }
         });
 
-        let max_payload_const = config.max_payload_len.map(|s| {
+        let max_payload_const = params.max_payload_len.map(|s| {
             quote! { const MAX_PAYLOAD_SIZE: usize = #s; }
         });
 
@@ -102,6 +111,11 @@ pub fn generate_shadow_node(
     } else {
         TokenStream::new()
     };
+
+    let delta_type = output.delta_type;
+    let reported_type = output.reported_type;
+    let shadow_node_impl = output.shadow_node_impl;
+    let reported_union_fields_impl = output.reported_union_fields_impl;
 
     Ok(quote! {
         #delta_type

--- a/rustot_derive/src/codegen/mod.rs
+++ b/rustot_derive/src/codegen/mod.rs
@@ -9,6 +9,8 @@
 
 mod adjacently_tagged;
 mod enum_codegen;
+mod helpers;
+mod kv_codegen;
 mod struct_codegen;
 
 use proc_macro2::{Span, TokenStream};

--- a/rustot_derive/src/codegen/mod.rs
+++ b/rustot_derive/src/codegen/mod.rs
@@ -9,7 +9,9 @@
 
 mod adjacently_tagged;
 mod enum_codegen;
+#[cfg(feature = "kv_persist")]
 mod helpers;
+#[cfg(feature = "kv_persist")]
 mod kv_codegen;
 mod struct_codegen;
 

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -1,4 +1,41 @@
 //! Code generation for struct types
+//!
+//! This module generates the `ShadowNode` and `KVPersist` implementations for struct types.
+//!
+//! # Field Classification: Leaf vs Nested
+//!
+//! Each field in a struct is classified as either a **leaf** or **nested** field.
+//! This classification fundamentally affects code generation:
+//!
+//! ## Leaf Fields
+//!
+//! A field is a leaf if **any** of these conditions hold:
+//! - `#[shadow_attr(opaque)]` - explicitly marks the field as opaque
+//! - `#[shadow_attr(migrate_from = "...")]` - has migration sources
+//!
+//! Leaf fields are treated as atomic values:
+//! - **Delta type**: `Option<FieldType>` (the field's own type wrapped in Option)
+//! - **Reported type**: `Option<FieldType>`
+//! - **KV storage**: Single key `/field_name` storing the serialized value
+//! - **Schema hash**: Hashes field name + type name
+//!
+//! **Why migrations imply leaf**: Migration logic operates on the raw serialized bytes,
+//! applying optional conversion functions. This only makes sense for atomic values,
+//! not for nested structures that delegate to their own KV paths.
+//!
+//! ## Nested Fields
+//!
+//! Fields without `opaque` or `migrate_from` are nested. They must implement `ShadowNode`:
+//! - **Delta type**: `Option<<FieldType as ShadowNode>::Delta>`
+//! - **Reported type**: `Option<<FieldType as ShadowNode>::Reported>`
+//! - **KV storage**: Delegates to inner type with prefix `/field_name`
+//! - **Schema hash**: Hashes field name + inner type's `SCHEMA_HASH`
+//!
+//! # Other Field Attributes
+//!
+//! - `#[shadow_attr(report_only)]`: Field is excluded from Delta type (not in desired state,
+//!   only reported). It will always be `None` in partial reported.
+//! - `#[shadow_attr(default = ...)]`: Custom default value when KV key is missing.
 
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -8,6 +45,446 @@ use crate::attr::{get_serde_rename, DefaultValue, FieldAttrs};
 
 use super::helpers::build_const_max_expr;
 use super::kv_codegen;
+use super::CodegenOutput;
+
+/// All generated code fragments for a single struct field.
+///
+/// This struct captures the complete output of processing one field,
+/// making it easier to understand what code is generated for each field
+/// without tracking ~20 separate collections.
+struct FieldCodegen {
+    /// The serde field name (for FIELD_NAMES constant)
+    serde_name: String,
+
+    /// Delta struct field definition (None if report_only)
+    delta_field: Option<TokenStream>,
+    /// Reported struct field definition
+    reported_field: TokenStream,
+
+    /// apply_delta() arm (None if report_only)
+    apply_delta_arm: Option<TokenStream>,
+    /// into_partial_reported() field assignment
+    into_partial_reported_arm: TokenStream,
+    /// SCHEMA_HASH computation code
+    schema_hash_code: TokenStream,
+    /// ReportedUnionFields::serialize_into_map arm
+    reported_serialize_arm: TokenStream,
+    /// variant_at_path() delegation arm (None for leaf fields)
+    variant_at_path_arm: Option<TokenStream>,
+
+    /// Field name for parse_delta (None if report_only)
+    parse_delta_field_name: Option<String>,
+    /// parse_delta() field parsing arm (None if report_only)
+    parse_delta_arm: Option<TokenStream>,
+
+    // KVPersist codegen
+    /// migration_sources() match arm (None if no migrations)
+    migration_arm: Option<TokenStream>,
+    /// apply_field_default() match arm (None if no custom default)
+    default_arm: Option<TokenStream>,
+    /// MAX_VALUE_LEN expression component
+    max_value_len_item: TokenStream,
+    /// MAX_KEY_LEN expression component
+    max_key_len_item: TokenStream,
+    /// load_from_kv() arm
+    load_from_kv_arm: TokenStream,
+    /// load_from_kv_with_migration() arm
+    load_from_kv_migration_arm: TokenStream,
+    /// persist_to_kv() arm
+    persist_to_kv_arm: TokenStream,
+    /// persist_delta() arm (None if report_only)
+    persist_delta_arm: Option<TokenStream>,
+    /// collect_valid_keys() arm
+    collect_valid_keys_arm: TokenStream,
+    /// collect_valid_prefixes() arm (None for leaf fields)
+    collect_valid_prefixes_arm: Option<TokenStream>,
+
+    /// Migration source keys (for all_migration_keys)
+    migration_from_keys: Vec<String>,
+    /// Opaque field type for where clause (None if not opaque)
+    opaque_field_type: Option<syn::Type>,
+}
+
+/// Process a single struct field and generate all code fragments.
+///
+/// # Leaf vs Nested fields
+///
+/// A field is considered a "leaf" if either:
+/// - It has the `#[shadow_attr(opaque)]` attribute, OR
+/// - It has migration sources via `#[shadow_attr(migrate_from = ...)]`
+///
+/// Leaf fields are serialized directly as their type. Nested fields delegate
+/// to their inner ShadowNode implementation for Delta/Reported types and
+/// KV operations.
+fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
+    let field_name = field.ident.as_ref().unwrap();
+    let field_ty = &field.ty;
+    let attrs = FieldAttrs::from_attrs(&field.attrs);
+
+    let serde_name = get_serde_rename(&field.attrs).unwrap_or_else(|| field_name.to_string());
+    let field_path = format!("/{}", serde_name);
+
+    // A field is a "leaf" (direct KV storage) if it's opaque OR has migrations.
+    // Fields with migrations must be leaves because migration logic operates on
+    // the serialized value directly.
+    let has_migration = !attrs.migrate_from().is_empty();
+    let is_leaf = attrs.opaque || has_migration;
+
+    // Filter out shadow_attr from forwarded attributes
+    let filtered_attrs: Vec<_> = field
+        .attrs
+        .iter()
+        .filter(|a| !a.path().is_ident("shadow_attr"))
+        .collect();
+
+    // --- Delta field ---
+    let delta_field = if attrs.report_only {
+        None
+    } else if is_leaf {
+        Some(quote! {
+            #(#filtered_attrs)*
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub #field_name: Option<#field_ty>,
+        })
+    } else {
+        let delta_field_ty = quote! { <#field_ty as #krate::shadows::ShadowNode>::Delta };
+        Some(quote! {
+            #(#filtered_attrs)*
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub #field_name: Option<#delta_field_ty>,
+        })
+    };
+
+    // --- Reported field ---
+    let reported_field = if is_leaf {
+        quote! {
+            #(#filtered_attrs)*
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub #field_name: Option<#field_ty>,
+        }
+    } else {
+        let reported_field_ty = quote! { <#field_ty as #krate::shadows::ShadowNode>::Reported };
+        quote! {
+            #(#filtered_attrs)*
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub #field_name: Option<#reported_field_ty>,
+        }
+    };
+
+    // --- apply_delta arm ---
+    let apply_delta_arm = if attrs.report_only {
+        None
+    } else if is_leaf {
+        Some(quote! {
+            if let Some(ref val) = delta.#field_name {
+                self.#field_name = val.clone();
+            }
+        })
+    } else {
+        Some(quote! {
+            if let Some(ref inner_delta) = delta.#field_name {
+                self.#field_name.apply_delta(inner_delta);
+            }
+        })
+    };
+
+    // --- into_partial_reported arm ---
+    let into_partial_reported_arm = if attrs.report_only {
+        quote! { #field_name: None, }
+    } else if is_leaf {
+        quote! {
+            #field_name: if delta.#field_name.is_some() {
+                Some(self.#field_name.clone())
+            } else {
+                None
+            },
+        }
+    } else {
+        quote! {
+            #field_name: if let Some(ref inner_delta) = delta.#field_name {
+                Some(self.#field_name.into_partial_reported(inner_delta))
+            } else {
+                None
+            },
+        }
+    };
+
+    // --- Schema hash code ---
+    let field_name_bytes = serde_name.as_bytes();
+    let schema_hash_code = if is_leaf {
+        let ty_name = quote!(#field_ty).to_string();
+        let ty_bytes = ty_name.as_bytes();
+        quote! {
+            h = #krate::shadows::fnv1a_bytes(h, &[#(#field_name_bytes),*]);
+            h = #krate::shadows::fnv1a_bytes(h, &[#(#ty_bytes),*]);
+        }
+    } else {
+        quote! {
+            h = #krate::shadows::fnv1a_bytes(h, &[#(#field_name_bytes),*]);
+            h = #krate::shadows::fnv1a_u64(h, <#field_ty as #krate::shadows::ShadowNode>::SCHEMA_HASH);
+        }
+    };
+
+    // --- MAX_VALUE_LEN item ---
+    let max_value_len_item = quote! {
+        <#field_ty as #krate::shadows::KVPersist>::MAX_VALUE_LEN
+    };
+
+    // --- reported serialize arm ---
+    let reported_serialize_arm = quote! {
+        if let Some(ref val) = self.#field_name {
+            map.serialize_entry(#serde_name, val)?;
+        }
+    };
+
+    // --- parse_delta ---
+    let (parse_delta_field_name, parse_delta_arm) = if attrs.report_only {
+        (None, None)
+    } else if is_leaf {
+        (
+            Some(serde_name.clone()),
+            Some(quote! {
+                if let Some(field_bytes) = scanner.field_bytes(#serde_name) {
+                    delta.#field_name = Some(
+                        ::serde_json_core::from_slice(field_bytes)
+                            .map(|(v, _)| v)
+                            .map_err(|_| #krate::shadows::ParseError::Deserialize)?
+                    );
+                }
+            }),
+        )
+    } else {
+        (
+            Some(serde_name.clone()),
+            Some(quote! {
+                if let Some(field_bytes) = scanner.field_bytes(#serde_name) {
+                    let mut nested_path: ::heapless::String<128> = ::heapless::String::new();
+                    let _ = nested_path.push_str(path);
+                    if !path.is_empty() {
+                        let _ = nested_path.push('/');
+                    }
+                    let _ = nested_path.push_str(#serde_name);
+                    delta.#field_name = Some(
+                        <#field_ty as #krate::shadows::ShadowNode>::parse_delta(
+                            field_bytes,
+                            &nested_path,
+                            resolver
+                        ).await?
+                    );
+                }
+            }),
+        )
+    };
+
+    // --- variant_at_path arm (only for nested fields) ---
+    let variant_at_path_arm = if is_leaf {
+        None
+    } else {
+        let field_prefix = format!("{}/", serde_name);
+        Some(quote! {
+            if path.starts_with(#field_prefix) {
+                let rest = &path[#field_prefix.len()..];
+                if let Some(v) = <#field_ty as #krate::shadows::ShadowNode>::variant_at_path(&self.#field_name, rest) {
+                    return Some(v);
+                }
+            } else if path == #serde_name {
+                if let Some(v) = <#field_ty as #krate::shadows::ShadowNode>::variant_at_path(&self.#field_name, "") {
+                    return Some(v);
+                }
+            }
+        })
+    };
+
+    // =======================================================================
+    // KVPersist codegen
+    // =======================================================================
+
+    // --- Migration arm ---
+    let migrate_from = attrs.migrate_from();
+    let migration_from_keys: Vec<String> = migrate_from.iter().cloned().collect();
+    let migration_arm = if migrate_from.is_empty() {
+        None
+    } else {
+        let from_keys: Vec<_> = migrate_from.iter().collect();
+        let convert_expr = if let Some(convert) = attrs.migrate_convert() {
+            quote! { Some(#convert) }
+        } else {
+            quote! { None }
+        };
+        Some(quote! {
+            #field_path => {
+                const SOURCES: &[#krate::shadows::MigrationSource] = &[
+                    #(#krate::shadows::MigrationSource {
+                        key: #from_keys,
+                        convert: #convert_expr,
+                    }),*
+                ];
+                SOURCES
+            }
+        })
+    };
+
+    // --- Default arm ---
+    let default_arm = attrs.default_value.as_ref().map(|default_val| {
+        let value_expr = match default_val {
+            DefaultValue::Literal(lit) => quote! { #lit },
+            DefaultValue::Function(path) => quote! { #path() },
+        };
+        quote! {
+            #field_path => {
+                self.#field_name = #value_expr;
+                true
+            }
+        }
+    });
+
+    let field_path_len = field_path.len();
+
+    // --- KV operations (leaf vs nested) ---
+    let (
+        max_key_len_item,
+        load_from_kv_arm,
+        load_from_kv_migration_arm,
+        persist_to_kv_arm,
+        persist_delta_arm,
+        collect_valid_keys_arm,
+        collect_valid_prefixes_arm,
+    ) = if is_leaf {
+        // Leaf field: direct KV operations
+        let max_key_len_item = quote! { #field_path_len };
+
+        let on_missing = quote! {
+            <Self as #krate::shadows::KVPersist>::apply_field_default(self, #field_path);
+            result.defaulted += 1;
+        };
+        let load_from_kv_arm =
+            kv_codegen::leaf_load(krate, &field_path, quote! { self.#field_name }, on_missing);
+
+        let migrate_from_vec = attrs.migrate_from();
+        let migrate_from_keys: Vec<_> = migrate_from_vec.iter().collect();
+        let migrate_convert = attrs.migrate_convert();
+        let migration_code = kv_codegen::migration_fallback(
+            krate,
+            &field_path,
+            quote! { self.#field_name },
+            &migrate_from_keys,
+            migrate_convert.as_ref(),
+        );
+        let load_from_kv_migration_arm = kv_codegen::leaf_load_with_migration(
+            krate,
+            &field_path,
+            quote! { self.#field_name },
+            migration_code,
+        );
+
+        let persist_to_kv_arm =
+            kv_codegen::leaf_persist(krate, &field_path, quote! { self.#field_name });
+
+        let persist_delta_arm = if attrs.report_only {
+            None
+        } else {
+            Some(kv_codegen::leaf_persist_delta(
+                krate,
+                &field_path,
+                field_name,
+            ))
+        };
+
+        let collect_valid_keys_arm = kv_codegen::leaf_collect_keys(&field_path);
+
+        (
+            max_key_len_item,
+            load_from_kv_arm,
+            load_from_kv_migration_arm,
+            persist_to_kv_arm,
+            persist_delta_arm,
+            collect_valid_keys_arm,
+            None, // leaf fields don't have prefixes
+        )
+    } else {
+        // Nested ShadowNode field: delegate
+        let max_key_len_item =
+            quote! { #field_path_len + <#field_ty as #krate::shadows::KVPersist>::MAX_KEY_LEN };
+
+        let load_from_kv_arm = kv_codegen::nested_load(
+            krate,
+            &field_path,
+            field_ty,
+            quote! { &mut self.#field_name },
+        );
+
+        let load_from_kv_migration_arm = kv_codegen::nested_load_with_migration(
+            krate,
+            &field_path,
+            field_ty,
+            quote! { &mut self.#field_name },
+        );
+
+        let persist_to_kv_arm =
+            kv_codegen::nested_persist(krate, &field_path, field_ty, quote! { &self.#field_name });
+
+        let persist_delta_arm = if attrs.report_only {
+            None
+        } else {
+            Some(kv_codegen::nested_persist_delta(
+                krate,
+                &field_path,
+                field_ty,
+                field_name,
+            ))
+        };
+
+        let collect_valid_keys_arm = kv_codegen::nested_collect_keys(krate, &field_path, field_ty);
+
+        let collect_valid_prefixes_arm = Some(kv_codegen::nested_collect_prefixes(
+            krate,
+            &field_path,
+            field_ty,
+        ));
+
+        (
+            max_key_len_item,
+            load_from_kv_arm,
+            load_from_kv_migration_arm,
+            persist_to_kv_arm,
+            persist_delta_arm,
+            collect_valid_keys_arm,
+            collect_valid_prefixes_arm,
+        )
+    };
+
+    // --- Opaque field type ---
+    let opaque_field_type = if attrs.opaque {
+        Some(field_ty.clone())
+    } else {
+        None
+    };
+
+    FieldCodegen {
+        serde_name,
+        delta_field,
+        reported_field,
+        apply_delta_arm,
+        into_partial_reported_arm,
+        schema_hash_code,
+        reported_serialize_arm,
+        variant_at_path_arm,
+        parse_delta_field_name,
+        parse_delta_arm,
+        migration_arm,
+        default_arm,
+        max_value_len_item,
+        max_key_len_item,
+        load_from_kv_arm,
+        load_from_kv_migration_arm,
+        persist_to_kv_arm,
+        persist_delta_arm,
+        collect_valid_keys_arm,
+        collect_valid_prefixes_arm,
+        migration_from_keys,
+        opaque_field_type,
+    }
+}
 
 /// Generate code for a struct type
 pub(crate) fn generate_struct_code(
@@ -15,7 +492,7 @@ pub(crate) fn generate_struct_code(
     delta_name: &Ident,
     reported_name: &Ident,
     krate: &TokenStream,
-) -> syn::Result<(TokenStream, TokenStream, TokenStream, TokenStream)> {
+) -> syn::Result<CodegenOutput> {
     let name = &input.ident;
     let vis = &input.vis;
 
@@ -34,391 +511,109 @@ pub(crate) fn generate_struct_code(
         }
     };
 
-    // Collect field info
-    let mut delta_fields = Vec::new();
-    let mut reported_fields = Vec::new();
-    let mut field_names = Vec::new();
-    let mut apply_delta_arms = Vec::new();
-    let mut into_partial_reported_arms = Vec::new();
-    let mut schema_hash_code = Vec::new();
-    let mut reported_serialize_arms = Vec::new();
-    let mut opaque_field_types: Vec<syn::Type> = Vec::new();
+    // Process all fields and collect their codegen output
+    let field_codegens: Vec<FieldCodegen> = named_fields
+        .iter()
+        .map(|field| process_field(field, krate))
+        .collect();
 
-    // For parse_delta: collect field parsing info
-    let mut parse_delta_field_names: Vec<String> = Vec::new();
-    let mut parse_delta_arms: Vec<TokenStream> = Vec::new();
+    // Extract vectors from FieldCodegen structs
+    let field_names: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.serde_name.clone())
+        .collect();
+    let delta_fields: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.delta_field.clone())
+        .collect();
+    let reported_fields: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.reported_field.clone())
+        .collect();
+    let apply_delta_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.apply_delta_arm.clone())
+        .collect();
+    let into_partial_reported_arms: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.into_partial_reported_arm.clone())
+        .collect();
+    let schema_hash_code: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.schema_hash_code.clone())
+        .collect();
+    let reported_serialize_arms: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.reported_serialize_arm.clone())
+        .collect();
+    let variant_at_path_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.variant_at_path_arm.clone())
+        .collect();
+    let parse_delta_field_names: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.parse_delta_field_name.clone())
+        .collect();
+    let parse_delta_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.parse_delta_arm.clone())
+        .collect();
 
-    // KVPersist-specific codegen (feature-gated)
-    let mut migration_arms = Vec::new();
-    let mut default_arms = Vec::new();
-    let mut max_value_len_items = Vec::new();
-    let mut load_from_kv_arms = Vec::new();
-    let mut load_from_kv_migration_arms = Vec::new();
-    let mut persist_to_kv_arms = Vec::new();
-    let mut persist_delta_arms = Vec::new();
-    let mut collect_valid_keys_arms = Vec::new();
-    let mut collect_valid_prefixes_arms = Vec::new();
-    let mut max_key_len_items = Vec::new();
-
-    for field in named_fields {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_ty = &field.ty;
-        let attrs = FieldAttrs::from_attrs(&field.attrs);
-
-        // Get serde rename if present
-        let serde_name = get_serde_rename(&field.attrs).unwrap_or_else(|| field_name.to_string());
-        let field_path = format!("/{}", serde_name);
-
-        field_names.push(serde_name.clone());
-
-        // Check if this is a leaf type for KV operations.
-        let has_migration = !attrs.migrate_from().is_empty();
-        let is_leaf = attrs.opaque || has_migration;
-
-        // Collect opaque field types for where clause
-        if attrs.opaque {
-            opaque_field_types.push(field_ty.clone());
-        }
-
-        // Delta field (unless report_only)
-        if !attrs.report_only {
-            let field_attrs = &field.attrs;
-            let filtered_attrs: Vec<_> = field_attrs
-                .iter()
-                .filter(|a| !a.path().is_ident("shadow_attr"))
-                .collect();
-
-            if is_leaf {
-                delta_fields.push(quote! {
-                    #(#filtered_attrs)*
-                    #[serde(skip_serializing_if = "Option::is_none")]
-                    pub #field_name: Option<#field_ty>,
-                });
-            } else {
-                let delta_field_ty = quote! { <#field_ty as #krate::shadows::ShadowNode>::Delta };
-                delta_fields.push(quote! {
-                    #(#filtered_attrs)*
-                    #[serde(skip_serializing_if = "Option::is_none")]
-                    pub #field_name: Option<#delta_field_ty>,
-                });
-            }
-        }
-
-        // Reported field (all fields)
-        {
-            let field_attrs = &field.attrs;
-            let filtered_attrs: Vec<_> = field_attrs
-                .iter()
-                .filter(|a| !a.path().is_ident("shadow_attr"))
-                .collect();
-
-            if is_leaf {
-                reported_fields.push(quote! {
-                    #(#filtered_attrs)*
-                    #[serde(skip_serializing_if = "Option::is_none")]
-                    pub #field_name: Option<#field_ty>,
-                });
-            } else {
-                let reported_field_ty =
-                    quote! { <#field_ty as #krate::shadows::ShadowNode>::Reported };
-                reported_fields.push(quote! {
-                    #(#filtered_attrs)*
-                    #[serde(skip_serializing_if = "Option::is_none")]
-                    pub #field_name: Option<#reported_field_ty>,
-                });
-            }
-        }
-
-        // Apply delta (non-report_only fields)
-        if !attrs.report_only {
-            if is_leaf {
-                apply_delta_arms.push(quote! {
-                    if let Some(ref val) = delta.#field_name {
-                        self.#field_name = val.clone();
-                    }
-                });
-            } else {
-                // Nested ShadowNode - delegate
-                apply_delta_arms.push(quote! {
-                    if let Some(ref inner_delta) = delta.#field_name {
-                        self.#field_name.apply_delta(inner_delta);
-                    }
-                });
-            }
-        }
-
-        // Into partial reported - only include fields present in delta
-        if attrs.report_only {
-            // Report-only fields are never in delta, so always None in partial
-            into_partial_reported_arms.push(quote! {
-                #field_name: None,
-            });
-        } else if is_leaf {
-            into_partial_reported_arms.push(quote! {
-                #field_name: if delta.#field_name.is_some() {
-                    Some(self.#field_name.clone())
-                } else {
-                    None
-                },
-            });
-        } else {
-            into_partial_reported_arms.push(quote! {
-                #field_name: if let Some(ref inner_delta) = delta.#field_name {
-                    Some(self.#field_name.into_partial_reported(inner_delta))
-                } else {
-                    None
-                },
-            });
-        }
-
-        // Schema hash
-        let field_name_bytes = serde_name.as_bytes();
-        if is_leaf {
-            let ty_name = quote!(#field_ty).to_string();
-            let ty_bytes = ty_name.as_bytes();
-            schema_hash_code.push(quote! {
-                h = #krate::shadows::fnv1a_bytes(h, &[#(#field_name_bytes),*]);
-                h = #krate::shadows::fnv1a_bytes(h, &[#(#ty_bytes),*]);
-            });
-
-            // MAX_VALUE_LEN for leaf types (KVPersist)
-            max_value_len_items.push(quote! {
-                <#field_ty as #krate::shadows::KVPersist>::MAX_VALUE_LEN
-            });
-        } else {
-            schema_hash_code.push(quote! {
-                h = #krate::shadows::fnv1a_bytes(h, &[#(#field_name_bytes),*]);
-                h = #krate::shadows::fnv1a_u64(h, <#field_ty as #krate::shadows::ShadowNode>::SCHEMA_HASH);
-            });
-
-            // MAX_VALUE_LEN for nested types (KVPersist)
-            max_value_len_items.push(quote! {
-                <#field_ty as #krate::shadows::KVPersist>::MAX_VALUE_LEN
-            });
-        }
-
-        // ReportedUnionFields serialize_into_map
-        reported_serialize_arms.push(quote! {
-            if let Some(ref val) = self.#field_name {
-                map.serialize_entry(#serde_name, val)?;
-            }
-        });
-
-        // parse_delta field parsing (for non-report_only fields)
-        if !attrs.report_only {
-            parse_delta_field_names.push(serde_name.clone());
-
-            if is_leaf {
-                // Leaf field: use serde directly
-                parse_delta_arms.push(quote! {
-                    if let Some(field_bytes) = scanner.field_bytes(#serde_name) {
-                        delta.#field_name = Some(
-                            ::serde_json_core::from_slice(field_bytes)
-                                .map(|(v, _)| v)
-                                .map_err(|_| #krate::shadows::ParseError::Deserialize)?
-                        );
-                    }
-                });
-            } else {
-                // Nested ShadowNode: delegate to parse_delta
-                parse_delta_arms.push(quote! {
-                    if let Some(field_bytes) = scanner.field_bytes(#serde_name) {
-                        let mut nested_path: ::heapless::String<128> = ::heapless::String::new();
-                        let _ = nested_path.push_str(path);
-                        if !path.is_empty() {
-                            let _ = nested_path.push('/');
-                        }
-                        let _ = nested_path.push_str(#serde_name);
-                        delta.#field_name = Some(
-                            <#field_ty as #krate::shadows::ShadowNode>::parse_delta(
-                                field_bytes,
-                                &nested_path,
-                                resolver
-                            ).await?
-                        );
-                    }
-                });
-            }
-        }
-
-        // =====================================================================
-        // KVPersist-specific codegen
-        // =====================================================================
-
-        // Migration sources
-        let migrate_from = attrs.migrate_from();
-        if !migrate_from.is_empty() {
-            let from_keys: Vec<_> = migrate_from.iter().collect();
-            let convert_expr = if let Some(convert) = attrs.migrate_convert() {
-                quote! { Some(#convert) }
-            } else {
-                quote! { None }
-            };
-
-            migration_arms.push(quote! {
-                #field_path => {
-                    const SOURCES: &[#krate::shadows::MigrationSource] = &[
-                        #(#krate::shadows::MigrationSource {
-                            key: #from_keys,
-                            convert: #convert_expr,
-                        }),*
-                    ];
-                    SOURCES
-                }
-            });
-        }
-
-        // Custom defaults
-        if let Some(ref default_val) = attrs.default_value {
-            let value_expr = match default_val {
-                DefaultValue::Literal(lit) => quote! { #lit },
-                DefaultValue::Function(path) => quote! { #path() },
-            };
-            default_arms.push(quote! {
-                #field_path => {
-                    self.#field_name = #value_expr;
-                    true
-                }
-            });
-        }
-
-        let field_path_len = field_path.len(); // "/field_name".len()
-
-        if is_leaf {
-            // Leaf field: direct KV operations
-
-            // MAX_KEY_LEN: just the field name length
-            max_key_len_items.push(quote! { #field_path_len });
-
-            // load_from_kv
-            let on_missing = quote! {
-                <Self as #krate::shadows::KVPersist>::apply_field_default(self, #field_path);
-                result.defaulted += 1;
-            };
-            load_from_kv_arms.push(kv_codegen::leaf_load(
-                krate,
-                &field_path,
-                quote! { self.#field_name },
-                on_missing,
-            ));
-
-            // load_from_kv_with_migration
-            let migrate_from_vec = attrs.migrate_from();
-            let migrate_from_keys: Vec<_> = migrate_from_vec.iter().collect();
-            let migrate_convert = attrs.migrate_convert();
-            let migration_code = kv_codegen::migration_fallback(
-                krate,
-                &field_path,
-                quote! { self.#field_name },
-                &migrate_from_keys,
-                migrate_convert.as_ref(),
-            );
-            load_from_kv_migration_arms.push(kv_codegen::leaf_load_with_migration(
-                krate,
-                &field_path,
-                quote! { self.#field_name },
-                migration_code,
-            ));
-
-            // persist_to_kv
-            persist_to_kv_arms.push(kv_codegen::leaf_persist(
-                krate,
-                &field_path,
-                quote! { self.#field_name },
-            ));
-
-            // persist_delta (for non-report_only fields)
-            if !attrs.report_only {
-                persist_delta_arms.push(kv_codegen::leaf_persist_delta(
-                    krate,
-                    &field_path,
-                    field_name,
-                ));
-            }
-
-            // collect_valid_keys
-            collect_valid_keys_arms.push(kv_codegen::leaf_collect_keys(&field_path));
-        } else {
-            // Nested ShadowNode field: delegate
-
-            // MAX_KEY_LEN: "/field_name".len() + nested MAX_KEY_LEN
-            max_key_len_items.push(
-                quote! { #field_path_len + <#field_ty as #krate::shadows::KVPersist>::MAX_KEY_LEN },
-            );
-
-            // load_from_kv
-            load_from_kv_arms.push(kv_codegen::nested_load(
-                krate,
-                &field_path,
-                field_ty,
-                quote! { &mut self.#field_name },
-            ));
-
-            // load_from_kv_with_migration
-            load_from_kv_migration_arms.push(kv_codegen::nested_load_with_migration(
-                krate,
-                &field_path,
-                field_ty,
-                quote! { &mut self.#field_name },
-            ));
-
-            // persist_to_kv
-            persist_to_kv_arms.push(kv_codegen::nested_persist(
-                krate,
-                &field_path,
-                field_ty,
-                quote! { &self.#field_name },
-            ));
-
-            // persist_delta (for non-report_only fields)
-            if !attrs.report_only {
-                persist_delta_arms.push(kv_codegen::nested_persist_delta(
-                    krate,
-                    &field_path,
-                    field_ty,
-                    field_name,
-                ));
-            }
-
-            // collect_valid_keys
-            collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(
-                krate,
-                &field_path,
-                field_ty,
-            ));
-
-            // collect_valid_prefixes
-            collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(
-                krate,
-                &field_path,
-                field_ty,
-            ));
-        }
-    }
+    // KVPersist collections
+    let migration_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.migration_arm.clone())
+        .collect();
+    let default_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.default_arm.clone())
+        .collect();
+    let max_value_len_items: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.max_value_len_item.clone())
+        .collect();
+    let max_key_len_items: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.max_key_len_item.clone())
+        .collect();
+    let load_from_kv_arms: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.load_from_kv_arm.clone())
+        .collect();
+    let load_from_kv_migration_arms: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.load_from_kv_migration_arm.clone())
+        .collect();
+    let persist_to_kv_arms: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.persist_to_kv_arm.clone())
+        .collect();
+    let persist_delta_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.persist_delta_arm.clone())
+        .collect();
+    let collect_valid_keys_arms: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.collect_valid_keys_arm.clone())
+        .collect();
+    let collect_valid_prefixes_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.collect_valid_prefixes_arm.clone())
+        .collect();
+    let all_migration_from_keys: Vec<_> = field_codegens
+        .iter()
+        .flat_map(|f| f.migration_from_keys.clone())
+        .collect();
+    let opaque_field_types: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.opaque_field_type.clone())
+        .collect();
 
     // Build max_value_len const expression
     let max_value_len_expr = build_const_max_expr(max_value_len_items, quote! { 0 });
 
     // Build MAX_KEY_LEN const expression (max of field paths)
     let max_key_len_expr = build_const_max_expr(max_key_len_items, quote! { 0 });
-
-    // Build SCHEMA_HASH const
-    let schema_hash_const = quote! {
-        {
-            let mut h = #krate::shadows::FNV1A_INIT;
-            #(#schema_hash_code)*
-            h
-        }
-    };
-
-    // Collect all migration source keys for all_migration_keys()
-    let mut all_migration_from_keys = Vec::new();
-    for field in named_fields {
-        let attrs = FieldAttrs::from_attrs(&field.attrs);
-        for from_key in &attrs.migrate_from() {
-            all_migration_from_keys.push(from_key.clone());
-        }
-    }
 
     // Generate Delta type - always use FieldScanner, no Deserialize needed
     let delta_type = quote! {
@@ -450,6 +645,15 @@ pub(crate) fn generate_struct_code(
         _ => false
     };
 
+    // Build SCHEMA_HASH const
+    let schema_hash_const = quote! {
+        {
+            let mut h = #krate::shadows::FNV1A_INIT;
+            #(#schema_hash_code)*
+            h
+        }
+    };
+
     // Generate where clause for opaque field types (KVPersist bound, feature-gated)
     let kv_where_clause = if opaque_field_types.is_empty() {
         quote! {}
@@ -459,34 +663,6 @@ pub(crate) fn generate_struct_code(
         });
         quote! { where #(#bounds),* }
     };
-
-    // Build variant_at_path delegation for nested ShadowNode fields
-    let mut variant_at_path_arms = Vec::new();
-    for field in named_fields {
-        let field_name = field.ident.as_ref().unwrap();
-        let field_ty = &field.ty;
-        let attrs = FieldAttrs::from_attrs(&field.attrs);
-        let has_migration = !attrs.migrate_from().is_empty();
-        let is_leaf = attrs.opaque || has_migration;
-
-        if !is_leaf {
-            let serde_name =
-                get_serde_rename(&field.attrs).unwrap_or_else(|| field_name.to_string());
-            let field_prefix = format!("{}/", serde_name);
-            variant_at_path_arms.push(quote! {
-                if path.starts_with(#field_prefix) {
-                    let rest = &path[#field_prefix.len()..];
-                    if let Some(v) = <#field_ty as #krate::shadows::ShadowNode>::variant_at_path(&self.#field_name, rest) {
-                        return Some(v);
-                    }
-                } else if path == #serde_name {
-                    if let Some(v) = <#field_ty as #krate::shadows::ShadowNode>::variant_at_path(&self.#field_name, "") {
-                        return Some(v);
-                    }
-                }
-            });
-        }
-    }
 
     // Generate parse_delta body - always use FieldScanner
     let field_name_strs: Vec<_> = parse_delta_field_names.iter().map(|s| s.as_str()).collect();
@@ -629,10 +805,10 @@ pub(crate) fn generate_struct_code(
         }
     };
 
-    Ok((
+    Ok(CodegenOutput {
         delta_type,
         reported_type,
         shadow_node_impl,
         reported_union_fields_impl,
-    ))
+    })
 }

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -326,7 +326,11 @@ pub(crate) fn generate_struct_code(
 
             // persist_delta (for non-report_only fields)
             if !attrs.report_only {
-                persist_delta_arms.push(kv_codegen::leaf_persist_delta(krate, &field_path, field_name));
+                persist_delta_arms.push(kv_codegen::leaf_persist_delta(
+                    krate,
+                    &field_path,
+                    field_name,
+                ));
             }
 
             // collect_valid_keys
@@ -374,10 +378,18 @@ pub(crate) fn generate_struct_code(
             }
 
             // collect_valid_keys
-            collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(krate, &field_path, field_ty));
+            collect_valid_keys_arms.push(kv_codegen::nested_collect_keys(
+                krate,
+                &field_path,
+                field_ty,
+            ));
 
             // collect_valid_prefixes
-            collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(krate, &field_path, field_ty));
+            collect_valid_prefixes_arms.push(kv_codegen::nested_collect_prefixes(
+                krate,
+                &field_path,
+                field_ty,
+            ));
         }
     }
 
@@ -455,7 +467,8 @@ pub(crate) fn generate_struct_code(
         let is_leaf = attrs.opaque || has_migration;
 
         if !is_leaf {
-            let serde_name = get_serde_rename(&field.attrs).unwrap_or_else(|| field_name.to_string());
+            let serde_name =
+                get_serde_rename(&field.attrs).unwrap_or_else(|| field_name.to_string());
             let field_prefix = format!("{}/", serde_name);
             variant_at_path_arms.push(quote! {
                 if path.starts_with(#field_prefix) {

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -240,7 +240,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
             Some(serde_name.clone()),
             Some(quote! {
                 if let Some(field_bytes) = scanner.field_bytes(#serde_name) {
-                    let mut nested_path: ::heapless::String<128> = ::heapless::String::new();
+                    let mut nested_path: ::heapless::String<64> = ::heapless::String::new();
                     let _ = nested_path.push_str(path);
                     if !path.is_empty() {
                         let _ = nested_path.push('/');

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -273,8 +273,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
     } else {
         let field_prefix = format!("{}/", serde_name);
         Some(quote! {
-            if path.starts_with(#field_prefix) {
-                let rest = &path[#field_prefix.len()..];
+            if let Some(rest) = path.strip_prefix(#field_prefix) {
                 if let Some(v) = <#field_ty as #krate::shadows::ShadowNode>::variant_at_path(&self.#field_name, rest) {
                     return Some(v);
                 }

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -228,7 +228,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
             Some(quote! {
                 if let Some(field_bytes) = scanner.field_bytes(#serde_name) {
                     delta.#field_name = Some(
-                        ::serde_json_core::from_slice(field_bytes)
+                        #krate::__macro_support::serde_json_core::from_slice(field_bytes)
                             .map(|(v, _)| v)
                             .map_err(|_| #krate::shadows::ParseError::Deserialize)?
                     );
@@ -240,7 +240,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
             Some(serde_name.clone()),
             Some(quote! {
                 if let Some(field_bytes) = scanner.field_bytes(#serde_name) {
-                    let mut nested_path: ::heapless::String<64> = ::heapless::String::new();
+                    let mut nested_path: #krate::__macro_support::heapless::String<64> = #krate::__macro_support::heapless::String::new();
                     let _ = nested_path.push_str(path);
                     if !path.is_empty() {
                         let _ = nested_path.push('/');
@@ -445,7 +445,7 @@ pub(crate) fn generate_struct_code(
                 #(#apply_delta_arms)*
             }
 
-            fn variant_at_path(&self, path: &str) -> Option<::heapless::String<32>> {
+            fn variant_at_path(&self, path: &str) -> Option<#krate::__macro_support::heapless::String<32>> {
                 #(#variant_at_path_arms)*
                 None
             }
@@ -503,7 +503,7 @@ pub(crate) fn generate_struct_code(
                 } else {
                     // No explicit size - require MaxSize trait
                     max_value_len_items.push(quote! {
-                        <#field_ty as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE
+                        <#field_ty as #krate::__macro_support::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE
                     });
                 }
             }
@@ -599,7 +599,7 @@ pub(crate) fn generate_struct_code(
                     field_name,
                 ));
 
-                collect_valid_keys_arms.push(kv_codegen::leaf_collect_keys(&field_path));
+                collect_valid_keys_arms.push(kv_codegen::leaf_collect_keys(krate, &field_path));
             } else {
                 max_key_len_items.push(
                     quote! { #field_path_len + <#field_ty as #krate::shadows::KVPersist>::MAX_KEY_LEN },
@@ -659,7 +659,7 @@ pub(crate) fn generate_struct_code(
             quote! {}
         } else {
             let bounds = opaque_field_types.iter().map(|ty| {
-                quote! { #ty: ::postcard::experimental::max_size::MaxSize }
+                quote! { #ty: #krate::__macro_support::postcard::experimental::max_size::MaxSize }
             });
             quote! { where #(#bounds),* }
         };

--- a/rustot_derive/src/lib.rs
+++ b/rustot_derive/src/lib.rs
@@ -7,7 +7,7 @@ use quote::quote;
 use syn::DeriveInput;
 
 use attr::{ShadowNodeParams, ShadowRootParams};
-use codegen::{generate_shadow_node, ShadowNodeConfig};
+use codegen::generate_shadow_node;
 
 // =============================================================================
 // KV-based shadow macros (Phase 8)
@@ -118,15 +118,8 @@ fn shadow_root_impl(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
     // Strip shadow_attr from the original definition
     let original = strip_shadow_attrs(&derive_input);
 
-    // Generate shadow node code
-    let config = ShadowNodeConfig {
-        is_root: true,
-        name: params.name,
-        topic_prefix: params.topic_prefix,
-        max_payload_len: params.max_payload_len,
-    };
-
-    let shadow_code = generate_shadow_node(&derive_input, &config)?;
+    // Generate shadow node code (with ShadowRoot impl)
+    let shadow_code = generate_shadow_node(&derive_input, Some(&params))?;
 
     Ok(quote! {
         #original
@@ -148,15 +141,8 @@ fn shadow_node_impl(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
     // Strip shadow_attr from the original definition
     let original = strip_shadow_attrs(&derive_input);
 
-    // Generate shadow node code
-    let config = ShadowNodeConfig {
-        is_root: false,
-        name: None,
-        topic_prefix: None,
-        max_payload_len: None,
-    };
-
-    let shadow_code = generate_shadow_node(&derive_input, &config)?;
+    // Generate shadow node code (without ShadowRoot impl)
+    let shadow_code = generate_shadow_node(&derive_input, None)?;
 
     Ok(quote! {
         #original

--- a/src/defender_metrics/mod.rs
+++ b/src/defender_metrics/mod.rs
@@ -6,7 +6,7 @@ use errors::{ErrorResponse, MetricError};
 #[cfg(feature = "metric_cbor")]
 use serde::Deserialize;
 use serde::Serialize;
-use topics::Topic;
+use topics::{Topic, MAX_DEFENDER_TOPIC_LEN};
 
 pub mod aws_types;
 pub mod data_types;
@@ -105,8 +105,8 @@ impl<'m, C: MqttClient> MetricHandler<'m, C> {
         &self,
         payload: impl ToPayload,
     ) -> Result<C::Subscription<'_, 2>, MetricError> {
-        let accepted = Topic::Accepted.format::<64>(self.mqtt.client_id())?;
-        let rejected = Topic::Rejected.format::<64>(self.mqtt.client_id())?;
+        let accepted = Topic::Accepted.format::<MAX_DEFENDER_TOPIC_LEN>(self.mqtt.client_id())?;
+        let rejected = Topic::Rejected.format::<MAX_DEFENDER_TOPIC_LEN>(self.mqtt.client_id())?;
 
         let sub = self
             .mqtt
@@ -117,7 +117,7 @@ impl<'m, C: MqttClient> MetricHandler<'m, C> {
             .await
             .map_err(|_| MetricError::Mqtt)?;
 
-        let topic_name = Topic::Publish.format::<64>(self.mqtt.client_id())?;
+        let topic_name = Topic::Publish.format::<MAX_DEFENDER_TOPIC_LEN>(self.mqtt.client_id())?;
 
         self.mqtt
             .publish(topic_name.as_str(), payload)

--- a/src/defender_metrics/mod.rs
+++ b/src/defender_metrics/mod.rs
@@ -158,6 +158,7 @@ mod tests {
             );
         }
     }
+    #[cfg(feature = "metric_cbor")]
     #[test]
     fn serialize_version_cbor() {
         let test_cases: [(Version, [u8; 8]); 4] = [
@@ -189,6 +190,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "metric_cbor")]
     #[test]
     fn custom_serialization_cbor() {
         #[derive(Debug)]

--- a/src/defender_metrics/topics.rs
+++ b/src/defender_metrics/topics.rs
@@ -60,6 +60,7 @@ impl Topic {
         Ok(topic_path)
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Topic> {
         let tt = s.splitn(7, '/').collect::<heapless::Vec<&str, 7>>();
         match (tt.first(), tt.get(1), tt.get(3), tt.get(4)) {

--- a/src/defender_metrics/topics.rs
+++ b/src/defender_metrics/topics.rs
@@ -4,6 +4,13 @@ use core::fmt::Write;
 use heapless::String;
 
 use super::errors::MetricError;
+use crate::jobs::MAX_THING_NAME_LEN;
+
+/// Maximum topic length for defender metrics MQTT operations.
+///
+/// Longest topic: `$aws/things/{thing_name}/defender/metrics/json/rejected`
+pub const MAX_DEFENDER_TOPIC_LEN: usize =
+    "$aws/things/".len() + MAX_THING_NAME_LEN + "/defender/metrics/json/rejected".len();
 
 pub enum PayloadFormat {
     #[cfg(feature = "metric_cbor")]

--- a/src/jobs/subscribe.rs
+++ b/src/jobs/subscribe.rs
@@ -16,6 +16,7 @@ pub enum Topic<'a> {
 }
 
 impl<'a> Topic<'a> {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &'a str) -> Option<Self> {
         let tt = s.splitn(8, '/').collect::<heapless::Vec<&str, 8>>();
         Some(match (tt.first(), tt.get(1), tt.get(2), tt.get(3)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,11 @@ pub mod mqtt;
 pub mod ota;
 pub mod provisioning;
 pub mod shadows;
+
+/// Re-exports for derive macro generated code. Not part of the public API.
+#[doc(hidden)]
+pub mod __macro_support {
+    pub use heapless;
+    pub use postcard;
+    pub use serde_json_core;
+}

--- a/src/mqtt/greengrass.rs
+++ b/src/mqtt/greengrass.rs
@@ -60,10 +60,8 @@ impl crate::mqtt::MqttClient for GreengrassClient {
         &self.client_id
     }
 
-    fn wait_connected(&self) -> impl core::future::Future<Output = ()> {
-        async {
-            // Greengrass IPC is already connected when client is created
-        }
+    async fn wait_connected(&self) {
+        // Greengrass IPC is already connected when client is created
     }
 
     fn publish_with_options<P: ToPayload>(
@@ -136,19 +134,15 @@ impl MqttSubscription for GreengrassSubscription {
         Self: 'm;
     type Error = greengrass_ipc_rust::Error;
 
-    fn next_message(&mut self) -> impl core::future::Future<Output = Option<Self::Message<'_>>> {
-        async {
-            self.merged.next().await.map(|iot_msg| GreengrassMessage {
-                inner: iot_msg.message,
-            })
-        }
+    async fn next_message(&mut self) -> Option<Self::Message<'_>> {
+        self.merged.next().await.map(|iot_msg| GreengrassMessage {
+            inner: iot_msg.message,
+        })
     }
 
-    fn unsubscribe(self) -> impl core::future::Future<Output = Result<(), Self::Error>> {
-        async move {
-            drop(self.merged);
-            Ok(())
-        }
+    async fn unsubscribe(self) -> Result<(), Self::Error> {
+        drop(self.merged);
+        Ok(())
     }
 }
 

--- a/src/ota/data_interface/mqtt.rs
+++ b/src/ota/data_interface/mqtt.rs
@@ -53,6 +53,7 @@ pub enum Topic<'a> {
 }
 
 impl<'a> Topic<'a> {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &'a str) -> Option<Self> {
         let tt = s.splitn(8, '/').collect::<heapless::Vec<&str, 8>>();
         Some(match (tt.first(), tt.get(1), tt.get(2), tt.get(3)) {

--- a/src/ota/encoding/cbor.rs
+++ b/src/ota/encoding/cbor.rs
@@ -72,6 +72,7 @@ pub struct StreamError<'a> {
     pub client_token: Option<&'a str>,
 }
 
+#[allow(clippy::result_unit_err)]
 pub fn to_slice<T>(value: &T, slice: &mut [u8]) -> Result<usize, ()>
 where
     T: serde::ser::Serialize,

--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -42,7 +42,7 @@ impl Updater {
         control.request_job()
     }
 
-    pub async fn perform_ota<'a, 'b, C: ControlInterface, D: DataInterface, P: pal::OtaPal>(
+    pub async fn perform_ota<C: ControlInterface, D: DataInterface, P: pal::OtaPal>(
         control: &C,
         data: &D,
         file_ctx: FileContext,
@@ -291,7 +291,7 @@ impl Updater {
         }
     }
 
-    async fn ingest_data_block<'a, D: DataInterface, E: StatusDetailsExt>(
+    async fn ingest_data_block<D: DataInterface, E: StatusDetailsExt>(
         data: &D,
         block_writer: &mut impl NorFlash,
         config: &config::Config,

--- a/src/provisioning/error.rs
+++ b/src/provisioning/error.rs
@@ -1,6 +1,5 @@
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-
 pub enum Error {
     Overflow,
     InvalidPayload,

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -115,8 +115,8 @@ impl FleetProvisioner {
         )
     }
 
-    async fn provision_inner<'m, Cfg, M: MqttClient>(
-        mqtt: &'m M,
+    async fn provision_inner<Cfg, M: MqttClient>(
+        mqtt: &M,
         template_name: &str,
         parameters: Option<impl Serialize>,
         csr: Option<&str>,

--- a/src/provisioning/topics.rs
+++ b/src/provisioning/topics.rs
@@ -94,6 +94,7 @@ impl<'a> Topic<'a> {
         s.starts_with(Self::CERT_PREFIX) || s.starts_with(Self::PROVISIONING_PREFIX)
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &'a str) -> Option<Self> {
         let tt = s.splitn(6, '/').collect::<heapless::Vec<&str, 6>>();
         match (tt.first(), tt.get(1)) {

--- a/src/shadows/data_types.rs
+++ b/src/shadows/data_types.rs
@@ -153,9 +153,8 @@ impl<'a, D> AcceptedResponse<'a, D, D> {
         S: ShadowNode<Delta = D>,
         Res: VariantResolver,
     {
-        let scanner =
-            FieldScanner::scan(json, &["state", "timestamp", "version", "clientToken"])
-                .map_err(ParseError::Scan)?;
+        let scanner = FieldScanner::scan(json, &["state", "timestamp", "version", "clientToken"])
+            .map_err(ParseError::Scan)?;
 
         // Parse timestamp (default to 0 if missing)
         let timestamp = scanner
@@ -224,9 +223,8 @@ impl<'a, U> DeltaResponse<'a, U> {
         S: ShadowNode<Delta = U>,
         R: VariantResolver,
     {
-        let scanner =
-            FieldScanner::scan(json, &["state", "timestamp", "version", "clientToken"])
-                .map_err(ParseError::Scan)?;
+        let scanner = FieldScanner::scan(json, &["state", "timestamp", "version", "clientToken"])
+            .map_err(ParseError::Scan)?;
 
         // Parse timestamp (default to 0 if missing)
         let timestamp = scanner

--- a/src/shadows/data_types.rs
+++ b/src/shadows/data_types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use super::{tag_scanner::FieldScanner, ParseError, ShadowNode, VariantResolver};
+
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Patch<T> {
@@ -34,13 +36,56 @@ pub struct RequestState<D, R> {
     pub reported: Option<R>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct DeltaState<D, R> {
     pub desired: Option<D>,
 
     pub reported: Option<R>,
 
     pub delta: Option<D>,
+}
+
+impl<D> DeltaState<D, D> {
+    /// Parse a delta state using `FieldScanner` and `parse_delta`.
+    ///
+    /// This method handles adjacently-tagged enums properly by using
+    /// the resolver for variant fallback when the tag is missing.
+    ///
+    /// Note: This method is only available when `desired`, `reported`, and `delta`
+    /// all use the same delta type (which is the common case for shadow responses).
+    pub async fn parse<S, Res>(json: &[u8], resolver: &Res) -> Result<Self, ParseError>
+    where
+        S: ShadowNode<Delta = D>,
+        Res: VariantResolver,
+    {
+        let scanner = FieldScanner::scan(json, &["desired", "reported", "delta"])
+            .map_err(ParseError::Scan)?;
+
+        // Parse each field using parse_delta
+        let desired = if let Some(bytes) = scanner.field_bytes("desired") {
+            Some(S::parse_delta(bytes, "", resolver).await?)
+        } else {
+            None
+        };
+
+        let reported = if let Some(bytes) = scanner.field_bytes("reported") {
+            Some(S::parse_delta(bytes, "", resolver).await?)
+        } else {
+            None
+        };
+
+        let delta = if let Some(bytes) = scanner.field_bytes("delta") {
+            Some(S::parse_delta(bytes, "", resolver).await?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            desired,
+            reported,
+            delta,
+        })
+    }
 }
 
 /// A request state document has the following format:
@@ -87,18 +132,66 @@ pub struct Request<'a, D, R> {
 /// - **version** — The current version of the document for the device's shadow
 ///   shared in AWS IoT. It is increased by one over the previous version of the
 ///   document.
-#[derive(Deserialize)]
 pub struct AcceptedResponse<'a, D, R> {
     pub state: DeltaState<D, R>,
     // pub metadata: Metadata<>.
     pub timestamp: u64,
-
-    #[serde(rename = "clientToken")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_token: Option<&'a str>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<i64>,
+}
+
+impl<'a, D> AcceptedResponse<'a, D, D> {
+    /// Parse an accepted response using `FieldScanner` and `parse_delta`.
+    ///
+    /// This method handles adjacently-tagged enums properly by using
+    /// the resolver for variant fallback when the tag is missing.
+    ///
+    /// Note: This method is only available when `desired`, `reported`, and `delta`
+    /// all use the same delta type (which is the common case for shadow responses).
+    pub async fn parse<S, Res>(json: &'a [u8], resolver: &Res) -> Result<Self, ParseError>
+    where
+        S: ShadowNode<Delta = D>,
+        Res: VariantResolver,
+    {
+        let scanner =
+            FieldScanner::scan(json, &["state", "timestamp", "version", "clientToken"])
+                .map_err(ParseError::Scan)?;
+
+        // Parse timestamp (default to 0 if missing)
+        let timestamp = scanner
+            .field_bytes("timestamp")
+            .and_then(|b| core::str::from_utf8(b).ok())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        // Parse version
+        let version = scanner
+            .field_bytes("version")
+            .and_then(|b| core::str::from_utf8(b).ok())
+            .and_then(|s| s.parse().ok());
+
+        // Parse client_token (strips surrounding quotes)
+        let client_token = scanner.field_str("clientToken");
+
+        // Parse state using DeltaState::parse
+        let state = if let Some(state_bytes) = scanner.field_bytes("state") {
+            DeltaState::parse::<S, Res>(state_bytes, resolver).await?
+        } else {
+            // No state field - return empty DeltaState
+            DeltaState {
+                desired: None,
+                reported: None,
+                delta: None,
+            }
+        };
+
+        Ok(Self {
+            state,
+            timestamp,
+            client_token,
+            version,
+        })
+    }
 }
 
 /// Response accepted state documents have the following format:
@@ -113,16 +206,58 @@ pub struct AcceptedResponse<'a, D, R> {
 /// - **version** — The current version of the document for the device's shadow
 ///   shared in AWS IoT. It is increased by one over the previous version of the
 ///   document.
-#[derive(Deserialize)]
 pub struct DeltaResponse<'a, U> {
     pub state: Option<U>,
     // pub metadata: Metadata<>.
     pub timestamp: u64,
-    #[serde(rename = "clientToken")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub client_token: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<i64>,
+}
+
+impl<'a, U> DeltaResponse<'a, U> {
+    /// Parse a delta response using `FieldScanner` and `parse_delta`.
+    ///
+    /// This method handles adjacently-tagged enums properly by using
+    /// the resolver for variant fallback when the tag is missing.
+    pub async fn parse<S, R>(json: &'a [u8], resolver: &R) -> Result<Self, ParseError>
+    where
+        S: ShadowNode<Delta = U>,
+        R: VariantResolver,
+    {
+        let scanner =
+            FieldScanner::scan(json, &["state", "timestamp", "version", "clientToken"])
+                .map_err(ParseError::Scan)?;
+
+        // Parse timestamp (default to 0 if missing)
+        let timestamp = scanner
+            .field_bytes("timestamp")
+            .and_then(|b| core::str::from_utf8(b).ok())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        // Parse version
+        let version = scanner
+            .field_bytes("version")
+            .and_then(|b| core::str::from_utf8(b).ok())
+            .and_then(|s| s.parse().ok());
+
+        // Parse client_token (strips surrounding quotes)
+        let client_token = scanner.field_str("clientToken");
+
+        // Parse state using parse_delta
+        let state = if let Some(state_bytes) = scanner.field_bytes("state") {
+            Some(S::parse_delta(state_bytes, "", resolver).await?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            state,
+            timestamp,
+            client_token,
+            version,
+        })
+    }
 }
 
 /// An error response document has the following format:

--- a/src/shadows/error.rs
+++ b/src/shadows/error.rs
@@ -57,6 +57,24 @@ impl<E: Debug> From<super::migration::MigrationError> for KvError<E> {
     }
 }
 
+impl<E: Debug> core::fmt::Display for KvError<E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            KvError::Kv(e) => write!(f, "KV store error: {:?}", e),
+            KvError::Serialization => write!(f, "serialization error"),
+            KvError::PathNotFound => write!(f, "path not found"),
+            KvError::KeyTooLong => write!(f, "key too long"),
+            KvError::VariantMismatch => write!(f, "variant mismatch"),
+            KvError::UnknownVariant => write!(f, "unknown variant"),
+            KvError::InvalidVariant => write!(f, "invalid variant"),
+            KvError::Migration(e) => write!(f, "migration error: {:?}", e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<E: Debug> std::error::Error for KvError<E> {}
+
 /// Error type for enum field operations.
 ///
 /// Used by `set_enum_variant()` and `get_enum_variant()`.
@@ -121,6 +139,24 @@ impl core::fmt::Display for ParseError {
         }
     }
 }
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::Overflow => write!(f, "overflow"),
+            Error::NoPersistence => write!(f, "no persistence"),
+            Error::DaoRead => write!(f, "DAO read error"),
+            Error::DaoWrite => write!(f, "DAO write error"),
+            Error::InvalidPayload => write!(f, "invalid payload"),
+            Error::WrongShadowName => write!(f, "wrong shadow name"),
+            Error::Mqtt => write!(f, "MQTT error"),
+            Error::ShadowError(e) => write!(f, "shadow error: {:?}", e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 impl From<ShadowError> for Error {
     fn from(e: ShadowError) -> Self {

--- a/src/shadows/error.rs
+++ b/src/shadows/error.rs
@@ -82,6 +82,46 @@ pub struct EnumFieldMeta {
     pub variants: &'static [&'static str],
 }
 
+/// Error type for delta parsing operations.
+///
+/// Returned by `ShadowNode::parse_delta()` when JSON parsing fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ParseError {
+    /// JSON scanning failed (malformed JSON)
+    Scan(super::tag_scanner::ScanError),
+
+    /// Serde deserialization failed
+    Deserialize,
+
+    /// Unknown enum variant name
+    UnknownVariant,
+
+    /// Missing variant tag and no fallback available
+    MissingVariant,
+
+    /// Content present but wrong type for variant
+    ContentTypeMismatch,
+}
+
+impl From<super::tag_scanner::ScanError> for ParseError {
+    fn from(e: super::tag_scanner::ScanError) -> Self {
+        ParseError::Scan(e)
+    }
+}
+
+impl core::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ParseError::Scan(e) => write!(f, "JSON scan error: {}", e),
+            ParseError::Deserialize => write!(f, "deserialization failed"),
+            ParseError::UnknownVariant => write!(f, "unknown enum variant"),
+            ParseError::MissingVariant => write!(f, "missing variant tag with no fallback"),
+            ParseError::ContentTypeMismatch => write!(f, "content type mismatch for variant"),
+        }
+    }
+}
+
 impl From<ShadowError> for Error {
     fn from(e: ShadowError) -> Self {
         Self::ShadowError(e)

--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -353,7 +353,8 @@ where
                     Patch::Set(inner_delta) => {
                         // Include the entry's partial reported (after apply_delta)
                         if let Some(v) = self.get(key) {
-                            let _ = reported.insert(key.clone(), v.into_partial_reported(inner_delta));
+                            let _ =
+                                reported.insert(key.clone(), v.into_partial_reported(inner_delta));
                         }
                     }
                     Patch::Unset => {

--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -42,6 +42,10 @@ impl<const N: usize> ShadowNode for heapless::String<N> {
         *self = delta.clone();
     }
 
+    fn into_reported(&self) -> Self::Reported {
+        self.clone()
+    }
+
     fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
         self.clone()
     }
@@ -154,6 +158,10 @@ where
 
     fn apply_delta(&mut self, delta: &Self::Delta) {
         *self = delta.clone();
+    }
+
+    fn into_reported(&self) -> Self::Reported {
+        self.clone()
     }
 
     fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
@@ -373,6 +381,14 @@ where
                 }
             }
         }
+    }
+
+    fn into_reported(&self) -> Self::Reported {
+        let mut reported = heapless::LinearMap::new();
+        for (key, value) in self.iter() {
+            let _ = reported.insert(key.clone(), value.into_reported());
+        }
+        LinearMapReported(reported)
     }
 
     fn into_partial_reported(&self, delta: &Self::Delta) -> Self::Reported {
@@ -710,6 +726,10 @@ macro_rules! impl_array_shadow_node {
 
             fn apply_delta(&mut self, delta: &Self::Delta) {
                 *self = delta.clone();
+            }
+
+            fn into_reported(&self) -> Self::Reported {
+                self.clone()
             }
 
             fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {

--- a/src/shadows/impls/opaque.rs
+++ b/src/shadows/impls/opaque.rs
@@ -38,6 +38,18 @@ macro_rules! impl_opaque {
 
             const SCHEMA_HASH: u64 = $crate::shadows::fnv1a_hash(stringify!($ty).as_bytes());
 
+            fn parse_delta<R: $crate::shadows::VariantResolver>(
+                json: &[u8],
+                _path: &str,
+                _resolver: &R,
+            ) -> impl ::core::future::Future<Output = Result<Self::Delta, $crate::shadows::ParseError>> {
+                async move {
+                    ::serde_json_core::from_slice(json)
+                        .map(|(v, _)| v)
+                        .map_err(|_| $crate::shadows::ParseError::Deserialize)
+                }
+            }
+
             fn apply_delta(&mut self, delta: &Self::Delta) {
                 *self = delta.clone();
             }
@@ -153,6 +165,18 @@ impl crate::shadows::ShadowNode for core::time::Duration {
     type Reported = core::time::Duration;
 
     const SCHEMA_HASH: u64 = crate::shadows::fnv1a_hash(b"core::time::Duration");
+
+    fn parse_delta<R: crate::shadows::VariantResolver>(
+        json: &[u8],
+        _path: &str,
+        _resolver: &R,
+    ) -> impl ::core::future::Future<Output = Result<Self::Delta, crate::shadows::ParseError>> {
+        async move {
+            ::serde_json_core::from_slice(json)
+                .map(|(v, _)| v)
+                .map_err(|_| crate::shadows::ParseError::Deserialize)
+        }
+    }
 
     fn apply_delta(&mut self, delta: &Self::Delta) {
         *self = *delta;

--- a/src/shadows/impls/opaque.rs
+++ b/src/shadows/impls/opaque.rs
@@ -54,8 +54,8 @@ macro_rules! impl_opaque {
                 *self = delta.clone();
             }
 
-            fn into_reported(self) -> Self::Reported {
-                self
+            fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
+                self.clone()
             }
         }
 
@@ -182,8 +182,8 @@ impl crate::shadows::ShadowNode for core::time::Duration {
         *self = *delta;
     }
 
-    fn into_reported(self) -> Self::Reported {
-        self
+    fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
+        *self
     }
 }
 
@@ -305,16 +305,6 @@ mod tests {
         // Schema hash should be deterministic
         assert_eq!(<u32 as ShadowNode>::SCHEMA_HASH, fnv1a_hash(b"u32"));
         assert_eq!(<bool as ShadowNode>::SCHEMA_HASH, fnv1a_hash(b"bool"));
-    }
-
-    #[test]
-    fn test_into_reported_identity() {
-        // into_reported should return self for primitives
-        let x: u32 = 42;
-        assert_eq!(ShadowNode::into_reported(x), 42);
-
-        let b: bool = true;
-        assert_eq!(ShadowNode::into_reported(b), true);
     }
 
     #[test]

--- a/src/shadows/impls/opaque.rs
+++ b/src/shadows/impls/opaque.rs
@@ -54,6 +54,10 @@ macro_rules! impl_opaque {
                 *self = delta.clone();
             }
 
+            fn into_reported(&self) -> Self::Reported {
+                self.clone()
+            }
+
             fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
                 self.clone()
             }
@@ -179,6 +183,10 @@ impl crate::shadows::ShadowNode for core::time::Duration {
 
     fn apply_delta(&mut self, delta: &Self::Delta) {
         *self = *delta;
+    }
+
+    fn into_reported(&self) -> Self::Reported {
+        *self
     }
 
     fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -34,9 +34,7 @@ impl ShadowNode for String {
         _path: &str,
         _resolver: &R,
     ) -> impl Future<Output = Result<Self::Delta, ParseError>> {
-        async move {
-            serde_json::from_slice(json).map_err(|_| ParseError::Deserialize)
-        }
+        async move { serde_json::from_slice(json).map_err(|_| ParseError::Deserialize) }
     }
 
     fn apply_delta(&mut self, delta: &Self::Delta) {
@@ -145,9 +143,7 @@ where
         _path: &str,
         _resolver: &R,
     ) -> impl Future<Output = Result<Self::Delta, ParseError>> {
-        async move {
-            serde_json::from_slice(json).map_err(|_| ParseError::Deserialize)
-        }
+        async move { serde_json::from_slice(json).map_err(|_| ParseError::Deserialize) }
     }
 
     fn apply_delta(&mut self, delta: &Self::Delta) {

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -40,6 +40,10 @@ impl ShadowNode for String {
         *self = delta.clone();
     }
 
+    fn into_reported(&self) -> Self::Reported {
+        self.clone()
+    }
+
     fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
         self.clone()
     }
@@ -144,6 +148,10 @@ where
 
     fn apply_delta(&mut self, delta: &Self::Delta) {
         *self = delta.clone();
+    }
+
+    fn into_reported(&self) -> Self::Reported {
+        self.clone()
     }
 
     fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
@@ -344,6 +352,14 @@ where
                 }
             }
         }
+    }
+
+    fn into_reported(&self) -> Self::Reported {
+        let mut reported = HashMap::new();
+        for (key, value) in self.iter() {
+            reported.insert(key.clone(), value.into_reported());
+        }
+        HashMapReported(reported)
     }
 
     fn into_partial_reported(&self, delta: &Self::Delta) -> Self::Reported {

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -301,6 +301,7 @@ pub trait ShadowNode: Default + Clone + Sized {
     /// Used for efficient acknowledgment - reports only changed fields.
     /// AWS IoT Shadow merges partial updates, so unchanged fields keep
     /// their cloud values.
+    #[allow(clippy::wrong_self_convention)]
     fn into_partial_reported(&self, delta: &Self::Delta) -> Self::Reported;
 }
 

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -296,8 +296,12 @@ pub trait ShadowNode: Default + Clone + Sized {
         None
     }
 
-    /// Convert this state into its reported representation.
-    fn into_reported(self) -> Self::Reported;
+    /// Convert to reported representation containing only fields present in delta.
+    ///
+    /// Used for efficient acknowledgment - reports only changed fields.
+    /// AWS IoT Shadow merges partial updates, so unchanged fields keep
+    /// their cloud values.
+    fn into_partial_reported(&self, delta: &Self::Delta) -> Self::Reported;
 }
 
 // =============================================================================

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -236,7 +236,8 @@ pub trait ShadowNode: Default + Clone + Sized {
     /// Reported type for serialization to cloud.
     ///
     /// Used for device→cloud acknowledgment after applying deltas.
-    /// Fields marked `report_only` are `None` in the Reported type.
+    /// Fields marked `report_only` are excluded from the state struct and only
+    /// appear in this Reported type. They are `None` in partial reported.
     ///
     /// ## Trait Bound: `ReportedUnionFields`
     ///
@@ -295,6 +296,13 @@ pub trait ShadowNode: Default + Clone + Sized {
     fn variant_at_path(&self, _path: &str) -> Option<heapless::String<32>> {
         None
     }
+
+    /// Convert to full reported representation (all fields set).
+    ///
+    /// This is used by the generated `From<State> for Reported` impl
+    /// to convert the entire state into a reported type.
+    #[allow(clippy::wrong_self_convention)]
+    fn into_reported(&self) -> Self::Reported;
 
     /// Convert to reported representation containing only fields present in delta.
     ///

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -86,11 +86,8 @@ where
                         );
 
                         let resolver = self.store.resolver(Self::prefix());
-                        let parsed = DeltaResponse::parse::<S, _>(
-                            delta_message.payload(),
-                            &resolver,
-                        )
-                        .await;
+                        let parsed =
+                            DeltaResponse::parse::<S, _>(delta_message.payload(), &resolver).await;
 
                         Some(
                             parsed

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -56,12 +56,11 @@ where
                 debug!("Subscribing to delta topic");
                 self.mqtt.wait_connected().await;
 
-                let topic = Topic::UpdateDelta
-                    .format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
-                        S::PREFIX,
-                        self.mqtt.client_id(),
-                        S::NAME,
-                    )?;
+                let topic = Topic::UpdateDelta.format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
+                    S::PREFIX,
+                    self.mqtt.client_id(),
+                    S::NAME,
+                )?;
 
                 let sub = self
                     .mqtt
@@ -307,18 +306,16 @@ where
         };
 
         //*** SUBSCRIBE ***/
-        let accepted_topic = accepted
-            .format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
-                S::PREFIX,
-                self.mqtt.client_id(),
-                S::NAME,
-            )?;
-        let rejected_topic = rejected
-            .format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
-                S::PREFIX,
-                self.mqtt.client_id(),
-                S::NAME,
-            )?;
+        let accepted_topic = accepted.format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
+            S::PREFIX,
+            self.mqtt.client_id(),
+            S::NAME,
+        )?;
+        let rejected_topic = rejected.format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
+            S::PREFIX,
+            self.mqtt.client_id(),
+            S::NAME,
+        )?;
 
         let sub = self
             .mqtt
@@ -330,12 +327,11 @@ where
             .map_err(|_| Error::Mqtt)?;
 
         //*** PUBLISH REQUEST ***/
-        let topic_name = topic
-            .format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
-                S::PREFIX,
-                self.mqtt.client_id(),
-                S::NAME,
-            )?;
+        let topic_name = topic.format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
+            S::PREFIX,
+            self.mqtt.client_id(),
+            S::NAME,
+        )?;
         self.mqtt
             .publish(topic_name.as_str(), payload)
             .await

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -370,8 +370,8 @@ where
                 .await
                 .map_err(|_| Error::DaoWrite)?;
 
-            // Acknowledge to cloud
-            self.update_shadow(None, Some(state.clone().into_reported()))
+            // Acknowledge to cloud with only the changed fields
+            self.update_shadow(None, Some(state.into_partial_reported(delta)))
                 .await?;
 
             state
@@ -482,7 +482,8 @@ where
                 .apply_and_save(&delta)
                 .await
                 .map_err(|_| Error::DaoWrite)?;
-            self.update_shadow(None, Some(state.clone().into_reported()))
+            // Acknowledge with only the changed fields
+            self.update_shadow(None, Some(state.into_partial_reported(&delta)))
                 .await?;
             state
         } else {

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -666,6 +666,7 @@ struct StaticIpCfg {
 }
 
 // Test struct using explicit max_size (doesn't require MaxSize trait on field type)
+#[allow(dead_code)]
 #[shadow_node]
 #[derive(Clone, Default, Serialize, Deserialize)]
 struct ExplicitSizeCfg {
@@ -681,6 +682,17 @@ enum IpSettingsCfg {
     #[default]
     Dhcp,
     Static(StaticIpCfg),
+}
+
+// Test: report_only fields with borrowed types work because they're not persisted to KV.
+// &'static str doesn't implement MaxSize, but report_only fields skip KV codegen entirely.
+#[allow(dead_code)]
+#[shadow_node]
+#[derive(Clone, Default, Serialize)]
+struct ReportOnlyStaticTest {
+    normal_field: u32,
+    #[shadow_attr(report_only, opaque)]
+    status: &'static str,
 }
 
 #[shadow_root(name = "wifi")]

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -1593,10 +1593,19 @@ async fn test_commit_preserves_map_entries_and_removes_orphans() {
             "dev/__schema_hash__",
             &0xDEADBEEFu64.to_le_bytes(), // different hash
         ),
-        ("dev/label", &encode(heapless::String::<8>::try_from("hello").unwrap())),
+        (
+            "dev/label",
+            &encode(heapless::String::<8>::try_from("hello").unwrap()),
+        ),
         ("dev/ports/__n__", &encode(2u16)),
-        ("dev/ports/__k/0", &encode(heapless::String::<4>::try_from("p1").unwrap())),
-        ("dev/ports/__k/1", &encode(heapless::String::<4>::try_from("p2").unwrap())),
+        (
+            "dev/ports/__k/0",
+            &encode(heapless::String::<4>::try_from("p1").unwrap()),
+        ),
+        (
+            "dev/ports/__k/1",
+            &encode(heapless::String::<4>::try_from("p2").unwrap()),
+        ),
         ("dev/ports/p1", &encode(100u32)),
         ("dev/ports/p2", &encode(200u32)),
         ("dev/old_field", &encode(42u32)), // orphan from previous schema

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -1057,8 +1057,8 @@ async fn test_apply_and_save_nested_struct_fields() {
 
 mod adjacently_tagged {
     use super::*;
-    use rustot_derive::shadow_node;
     use crate::shadows::store::StateStore;
+    use rustot_derive::shadow_node;
 
     // Inner config type for Sio variant
     #[shadow_node]
@@ -1164,7 +1164,9 @@ mod adjacently_tagged {
 
         // Test deserialization using parse_delta
         use crate::shadows::{NullResolver, ShadowNode};
-        let parsed = PortMode::parse_delta(json.as_bytes(), "", &NullResolver).await.unwrap();
+        let parsed = PortMode::parse_delta(json.as_bytes(), "", &NullResolver)
+            .await
+            .unwrap();
         assert_eq!(parsed.mode, Some(PortModeVariant::Sio));
     }
 
@@ -1173,7 +1175,9 @@ mod adjacently_tagged {
         // Test mode-only delta (no config)
         let json = br#"{"mode": "inactive"}"#;
         use crate::shadows::{NullResolver, ShadowNode};
-        let delta = PortMode::parse_delta(json, "", &NullResolver).await.unwrap();
+        let delta = PortMode::parse_delta(json, "", &NullResolver)
+            .await
+            .unwrap();
         assert_eq!(delta.mode, Some(PortModeVariant::Inactive));
         assert!(delta.config.is_none());
     }
@@ -1187,7 +1191,10 @@ mod adjacently_tagged {
 
         // Set up InMemory store with current state set to Sio variant
         let store = InMemory::<PortMode>::new();
-        store.set_state("/test", &PortMode::Sio(SioConfig { polarity: true })).await.unwrap();
+        store
+            .set_state("/test", &PortMode::Sio(SioConfig { polarity: true }))
+            .await
+            .unwrap();
         let resolver = store.resolver("/test");
 
         let json = br#"{"config": {"polarity": false}}"#;
@@ -1424,10 +1431,22 @@ mod adjacently_tagged {
         let partial_json = serde_json::to_string(&partial).unwrap();
 
         // Partial should ONLY have adjacent (the field that was in delta)
-        assert!(!partial_json.contains("\"simple_field\""), "partial should NOT have simple_field");
-        assert!(partial_json.contains("\"adjacent\""), "partial should have adjacent");
-        assert!(partial_json.contains("\"mode\""), "adjacent's mode should be present");
-        assert!(partial_json.contains("\"polarity\""), "adjacent's polarity should be present");
+        assert!(
+            !partial_json.contains("\"simple_field\""),
+            "partial should NOT have simple_field"
+        );
+        assert!(
+            partial_json.contains("\"adjacent\""),
+            "partial should have adjacent"
+        );
+        assert!(
+            partial_json.contains("\"mode\""),
+            "adjacent's mode should be present"
+        );
+        assert!(
+            partial_json.contains("\"polarity\""),
+            "adjacent's polarity should be present"
+        );
     }
 
     #[test]
@@ -1435,7 +1454,9 @@ mod adjacently_tagged {
         use crate::shadows::ShadowNode;
         // Test with IoLinkConfig which has cycle_time field
         let mut config = IoLinkConfig { cycle_time: 1000 };
-        let delta = DeltaIoLinkConfig { cycle_time: Some(2000) };
+        let delta = DeltaIoLinkConfig {
+            cycle_time: Some(2000),
+        };
         config.apply_delta(&delta);
 
         let partial = config.into_partial_reported(&delta);
@@ -1458,7 +1479,11 @@ mod adjacently_tagged {
     fn test_struct_into_partial_reported_excludes_unchanged_fields() {
         use crate::shadows::ShadowNode;
 
-        let mut config = MultiFieldConfig { alpha: 1, beta: 2, gamma: true };
+        let mut config = MultiFieldConfig {
+            alpha: 1,
+            beta: 2,
+            gamma: true,
+        };
 
         // Delta only changes alpha
         let delta = DeltaMultiFieldConfig {
@@ -1472,8 +1497,17 @@ mod adjacently_tagged {
         let partial_json = serde_json::to_string(&partial).unwrap();
 
         // Partial should ONLY have alpha (the field that was in delta)
-        assert!(partial_json.contains("\"alpha\""), "partial should have alpha");
-        assert!(!partial_json.contains("\"beta\""), "partial should NOT have beta");
-        assert!(!partial_json.contains("\"gamma\""), "partial should NOT have gamma");
+        assert!(
+            partial_json.contains("\"alpha\""),
+            "partial should have alpha"
+        );
+        assert!(
+            !partial_json.contains("\"beta\""),
+            "partial should NOT have beta"
+        );
+        assert!(
+            !partial_json.contains("\"gamma\""),
+            "partial should NOT have gamma"
+        );
     }
 }

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -665,6 +665,16 @@ struct StaticIpCfg {
     gateway: heapless::Vec<u8, 4>,
 }
 
+// Test struct using explicit max_size (doesn't require MaxSize trait on field type)
+#[shadow_node]
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct ExplicitSizeCfg {
+    // Using opaque with explicit max_size - heapless::Vec still implements MaxSize,
+    // but the explicit size takes precedence and no MaxSize bound is required
+    #[shadow_attr(opaque(max_size = 32))]
+    data: heapless::Vec<u8, 8>,
+}
+
 #[shadow_node]
 #[derive(Clone, Default, Serialize, Deserialize)]
 enum IpSettingsCfg {

--- a/src/shadows/store/file.rs
+++ b/src/shadows/store/file.rs
@@ -8,11 +8,11 @@ use tokio::fs;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
 
-use super::{KVStore, StateStore};
+use super::{ApplyJsonError, KVStore, StateStore};
 use crate::shadows::commit::CommitStats;
 use crate::shadows::error::KvError;
 use crate::shadows::migration::LoadResult;
-use crate::shadows::KVPersist;
+use crate::shadows::{KVPersist, VariantResolver};
 
 /// Suffix for schema hash keys.
 const SCHEMA_HASH_SUFFIX: &str = "/__schema_hash__";
@@ -407,5 +407,59 @@ impl<St: KVPersist> StateStore<St> for FileKVStore {
             orphans_removed,
             schema_hash_updated: true,
         })
+    }
+
+    fn resolver<'a>(&'a self, prefix: &'a str) -> impl VariantResolver + 'a {
+        FileKvResolver { kv: self, prefix }
+    }
+
+    async fn apply_json_delta(
+        &self,
+        prefix: &str,
+        json: &[u8],
+    ) -> Result<St::Delta, ApplyJsonError<Self::Error>> {
+        let resolver =
+            <Self as StateStore<St>>::resolver(self, prefix);
+        let delta = St::parse_delta(json, "", &resolver)
+            .await
+            .map_err(ApplyJsonError::Parse)?;
+
+        // Persist delta directly (avoids method dispatch ambiguity)
+        St::persist_delta::<Self, 128>(&delta, self, prefix)
+            .await
+            .map_err(|e| match e {
+                KvError::Kv(kv_err) => ApplyJsonError::Store(kv_err),
+                _ => ApplyJsonError::Store(FileKVStoreError::KeyEncoding),
+            })?;
+
+        Ok(delta)
+    }
+}
+
+/// Resolver for FileKVStore that fetches `_variant` keys on demand.
+struct FileKvResolver<'a> {
+    kv: &'a FileKVStore,
+    prefix: &'a str,
+}
+
+impl VariantResolver for FileKvResolver<'_> {
+    async fn resolve(&self, path: &str) -> Option<heapless::String<32>> {
+        // Build the variant key: prefix/path/_variant
+        // KV keys always have format {prefix}/{field_path} where field_path starts with /
+        // So the full key is {prefix}/{path}/_variant (slash always present between components)
+        let key = format!("{}/{}/_variant", self.prefix, path);
+
+        // Fetch the variant name from storage
+        let mut buf = [0u8; 64];
+        match self.kv.fetch(&key, &mut buf).await {
+            Ok(Some(bytes)) => {
+                // Try to parse as UTF-8 string
+                std::str::from_utf8(bytes)
+                    .ok()
+                    .and_then(|s| heapless::String::try_from(s).ok())
+            }
+            Ok(None) => None,
+            Err(_) => None,
+        }
     }
 }

--- a/src/shadows/store/file.rs
+++ b/src/shadows/store/file.rs
@@ -418,8 +418,7 @@ impl<St: KVPersist> StateStore<St> for FileKVStore {
         prefix: &str,
         json: &[u8],
     ) -> Result<St::Delta, ApplyJsonError<Self::Error>> {
-        let resolver =
-            <Self as StateStore<St>>::resolver(self, prefix);
+        let resolver = <Self as StateStore<St>>::resolver(self, prefix);
         let delta = St::parse_delta(json, "", &resolver)
             .await
             .map_err(ApplyJsonError::Parse)?;

--- a/src/shadows/store/sequential.rs
+++ b/src/shadows/store/sequential.rs
@@ -408,10 +408,7 @@ impl<
     }
 
     fn resolver<'a>(&'a self, prefix: &'a str) -> impl VariantResolver + 'a {
-        KvResolver::<Self, MAX_KEY_LEN> {
-            kv: self,
-            prefix,
-        }
+        KvResolver::<Self, MAX_KEY_LEN> { kv: self, prefix }
     }
 
     async fn apply_json_delta(
@@ -419,8 +416,7 @@ impl<
         prefix: &str,
         json: &[u8],
     ) -> Result<St::Delta, ApplyJsonError<Self::Error>> {
-        let resolver =
-            <Self as StateStore<St>>::resolver(self, prefix);
+        let resolver = <Self as StateStore<St>>::resolver(self, prefix);
         let delta = St::parse_delta(json, "", &resolver)
             .await
             .map_err(ApplyJsonError::Parse)?;

--- a/src/shadows/tag_scanner.rs
+++ b/src/shadows/tag_scanner.rs
@@ -647,7 +647,10 @@ mod tests {
         let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
 
         assert_eq!(scan.tag_str(), Some("sio"));
-        assert_eq!(scan.content_bytes(), Some(br#"{"polarity": "pnp"}"#.as_slice()));
+        assert_eq!(
+            scan.content_bytes(),
+            Some(br#"{"polarity": "pnp"}"#.as_slice())
+        );
     }
 
     #[test]
@@ -656,7 +659,10 @@ mod tests {
         let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
 
         assert_eq!(scan.tag_str(), Some("sio"));
-        assert_eq!(scan.content_bytes(), Some(br#"{"polarity": "pnp"}"#.as_slice()));
+        assert_eq!(
+            scan.content_bytes(),
+            Some(br#"{"polarity": "pnp"}"#.as_slice())
+        );
     }
 
     #[test]
@@ -674,7 +680,10 @@ mod tests {
         let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
 
         assert_eq!(scan.tag_str(), None);
-        assert_eq!(scan.content_bytes(), Some(br#"{"polarity": "pnp"}"#.as_slice()));
+        assert_eq!(
+            scan.content_bytes(),
+            Some(br#"{"polarity": "pnp"}"#.as_slice())
+        );
     }
 
     #[test]
@@ -798,7 +807,10 @@ mod tests {
     fn test_error_expected_object() {
         let json = br#"["not", "an", "object"]"#;
         let result = TaggedJsonScan::scan(json, "mode", "config");
-        assert!(matches!(result, Err(ScanError::Expected { expected: b'{', .. })));
+        assert!(matches!(
+            result,
+            Err(ScanError::Expected { expected: b'{', .. })
+        ));
     }
 
     #[test]
@@ -884,7 +896,8 @@ mod tests {
 
     #[test]
     fn test_field_scanner_all_json_types() {
-        let json = br#"{"str": "hello", "num": 42, "bool": true, "null": null, "arr": [1], "obj": {}}"#;
+        let json =
+            br#"{"str": "hello", "num": 42, "bool": true, "null": null, "arr": [1], "obj": {}}"#;
         let scanner =
             FieldScanner::scan(json, &["str", "num", "bool", "null", "arr", "obj"]).unwrap();
 

--- a/src/shadows/tag_scanner.rs
+++ b/src/shadows/tag_scanner.rs
@@ -1,0 +1,907 @@
+//! Lightweight JSON scanner for adjacently-tagged enum deserialization.
+//!
+//! This module provides zero-allocation JSON scanners that extract fields from JSON
+//! representations. It's used to deserialize adjacently-tagged enum Delta types and
+//! wrapper structures without requiring the `alloc` feature.
+//!
+//! ## Why This Exists
+//!
+//! Serde's adjacently-tagged enum deserialization requires `alloc` because JSON field
+//! order isn't guaranteed. If `content` appears before `tag`, serde must buffer the
+//! content until it knows which variant to deserialize into.
+//!
+//! This scanner solves the problem by:
+//! 1. Scanning the JSON to extract the tag value (if present)
+//! 2. Extracting the raw bytes of the content field (if present)
+//! 3. Allowing the caller to deserialize the content with type knowledge
+//!
+//! ## Public APIs
+//!
+//! - [`TaggedJsonScan`]: Extracts exactly 2 fields (tag + content) for adjacently-tagged enums
+//! - [`FieldScanner`]: Extracts N arbitrary fields for wrapper type parsing
+//!
+//! ## Example: Adjacently-Tagged Enum
+//!
+//! ```ignore
+//! let json = br#"{"config": {"polarity": "pnp"}, "mode": "sio"}"#;
+//! let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+//!
+//! let mode = scan.tag_str(); // Some("sio")
+//! let content = scan.content_bytes(); // Some(b"{\"polarity\": \"pnp\"}")
+//!
+//! // Now deserialize content with known type
+//! let (config, _): (SioConfig, _) = serde_json_core::from_slice(content.unwrap())?;
+//! ```
+//!
+//! ## Example: Multiple Fields
+//!
+//! ```ignore
+//! let json = br#"{"state": {"desired": null, "delta": {"temp": 25}}, "version": 42}"#;
+//! let scanner = FieldScanner::scan(json, &["state", "version"]).unwrap();
+//!
+//! let state = scanner.field_bytes("state"); // Some(b"{\"desired\": null, \"delta\": {...}}")
+//! let version = scanner.field_bytes("version"); // Some(b"42")
+//! ```
+
+/// Error type for JSON scanning operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScanError {
+    /// Unexpected end of input
+    UnexpectedEof,
+    /// Invalid UTF-8 in string
+    InvalidUtf8,
+    /// Expected a specific byte but found something else
+    Expected { expected: u8, found: Option<u8> },
+    /// Expected an object at the root level
+    ExpectedObject,
+    /// Unterminated string literal
+    UnterminatedString,
+    /// Invalid escape sequence in string
+    InvalidEscape,
+    /// Nesting depth exceeded (prevents stack overflow on malicious input)
+    NestingTooDeep,
+}
+
+impl core::fmt::Display for ScanError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ScanError::UnexpectedEof => write!(f, "unexpected end of input"),
+            ScanError::InvalidUtf8 => write!(f, "invalid UTF-8 in string"),
+            ScanError::Expected { expected, found } => {
+                write!(f, "expected '{}', found ", *expected as char)?;
+                match found {
+                    Some(b) => write!(f, "'{}'", *b as char),
+                    None => write!(f, "EOF"),
+                }
+            }
+            ScanError::ExpectedObject => write!(f, "expected JSON object at root"),
+            ScanError::UnterminatedString => write!(f, "unterminated string literal"),
+            ScanError::InvalidEscape => write!(f, "invalid escape sequence"),
+            ScanError::NestingTooDeep => write!(f, "nesting depth exceeded"),
+        }
+    }
+}
+
+/// Result of scanning a JSON object for tag and content fields.
+///
+/// Contains borrowed slices into the original JSON input.
+#[derive(Debug, Clone)]
+pub struct TaggedJsonScan<'a> {
+    /// The tag field value, if present and a valid string.
+    tag: Option<&'a str>,
+    /// The raw JSON bytes of the content field, if present.
+    content: Option<&'a [u8]>,
+}
+
+impl<'a> TaggedJsonScan<'a> {
+    /// Scan a JSON object for tag and content fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `json` - The JSON bytes to scan
+    /// * `tag_key` - The key name for the tag field (e.g., "mode")
+    /// * `content_key` - The key name for the content field (e.g., "config")
+    ///
+    /// # Returns
+    ///
+    /// A `TaggedJsonScan` containing the extracted tag value and content bytes,
+    /// or an error if the JSON is malformed.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let json = br#"{"mode": "sio", "config": {"value": 42}}"#;
+    /// let scan = TaggedJsonScan::scan(json, "mode", "config")?;
+    /// assert_eq!(scan.tag_str(), Some("sio"));
+    /// assert!(scan.content_bytes().is_some());
+    /// ```
+    pub fn scan(json: &'a [u8], tag_key: &str, content_key: &str) -> Result<Self, ScanError> {
+        let mut scanner = Scanner::new(json);
+        scanner.scan_for_fields(tag_key, content_key)
+    }
+
+    /// Get the tag field value as a string slice.
+    ///
+    /// Returns `None` if the tag field was not present in the JSON.
+    pub fn tag_str(&self) -> Option<&'a str> {
+        self.tag
+    }
+
+    /// Get the raw JSON bytes of the content field.
+    ///
+    /// Returns `None` if the content field was not present in the JSON.
+    /// The returned bytes are the complete JSON value (object, array, string, etc.)
+    /// and can be passed to `serde_json_core::from_slice()` for deserialization.
+    pub fn content_bytes(&self) -> Option<&'a [u8]> {
+        self.content
+    }
+}
+
+/// Result of scanning a JSON object for multiple named fields.
+///
+/// Contains byte ranges into the original JSON input for each requested field.
+/// Used for parsing wrapper types like `DeltaResponse` and `AcceptedResponse`
+/// where we need to extract several fields without full deserialization.
+///
+/// # Example
+///
+/// ```ignore
+/// let json = br#"{"state": {"delta": {"temp": 25}}, "version": 42, "timestamp": 1234}"#;
+/// let scanner = FieldScanner::scan(json, &["state", "version"]).unwrap();
+///
+/// let state_bytes = scanner.field_bytes("state"); // Some(b"{\"delta\": ...}")
+/// let version_bytes = scanner.field_bytes("version"); // Some(b"42")
+/// let timestamp = scanner.field_bytes("timestamp"); // None (not requested)
+/// ```
+#[derive(Debug, Clone)]
+pub struct FieldScanner<'a> {
+    /// Byte ranges for each found field: (start, end)
+    fields: heapless::LinearMap<&'static str, (usize, usize), 8>,
+    /// Reference to the original JSON input
+    json: &'a [u8],
+}
+
+impl<'a> FieldScanner<'a> {
+    /// Scan a JSON object for specific fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `json` - The JSON bytes to scan (must be a JSON object)
+    /// * `field_names` - Names of fields to extract (max 8)
+    ///
+    /// # Returns
+    ///
+    /// A `FieldScanner` containing byte ranges for each found field,
+    /// or an error if the JSON is malformed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `field_names` contains more than 8 entries.
+    pub fn scan(json: &'a [u8], field_names: &[&'static str]) -> Result<Self, ScanError> {
+        assert!(
+            field_names.len() <= 8,
+            "FieldScanner supports at most 8 fields"
+        );
+
+        let mut scanner = Scanner::new(json);
+        let fields = scanner.scan_for_multiple_fields(field_names)?;
+        Ok(Self { fields, json })
+    }
+
+    /// Get the raw JSON bytes for a field.
+    ///
+    /// Returns `None` if the field was not present in the JSON or
+    /// was not in the list of requested field names.
+    pub fn field_bytes(&self, name: &str) -> Option<&'a [u8]> {
+        for (k, (start, end)) in self.fields.iter() {
+            if *k == name {
+                return Some(&self.json[*start..*end]);
+            }
+        }
+        None
+    }
+
+    /// Get the field value as a string (if it's a JSON string).
+    ///
+    /// This parses the field as a JSON string and returns the content
+    /// without the surrounding quotes. Returns `None` if:
+    /// - The field was not present
+    /// - The field value is not a string
+    /// - The string contains invalid UTF-8
+    ///
+    /// Note: Escape sequences are validated but not unescaped.
+    pub fn field_str(&self, name: &str) -> Option<&'a str> {
+        let bytes = self.field_bytes(name)?;
+        // Must start and end with quotes
+        if bytes.len() < 2 || bytes[0] != b'"' || bytes[bytes.len() - 1] != b'"' {
+            return None;
+        }
+        // Return content without quotes
+        core::str::from_utf8(&bytes[1..bytes.len() - 1]).ok()
+    }
+
+    /// Check if a field was present in the JSON.
+    pub fn has_field(&self, name: &str) -> bool {
+        for (k, _) in self.fields.iter() {
+            if *k == name {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Internal scanner state.
+struct Scanner<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+/// Maximum nesting depth to prevent stack overflow on malicious input.
+const MAX_NESTING_DEPTH: usize = 32;
+
+impl<'a> Scanner<'a> {
+    fn new(input: &'a [u8]) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    /// Peek at the current byte without advancing.
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    /// Advance position by one byte.
+    fn advance(&mut self) {
+        self.pos += 1;
+    }
+
+    /// Consume the current byte if it matches expected.
+    fn expect(&mut self, expected: u8) -> Result<(), ScanError> {
+        match self.peek() {
+            Some(b) if b == expected => {
+                self.advance();
+                Ok(())
+            }
+            found => Err(ScanError::Expected { expected, found }),
+        }
+    }
+
+    /// Skip whitespace characters.
+    fn skip_whitespace(&mut self) {
+        while let Some(b) = self.peek() {
+            match b {
+                b' ' | b'\t' | b'\n' | b'\r' => self.advance(),
+                _ => break,
+            }
+        }
+    }
+
+    /// Parse a JSON string, returning the content (without quotes).
+    ///
+    /// For simplicity, this returns a slice of the original input.
+    /// It validates escape sequences but doesn't unescape them.
+    /// This works for tag values which are typically simple identifiers.
+    fn parse_string(&mut self) -> Result<&'a str, ScanError> {
+        self.expect(b'"')?;
+        let start = self.pos;
+
+        loop {
+            match self.peek() {
+                None => return Err(ScanError::UnterminatedString),
+                Some(b'"') => {
+                    let end = self.pos;
+                    self.advance(); // consume closing quote
+                    let bytes = &self.input[start..end];
+                    return core::str::from_utf8(bytes).map_err(|_| ScanError::InvalidUtf8);
+                }
+                Some(b'\\') => {
+                    self.advance();
+                    // Validate escape sequence
+                    match self.peek() {
+                        Some(b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't') => {
+                            self.advance();
+                        }
+                        Some(b'u') => {
+                            // Unicode escape: \uXXXX
+                            self.advance();
+                            for _ in 0..4 {
+                                match self.peek() {
+                                    Some(b) if b.is_ascii_hexdigit() => self.advance(),
+                                    _ => return Err(ScanError::InvalidEscape),
+                                }
+                            }
+                        }
+                        _ => return Err(ScanError::InvalidEscape),
+                    }
+                }
+                Some(_) => self.advance(),
+            }
+        }
+    }
+
+    /// Skip a JSON string without extracting its value.
+    fn skip_string(&mut self) -> Result<(), ScanError> {
+        self.expect(b'"')?;
+
+        loop {
+            match self.peek() {
+                None => return Err(ScanError::UnterminatedString),
+                Some(b'"') => {
+                    self.advance();
+                    return Ok(());
+                }
+                Some(b'\\') => {
+                    self.advance();
+                    // Skip the escaped character
+                    if self.peek().is_some() {
+                        self.advance();
+                    }
+                }
+                Some(_) => self.advance(),
+            }
+        }
+    }
+
+    /// Skip any JSON value, returning the byte range it occupied.
+    fn skip_value(&mut self) -> Result<(usize, usize), ScanError> {
+        self.skip_value_with_depth(0)
+    }
+
+    /// Skip any JSON value with depth tracking.
+    fn skip_value_with_depth(&mut self, depth: usize) -> Result<(usize, usize), ScanError> {
+        if depth > MAX_NESTING_DEPTH {
+            return Err(ScanError::NestingTooDeep);
+        }
+
+        self.skip_whitespace();
+        let start = self.pos;
+
+        match self.peek() {
+            None => Err(ScanError::UnexpectedEof),
+            Some(b'"') => {
+                self.skip_string()?;
+                Ok((start, self.pos))
+            }
+            Some(b'{') => {
+                self.skip_object(depth)?;
+                Ok((start, self.pos))
+            }
+            Some(b'[') => {
+                self.skip_array(depth)?;
+                Ok((start, self.pos))
+            }
+            Some(b't') => {
+                // true
+                self.expect_bytes(b"true")?;
+                Ok((start, self.pos))
+            }
+            Some(b'f') => {
+                // false
+                self.expect_bytes(b"false")?;
+                Ok((start, self.pos))
+            }
+            Some(b'n') => {
+                // null
+                self.expect_bytes(b"null")?;
+                Ok((start, self.pos))
+            }
+            Some(b) if b == b'-' || b.is_ascii_digit() => {
+                self.skip_number()?;
+                Ok((start, self.pos))
+            }
+            Some(b) => Err(ScanError::Expected {
+                expected: b'"',
+                found: Some(b),
+            }),
+        }
+    }
+
+    /// Expect and consume a specific byte sequence.
+    fn expect_bytes(&mut self, bytes: &[u8]) -> Result<(), ScanError> {
+        for &expected in bytes {
+            self.expect(expected)?;
+        }
+        Ok(())
+    }
+
+    /// Skip a JSON number.
+    fn skip_number(&mut self) -> Result<(), ScanError> {
+        // Optional minus
+        if self.peek() == Some(b'-') {
+            self.advance();
+        }
+
+        // Integer part
+        match self.peek() {
+            Some(b'0') => self.advance(),
+            Some(b) if b.is_ascii_digit() => {
+                while let Some(b) = self.peek() {
+                    if b.is_ascii_digit() {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            _ => {
+                return Err(ScanError::Expected {
+                    expected: b'0',
+                    found: self.peek(),
+                })
+            }
+        }
+
+        // Optional fraction
+        if self.peek() == Some(b'.') {
+            self.advance();
+            while let Some(b) = self.peek() {
+                if b.is_ascii_digit() {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Optional exponent
+        if let Some(b'e' | b'E') = self.peek() {
+            self.advance();
+            if let Some(b'+' | b'-') = self.peek() {
+                self.advance();
+            }
+            while let Some(b) = self.peek() {
+                if b.is_ascii_digit() {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Skip a JSON object.
+    fn skip_object(&mut self, depth: usize) -> Result<(), ScanError> {
+        self.expect(b'{')?;
+        self.skip_whitespace();
+
+        if self.peek() == Some(b'}') {
+            self.advance();
+            return Ok(());
+        }
+
+        loop {
+            self.skip_whitespace();
+            self.skip_string()?; // key
+            self.skip_whitespace();
+            self.expect(b':')?;
+            self.skip_value_with_depth(depth + 1)?;
+            self.skip_whitespace();
+
+            match self.peek() {
+                Some(b',') => self.advance(),
+                Some(b'}') => {
+                    self.advance();
+                    return Ok(());
+                }
+                found => {
+                    return Err(ScanError::Expected {
+                        expected: b'}',
+                        found,
+                    })
+                }
+            }
+        }
+    }
+
+    /// Skip a JSON array.
+    fn skip_array(&mut self, depth: usize) -> Result<(), ScanError> {
+        self.expect(b'[')?;
+        self.skip_whitespace();
+
+        if self.peek() == Some(b']') {
+            self.advance();
+            return Ok(());
+        }
+
+        loop {
+            self.skip_value_with_depth(depth + 1)?;
+            self.skip_whitespace();
+
+            match self.peek() {
+                Some(b',') => self.advance(),
+                Some(b']') => {
+                    self.advance();
+                    return Ok(());
+                }
+                found => {
+                    return Err(ScanError::Expected {
+                        expected: b']',
+                        found,
+                    })
+                }
+            }
+        }
+    }
+
+    /// Scan a JSON object for specific tag and content fields.
+    fn scan_for_fields(
+        &mut self,
+        tag_key: &str,
+        content_key: &str,
+    ) -> Result<TaggedJsonScan<'a>, ScanError> {
+        let mut tag: Option<&'a str> = None;
+        let mut content: Option<&'a [u8]> = None;
+
+        self.skip_whitespace();
+        self.expect(b'{')?;
+
+        self.skip_whitespace();
+        if self.peek() == Some(b'}') {
+            self.advance();
+            return Ok(TaggedJsonScan { tag, content });
+        }
+
+        loop {
+            self.skip_whitespace();
+            let key = self.parse_string()?;
+            self.skip_whitespace();
+            self.expect(b':')?;
+            self.skip_whitespace();
+
+            if key == tag_key {
+                // This is the tag field - extract its string value
+                tag = Some(self.parse_string()?);
+            } else if key == content_key {
+                // This is the content field - capture raw bytes
+                let (start, end) = self.skip_value()?;
+                content = Some(&self.input[start..end]);
+            } else {
+                // Unknown field - skip it
+                self.skip_value()?;
+            }
+
+            self.skip_whitespace();
+
+            match self.peek() {
+                Some(b',') => self.advance(),
+                Some(b'}') => {
+                    self.advance();
+                    break;
+                }
+                found => {
+                    return Err(ScanError::Expected {
+                        expected: b'}',
+                        found,
+                    })
+                }
+            }
+        }
+
+        Ok(TaggedJsonScan { tag, content })
+    }
+
+    /// Scan a JSON object for multiple named fields.
+    fn scan_for_multiple_fields(
+        &mut self,
+        field_names: &[&'static str],
+    ) -> Result<heapless::LinearMap<&'static str, (usize, usize), 8>, ScanError> {
+        let mut fields: heapless::LinearMap<&'static str, (usize, usize), 8> =
+            heapless::LinearMap::new();
+
+        self.skip_whitespace();
+        self.expect(b'{')?;
+
+        self.skip_whitespace();
+        if self.peek() == Some(b'}') {
+            self.advance();
+            return Ok(fields);
+        }
+
+        loop {
+            self.skip_whitespace();
+            let key = self.parse_string()?;
+            self.skip_whitespace();
+            self.expect(b':')?;
+            self.skip_whitespace();
+
+            // Check if this is one of the fields we're looking for
+            if let Some(&field_name) = field_names.iter().find(|&&name| name == key) {
+                let (start, end) = self.skip_value()?;
+                // Ignore error from insert - map is full but we continue parsing
+                let _ = fields.insert(field_name, (start, end));
+            } else {
+                // Unknown field - skip it
+                self.skip_value()?;
+            }
+
+            self.skip_whitespace();
+
+            match self.peek() {
+                Some(b',') => self.advance(),
+                Some(b'}') => {
+                    self.advance();
+                    break;
+                }
+                found => {
+                    return Err(ScanError::Expected {
+                        expected: b'}',
+                        found,
+                    })
+                }
+            }
+        }
+
+        Ok(fields)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tag_before_content() {
+        let json = br#"{"mode": "sio", "config": {"polarity": "pnp"}}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("sio"));
+        assert_eq!(scan.content_bytes(), Some(br#"{"polarity": "pnp"}"#.as_slice()));
+    }
+
+    #[test]
+    fn test_content_before_tag() {
+        let json = br#"{"config": {"polarity": "pnp"}, "mode": "sio"}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("sio"));
+        assert_eq!(scan.content_bytes(), Some(br#"{"polarity": "pnp"}"#.as_slice()));
+    }
+
+    #[test]
+    fn test_tag_only() {
+        let json = br#"{"mode": "inactive"}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("inactive"));
+        assert_eq!(scan.content_bytes(), None);
+    }
+
+    #[test]
+    fn test_content_only() {
+        let json = br#"{"config": {"polarity": "pnp"}}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), None);
+        assert_eq!(scan.content_bytes(), Some(br#"{"polarity": "pnp"}"#.as_slice()));
+    }
+
+    #[test]
+    fn test_neither_present() {
+        let json = br#"{"other": "value"}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), None);
+        assert_eq!(scan.content_bytes(), None);
+    }
+
+    #[test]
+    fn test_empty_object() {
+        let json = br#"{}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), None);
+        assert_eq!(scan.content_bytes(), None);
+    }
+
+    #[test]
+    fn test_nested_content() {
+        let json = br#"{"mode": "complex", "config": {"nested": {"deep": [1, 2, 3]}}}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("complex"));
+        assert_eq!(
+            scan.content_bytes(),
+            Some(br#"{"nested": {"deep": [1, 2, 3]}}"#.as_slice())
+        );
+    }
+
+    #[test]
+    fn test_content_is_array() {
+        let json = br#"{"mode": "list", "config": [1, 2, 3]}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("list"));
+        assert_eq!(scan.content_bytes(), Some(br#"[1, 2, 3]"#.as_slice()));
+    }
+
+    #[test]
+    fn test_content_is_string() {
+        let json = br#"{"mode": "simple", "config": "just a string"}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("simple"));
+        assert_eq!(scan.content_bytes(), Some(br#""just a string""#.as_slice()));
+    }
+
+    #[test]
+    fn test_content_is_number() {
+        let json = br#"{"mode": "numeric", "config": 42.5}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("numeric"));
+        assert_eq!(scan.content_bytes(), Some(br#"42.5"#.as_slice()));
+    }
+
+    #[test]
+    fn test_content_is_null() {
+        let json = br#"{"mode": "nullable", "config": null}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("nullable"));
+        assert_eq!(scan.content_bytes(), Some(br#"null"#.as_slice()));
+    }
+
+    #[test]
+    fn test_content_is_bool() {
+        let json = br#"{"mode": "flag", "config": true}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("flag"));
+        assert_eq!(scan.content_bytes(), Some(br#"true"#.as_slice()));
+    }
+
+    #[test]
+    fn test_whitespace_variations() {
+        let json = br#"  {  "mode"  :  "sio"  ,  "config"  :  {  "x"  :  1  }  }  "#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("sio"));
+        assert!(scan.content_bytes().is_some());
+    }
+
+    #[test]
+    fn test_escaped_string_in_tag() {
+        let json = br#"{"mode": "with\"quote", "config": {}}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        // Note: we return the raw string including escape sequences
+        assert_eq!(scan.tag_str(), Some(r#"with\"quote"#));
+    }
+
+    #[test]
+    fn test_unicode_escape_in_tag() {
+        let json = br#"{"mode": "test\u0041", "config": {}}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some(r#"test\u0041"#));
+    }
+
+    #[test]
+    fn test_extra_fields_ignored() {
+        let json = br#"{"before": 1, "mode": "sio", "middle": true, "config": {}, "after": null}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("sio"));
+        assert_eq!(scan.content_bytes(), Some(br#"{}"#.as_slice()));
+    }
+
+    #[test]
+    fn test_error_unterminated_string() {
+        let json = br#"{"mode": "unterminated}"#;
+        let result = TaggedJsonScan::scan(json, "mode", "config");
+        assert!(matches!(result, Err(ScanError::UnterminatedString)));
+    }
+
+    #[test]
+    fn test_error_expected_object() {
+        let json = br#"["not", "an", "object"]"#;
+        let result = TaggedJsonScan::scan(json, "mode", "config");
+        assert!(matches!(result, Err(ScanError::Expected { expected: b'{', .. })));
+    }
+
+    #[test]
+    fn test_error_unexpected_eof() {
+        let json = br#"{"mode": "#;
+        let result = TaggedJsonScan::scan(json, "mode", "config");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_negative_number_in_content() {
+        let json = br#"{"mode": "num", "config": -123.45e-6}"#;
+        let scan = TaggedJsonScan::scan(json, "mode", "config").unwrap();
+
+        assert_eq!(scan.tag_str(), Some("num"));
+        assert_eq!(scan.content_bytes(), Some(br#"-123.45e-6"#.as_slice()));
+    }
+
+    // FieldScanner tests
+
+    #[test]
+    fn test_field_scanner_basic() {
+        let json = br#"{"state": {"delta": {"temp": 25}}, "version": 42}"#;
+        let scanner = FieldScanner::scan(json, &["state", "version"]).unwrap();
+
+        assert_eq!(
+            scanner.field_bytes("state"),
+            Some(br#"{"delta": {"temp": 25}}"#.as_slice())
+        );
+        assert_eq!(scanner.field_bytes("version"), Some(b"42".as_slice()));
+    }
+
+    #[test]
+    fn test_field_scanner_missing_field() {
+        let json = br#"{"state": {}, "version": 42}"#;
+        let scanner = FieldScanner::scan(json, &["state", "timestamp"]).unwrap();
+
+        assert!(scanner.has_field("state"));
+        assert!(!scanner.has_field("timestamp"));
+        assert_eq!(scanner.field_bytes("timestamp"), None);
+    }
+
+    #[test]
+    fn test_field_scanner_empty_object() {
+        let json = br#"{}"#;
+        let scanner = FieldScanner::scan(json, &["state", "version"]).unwrap();
+
+        assert!(!scanner.has_field("state"));
+        assert!(!scanner.has_field("version"));
+    }
+
+    #[test]
+    fn test_field_scanner_string_field() {
+        let json = br#"{"name": "test", "value": 123}"#;
+        let scanner = FieldScanner::scan(json, &["name", "value"]).unwrap();
+
+        assert_eq!(scanner.field_str("name"), Some("test"));
+        assert_eq!(scanner.field_str("value"), None); // not a string
+        assert_eq!(scanner.field_bytes("value"), Some(b"123".as_slice()));
+    }
+
+    #[test]
+    fn test_field_scanner_extra_fields_ignored() {
+        let json = br#"{"a": 1, "b": 2, "c": 3, "d": 4}"#;
+        let scanner = FieldScanner::scan(json, &["b", "d"]).unwrap();
+
+        assert_eq!(scanner.field_bytes("b"), Some(b"2".as_slice()));
+        assert_eq!(scanner.field_bytes("d"), Some(b"4".as_slice()));
+        assert!(!scanner.has_field("a"));
+        assert!(!scanner.has_field("c"));
+    }
+
+    #[test]
+    fn test_field_scanner_nested_object() {
+        let json = br#"{"outer": {"inner": {"deep": [1, 2, 3]}}}"#;
+        let scanner = FieldScanner::scan(json, &["outer"]).unwrap();
+
+        assert_eq!(
+            scanner.field_bytes("outer"),
+            Some(br#"{"inner": {"deep": [1, 2, 3]}}"#.as_slice())
+        );
+    }
+
+    #[test]
+    fn test_field_scanner_all_json_types() {
+        let json = br#"{"str": "hello", "num": 42, "bool": true, "null": null, "arr": [1], "obj": {}}"#;
+        let scanner =
+            FieldScanner::scan(json, &["str", "num", "bool", "null", "arr", "obj"]).unwrap();
+
+        assert_eq!(scanner.field_bytes("str"), Some(br#""hello""#.as_slice()));
+        assert_eq!(scanner.field_bytes("num"), Some(b"42".as_slice()));
+        assert_eq!(scanner.field_bytes("bool"), Some(b"true".as_slice()));
+        assert_eq!(scanner.field_bytes("null"), Some(b"null".as_slice()));
+        assert_eq!(scanner.field_bytes("arr"), Some(b"[1]".as_slice()));
+        assert_eq!(scanner.field_bytes("obj"), Some(b"{}".as_slice()));
+    }
+
+    #[test]
+    fn test_field_scanner_whitespace() {
+        let json = br#"  {  "a"  :  1  ,  "b"  :  2  }  "#;
+        let scanner = FieldScanner::scan(json, &["a", "b"]).unwrap();
+
+        assert_eq!(scanner.field_bytes("a"), Some(b"1".as_slice()));
+        assert_eq!(scanner.field_bytes("b"), Some(b"2".as_slice()));
+    }
+}

--- a/tests/metric.rs
+++ b/tests/metric.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "metric_cbor")]
+
 //! ## Integration test of `AWS IoT Device defender metrics`
 //!
 //!

--- a/tests/provisioning.rs
+++ b/tests/provisioning.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "provision_cbor")]
 #![allow(async_fn_in_trait)]
 #![feature(type_alias_impl_trait)]
 

--- a/tests/shadows.rs
+++ b/tests/shadows.rs
@@ -11,21 +11,95 @@ use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use mqttrust::transport::embedded_nal::NalTransport;
 use mqttrust::{Config, DomainBroker, Publish, State, Subscribe, SubscribeTopic};
 use postcard::experimental::max_size::MaxSize;
-use rustot_derive::shadow_root;
+use rustot_derive::{shadow_node, shadow_root};
 use serde::{Deserialize, Serialize};
 use static_cell::StaticCell;
 
 use rustot::shadows::{FileKVStore, Shadow};
 
 // =============================================================================
-// Test Shadow Type
+// Test Shadow Types
 // =============================================================================
 
+/// Nested struct field
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+pub struct Inner {
+    pub value: u32,
+    pub flag: bool,
+}
+
+/// Config for internally-tagged single variant
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+pub struct SingleConfig {
+    pub x: u8,
+}
+
+/// Config for internally-tagged pair variant
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+pub struct PairConfig {
+    pub x: u8,
+    pub y: u8,
+}
+
+/// Regular internally-tagged enum with data variants
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TaggedEnum {
+    #[default]
+    None,
+    Single(SingleConfig),
+    Pair(PairConfig),
+}
+
+/// Config for variant A of the adjacently-tagged enum
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+pub struct ConfigA {
+    pub alpha: bool,
+    pub beta: u16,
+}
+
+/// Config for variant B of the adjacently-tagged enum
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+pub struct ConfigB {
+    pub gamma: u32,
+    pub delta: u16,
+}
+
+/// Adjacently-tagged enum - tests variant fallback when tag is missing
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+#[serde(tag = "mode", content = "config", rename_all = "snake_case")]
+pub enum Adjacent {
+    #[default]
+    Off,
+    ModeA(ConfigA),
+    ModeB(ConfigB),
+}
+
+/// Main test shadow covering all field types
 #[shadow_root(name = "state")]
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
 pub struct TestShadow {
-    pub foo: u32,
-    pub bar: bool,
+    /// Primitive fields
+    pub count: u32,
+    pub active: bool,
+
+    /// Nested struct
+    pub inner: Inner,
+
+    /// Regular internally-tagged enum
+    pub tagged: TaggedEnum,
+
+    /// Adjacently-tagged enum (key test: config-only delta uses variant fallback)
+    pub adjacent: Adjacent,
+
+    /// Report-only field
     #[shadow_attr(report_only)]
     pub version: u32,
 }
@@ -183,79 +257,168 @@ async fn test_shadow_end_to_end() {
         let shadow = Shadow::<TestShadow, _, FileKVStore>::new(&kv, &client);
 
         // =====================================================================
-        // Step 2: Load shadow → initializes defaults, persists to file store
+        // Setup: Load and sync shadow
         // =====================================================================
         let load_result = shadow.load().await.expect("Failed to load shadow");
         log::info!("Load result: first_boot={}", load_result.first_boot);
         assert!(load_result.first_boot);
 
-        // =====================================================================
-        // Step 3: Delete shadow from cloud (ignore NotFound)
-        // =====================================================================
+        // Delete any existing shadow from previous test runs
         match shadow.delete_shadow().await {
             Ok(()) => log::info!("Deleted existing shadow from cloud"),
             Err(e) => log::info!("Delete shadow (expected if not found): {:?}", e),
         }
 
-        // =====================================================================
-        // Step 4: Sync shadow → creates shadow with defaults, subscribes to delta
-        // =====================================================================
-        let state_val = shadow.sync_shadow().await.expect("Failed to sync shadow");
-        log::info!("Synced shadow: {:?}", state_val);
+        // Sync creates shadow with defaults
+        let state = shadow.sync_shadow().await.expect("Failed to sync shadow");
+        log::info!("Synced shadow: {:?}", state);
+
+        // Assert defaults
+        assert_eq!(state.count, 0);
+        assert_eq!(state.active, false);
+        assert_eq!(state.inner, Inner::default());
+        assert_eq!(state.tagged, TaggedEnum::None);
+        assert_eq!(state.adjacent, Adjacent::Off);
 
         // =====================================================================
-        // Step 5: Assert defaults
+        // Test 1: Primitive fields (count, active)
         // =====================================================================
-        assert_eq!(state_val.foo, 0);
-        assert_eq!(state_val.bar, false);
+        log::info!("Test 1: Updating primitive fields...");
+        cloud_update_desired(
+            &client,
+            thing_name,
+            br#"{"state":{"desired":{"count":42,"active":true}}}"#,
+        )
+        .await
+        .expect("Failed to update primitives");
+
+        let (state, delta) = shadow.wait_delta().await.expect("Failed to wait_delta");
+        assert!(delta.is_some());
+        assert_eq!(state.count, 42);
+        assert_eq!(state.active, true);
+        log::info!("Test 1 passed: primitives updated");
 
         // =====================================================================
-        // Step 6: Cloud updates desired foo=42
+        // Test 2: Nested struct (inner)
         // =====================================================================
-        log::info!("Cloud updating desired foo=42...");
-        cloud_update_desired(&client, thing_name, br#"{"state":{"desired":{"foo":42}}}"#)
-            .await
-            .expect("Failed to update desired foo");
+        log::info!("Test 2: Updating nested struct...");
+        cloud_update_desired(
+            &client,
+            thing_name,
+            br#"{"state":{"desired":{"inner":{"value":100,"flag":true}}}}"#,
+        )
+        .await
+        .expect("Failed to update nested struct");
+
+        let (state, delta) = shadow.wait_delta().await.expect("Failed to wait_delta");
+        assert!(delta.is_some());
+        assert_eq!(state.inner.value, 100);
+        assert_eq!(state.inner.flag, true);
+        log::info!("Test 2 passed: nested struct updated");
 
         // =====================================================================
-        // Step 7: Wait for delta → receives foo delta, applies, persists, acknowledges
+        // Test 3: Regular internally-tagged enum
         // =====================================================================
-        log::info!("Waiting for delta...");
-        let (state_val, delta) = shadow
-            .wait_delta()
-            .await
-            .expect("Failed to wait_delta (foo)");
-        log::info!(
-            "Got foo delta: has_delta={}, state: {:?}",
-            delta.is_some(),
-            state_val
+        log::info!("Test 3: Updating internally-tagged enum...");
+        cloud_update_desired(
+            &client,
+            thing_name,
+            br#"{"state":{"desired":{"tagged":{"kind":"pair","x":10,"y":20}}}}"#,
+        )
+        .await
+        .expect("Failed to update tagged enum");
+
+        let (state, delta) = shadow.wait_delta().await.expect("Failed to wait_delta");
+        assert!(delta.is_some());
+        assert_eq!(state.tagged, TaggedEnum::Pair(PairConfig { x: 10, y: 20 }));
+        log::info!("Test 3 passed: internally-tagged enum updated");
+
+        // =====================================================================
+        // Test 4: Adjacently-tagged enum - mode + config together
+        // =====================================================================
+        log::info!("Test 4: Updating adjacently-tagged enum (mode + config)...");
+        cloud_update_desired(
+            &client,
+            thing_name,
+            br#"{"state":{"desired":{"adjacent":{"mode":"mode_a","config":{"alpha":true,"beta":500}}}}}"#,
+        )
+        .await
+        .expect("Failed to update adjacent enum");
+
+        let (state, delta) = shadow.wait_delta().await.expect("Failed to wait_delta");
+        assert!(delta.is_some());
+        assert_eq!(
+            state.adjacent,
+            Adjacent::ModeA(ConfigA {
+                alpha: true,
+                beta: 500
+            })
         );
+        log::info!("Test 4 passed: adjacently-tagged enum with mode+config");
 
         // =====================================================================
-        // Step 8: Assert foo updated
+        // Test 5: Adjacently-tagged enum - config only (variant fallback)
+        // This is the key test: cloud sends only config, device uses current mode
         // =====================================================================
-        assert_eq!(state_val.foo, 42);
-        assert_eq!(state_val.bar, false);
+        log::info!("Test 5: Updating adjacently-tagged config only (variant fallback)...");
+        cloud_update_desired(
+            &client,
+            thing_name,
+            // Note: no "mode" field, only "config" - device must use current mode (mode_a)
+            br#"{"state":{"desired":{"adjacent":{"config":{"alpha":false,"beta":999}}}}}"#,
+        )
+        .await
+        .expect("Failed to update adjacent config only");
+
+        let (state, delta) = shadow.wait_delta().await.expect("Failed to wait_delta");
+        assert!(delta.is_some());
+        // Should still be ModeA, with updated config
+        assert_eq!(
+            state.adjacent,
+            Adjacent::ModeA(ConfigA {
+                alpha: false,
+                beta: 999
+            })
+        );
+        log::info!("Test 5 passed: config-only delta used variant fallback");
 
         // =====================================================================
-        // Step 9: Report version=1 to cloud (report_only field)
+        // Test 6: Adjacently-tagged enum - switch to different mode
         // =====================================================================
-        log::info!("Reporting version=1...");
+        log::info!("Test 6: Switching adjacently-tagged to different mode...");
+        cloud_update_desired(
+            &client,
+            thing_name,
+            br#"{"state":{"desired":{"adjacent":{"mode":"mode_b","config":{"gamma":12345,"delta":42}}}}}"#,
+        )
+        .await
+        .expect("Failed to switch adjacent mode");
+
+        let (state, delta) = shadow.wait_delta().await.expect("Failed to wait_delta");
+        assert!(delta.is_some());
+        assert_eq!(
+            state.adjacent,
+            Adjacent::ModeB(ConfigB {
+                gamma: 12345,
+                delta: 42
+            })
+        );
+        log::info!("Test 6 passed: switched to different mode");
+
+        // =====================================================================
+        // Test 7: Report-only field
+        // =====================================================================
+        log::info!("Test 7: Reporting version (report_only)...");
         shadow
             .update(|_, r| {
                 r.version = Some(1);
             })
             .await
-            .expect("Failed to update reported version");
+            .expect("Failed to report version");
 
-        // =====================================================================
-        // Step 10: Cloud get shadow → assert reported.version == 1
-        // =====================================================================
-        log::info!("Getting shadow document from cloud...");
         let doc = cloud_get_shadow(&client, thing_name)
             .await
             .expect("Failed to get shadow");
-        log::info!("Shadow document: {}", doc);
 
         let reported_version = doc["state"]["reported"]["version"]
             .as_u64()
@@ -263,50 +426,15 @@ async fn test_shadow_end_to_end() {
         assert_eq!(reported_version, 1);
 
         // version should NOT generate a delta (it's report_only)
-        assert!(
-            doc["state"]["delta"].is_null()
-                || doc["state"].get("delta").is_none()
-                || !doc["state"]["delta"]
-                    .as_object()
-                    .map(|d| d.contains_key("version"))
-                    .unwrap_or(false),
-            "version should not appear in delta (report_only)"
-        );
+        let has_version_delta = doc["state"]["delta"]
+            .as_object()
+            .map(|d| d.contains_key("version"))
+            .unwrap_or(false);
+        assert!(!has_version_delta, "version should not appear in delta");
+        log::info!("Test 7 passed: report_only field works");
 
         // =====================================================================
-        // Step 11: Cloud updates desired bar=true
-        // =====================================================================
-        log::info!("Cloud updating desired bar=true...");
-        cloud_update_desired(
-            &client,
-            thing_name,
-            br#"{"state":{"desired":{"bar":true}}}"#,
-        )
-        .await
-        .expect("Failed to update desired bar");
-
-        // =====================================================================
-        // Step 12: Wait for delta → receives bar delta
-        // =====================================================================
-        log::info!("Waiting for delta (bar)...");
-        let (state_val, delta) = shadow
-            .wait_delta()
-            .await
-            .expect("Failed to wait_delta (bar)");
-        log::info!(
-            "Got bar delta: has_delta={}, state: {:?}",
-            delta.is_some(),
-            state_val
-        );
-
-        // =====================================================================
-        // Step 13: Assert both fields updated
-        // =====================================================================
-        assert_eq!(state_val.foo, 42);
-        assert_eq!(state_val.bar, true);
-
-        // =====================================================================
-        // Step 14: Assert temp dir contains persisted files
+        // Verify persistence
         // =====================================================================
         let entries: Vec<_> = std::fs::read_dir(kv.base_path())
             .expect("Failed to read temp dir")
@@ -314,37 +442,29 @@ async fn test_shadow_end_to_end() {
         log::info!("FileKVStore has {} files", entries.len());
         assert!(
             !entries.is_empty(),
-            "FileKVStore temp dir should contain persisted files"
+            "FileKVStore should have persisted files"
         );
 
         // =====================================================================
-        // Step 15: Delete shadow → delete from cloud, reset store to defaults
+        // Cleanup
         // =====================================================================
-        log::info!("Deleting shadow...");
+        log::info!("Cleaning up...");
         shadow
             .delete_shadow()
             .await
             .expect("Failed to delete shadow");
 
-        // =====================================================================
-        // Step 16: Assert state loaded from store == defaults
-        // =====================================================================
-        let state_val = shadow
+        let state = shadow
             .state()
             .await
             .expect("Failed to get state after delete");
-        assert_eq!(state_val.foo, 0);
-        assert_eq!(state_val.bar, false);
-        assert_eq!(state_val.version, 0);
+        assert_eq!(state, TestShadow::default());
 
-        // =====================================================================
-        // Step 17: Remove temp dir, assert removal succeeded
-        // =====================================================================
         let temp_path = kv.base_path().to_owned();
         std::fs::remove_dir_all(&temp_path).expect("Failed to remove temp dir");
         assert!(!temp_path.exists(), "Temp dir should be removed");
 
-        log::info!("Shadow integration test passed!");
+        log::info!("All shadow integration tests passed!");
         Ok::<_, Box<dyn std::error::Error>>(())
     };
 

--- a/tests/shadows.rs
+++ b/tests/shadows.rs
@@ -1,5 +1,7 @@
 #![cfg(all(feature = "std", feature = "shadows_kv_persist"))]
 #![allow(async_fn_in_trait)]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
 #![feature(type_alias_impl_trait)]
 
 mod common;


### PR DESCRIPTION
Overhauls `rustot_derive` codegen for clarity and correctness, and adds full support for adjacently-tagged serde enums (`#[serde(tag = "...", content = "...")]`) in the shadow system — including delta parsing, KV persistence, and commit GC.

The derive macro internals have been restructured: attribute parsing now uses [Darling](https://github.com/TedDriggs/darling) instead of hand-rolled parsing, case conversion uses `heck`, shared codegen helpers are extracted into dedicated modules (`kv_codegen`, `helpers`), and enum method bodies are deduplicated across variants.

A new zero-allocation `TaggedJsonScan` parser handles adjacently-tagged enum deserialization without requiring `alloc` — serde's built-in adjacently-tagged support buffers content when field order varies, which needs an allocator. The scanner extracts tag and content fields in a single pass, then deserializes content with known type info.

KV persistence now uses associated `ValueBuf`/`KeyBuf` types instead of requiring `Default` on const-generic arrays (which Rust's type system doesn't support for `[u8; N + K]` expressions). Opaque fields only require `MaxSize`, not full `KVPersist`. `report_only` fields are fully excluded from KV codegen.

## Changelog

- Add `parse_delta` for adjacently-tagged enum deserialization with `VariantResolver` trait
- Add `TaggedJsonScan` and `FieldScanner` zero-alloc JSON scanners in `tag_scanner` module
- Add `into_partial_reported` for efficient delta acknowledgement (replaces `into_reported`)
- Add commit GC tests for map and adjacently-tagged enum types
- Add `From<State>` for `Reported`; exclude `report_only` fields from state struct
- Refactor `KVPersist` to use associated `ValueBuf`/`KeyBuf` types
- Refactor derive macro to use Darling for attribute parsing and `heck` for case conversion
- Extract shared enum KV helpers into `kv_codegen` module
- Reduce codegen duplication across struct/enum/adjacently-tagged generators
- Make opaque fields require only `MaxSize` instead of `KVPersist`
- Fix `kv_persist` feature gating and clippy warnings
- Fix MQTT topic buffer overflow and reduce `parse_delta` stack usage
- Fix `clippy::manual_strip` in generated `variant_at_path` code
- Route derive macro imports through `__macro_support`
- Add `serde_json` as optional dependency for `std` feature
- Clean up unused lifetimes and simplify async fn signatures