### PR TITLE
Detect OTA job cancellation during download via notify-next

### DIFF
--- a/src/ota/data_interface/mqtt.rs
+++ b/src/ota/data_interface/mqtt.rs
@@ -4,6 +4,7 @@ use core::str::FromStr;
 
 use crate::mqtt::{Mqtt, MqttClient, MqttMessage, MqttSubscription, QoS};
 
+use crate::jobs::JobTopic;
 use crate::ota::error::OtaError;
 use crate::ota::status_details::StatusDetailsExt;
 use crate::ota::ProgressState;
@@ -143,7 +144,15 @@ pub struct MqttTransfer<S>(S);
 
 impl<S: MqttSubscription> BlockTransfer for MqttTransfer<S> {
     async fn next_block(&mut self) -> Result<Option<impl DerefMut<Target = [u8]>>, OtaError> {
-        Ok(self.0.next_message().await.map(MessagePayload))
+        match self.0.next_message().await {
+            Some(msg) => {
+                if !msg.topic_name().contains("/streams/") {
+                    return Err(OtaError::UserAbort);
+                }
+                Ok(Some(MessagePayload(msg)))
+            }
+            None => Ok(None),
+        }
     }
 }
 
@@ -151,22 +160,33 @@ impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {
     const PROTOCOL: Protocol = Protocol::Mqtt;
 
     type ActiveTransfer<'t>
-        = MqttTransfer<C::Subscription<'t, 1>>
+        = MqttTransfer<C::Subscription<'t, 2>>
     where
         Self: 't;
 
     /// Init file transfer by subscribing to the OTA data stream topic
+    /// and the jobs notify-next topic (to detect cancellation).
     async fn init_file_transfer(
         &self,
         file_ctx: &FileContext,
     ) -> Result<Self::ActiveTransfer<'_>, OtaError> {
-        let topic_path = OtaTopic::Data(Encoding::Cbor, file_ctx.stream_name.as_str())
+        let data_topic = OtaTopic::Data(Encoding::Cbor, file_ctx.stream_name.as_str())
             .format::<256>(self.0.client_id())?;
 
-        debug!("Subscribing to: [{:?}]", &topic_path);
+        let notify_topic: heapless::String<256> = JobTopic::NotifyNext
+            .format::<256>(self.0.client_id())
+            .map_err(|_| OtaError::Overflow)?;
+
+        debug!(
+            "Subscribing to: [{:?}] and [{:?}]",
+            &data_topic, &notify_topic
+        );
 
         self.0
-            .subscribe(&[(topic_path.as_str(), QoS::AtMostOnce)])
+            .subscribe(&[
+                (data_topic.as_str(), QoS::AtMostOnce),
+                (notify_topic.as_str(), QoS::AtMostOnce),
+            ])
             .await
             .map(MqttTransfer)
             .map_err(|_| OtaError::Mqtt)

--- a/src/ota/error.rs
+++ b/src/ota/error.rs
@@ -25,6 +25,7 @@ pub enum OtaError {
     Encoding,
     Pal(OtaPalError),
     Timeout,
+    UserAbort,
 }
 
 impl OtaError {

--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -220,9 +220,8 @@ impl Updater {
                             break;
                         }
 
-                        // Handle status update future results
                         Err(e) => {
-                            error!("Status update error: {:?}", e);
+                            error!("Block transfer error: {:?}", e);
                             return Err(e);
                         }
                     }
@@ -270,6 +269,17 @@ impl Updater {
                     .await?;
 
                 Err(error::OtaError::MomentumAbort)
+            }
+            Err(error::OtaError::UserAbort) => {
+                warn!("[OTA] Job cancelled (detected via notification)");
+                job_updater
+                    .set_image_state_with_reason(
+                        pal,
+                        ImageState::Aborted(ImageStateReason::UserAbort),
+                    )
+                    .await?;
+
+                Err(error::OtaError::UserAbort)
             }
             Err(e) => {
                 // Signal the error status, preserving the failure reason if available

--- a/tests/ota_mqtt.rs
+++ b/tests/ota_mqtt.rs
@@ -385,7 +385,7 @@ async fn run_ota_cancel(
 
     static STATE: StaticCell<State<NoopRawMutex, 4096, { 4096 * 20 }>> = StaticCell::new();
     let state = STATE.init(State::new());
-    let (mut stack, client) = embedded_mqtt::new(state, config);
+    let (mut stack, client) = mqttrust::new(state, config);
 
     let mut file_handler = FileHandler::new("tests/assets/ota_file".to_owned());
 

--- a/tests/ota_mqtt.rs
+++ b/tests/ota_mqtt.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 use serial_test::serial;
 use static_cell::StaticCell;
 
+use aws_credential_types::provider::SharedCredentialsProvider;
 use rustot::{
     jobs::{
         self,
@@ -296,6 +297,208 @@ async fn test_mqtt_ota_signature_failure() {
             std::panic::resume_unwind(panic);
         }
     }
+}
+
+/// Test OTA cancel mid-download — verifies device detects cancellation.
+///
+/// When an in-progress OTA job is force-cancelled from the cloud, the device
+/// execution transitions to CANCELED and AWS IoT sends a `notify-next`
+/// notification. The device detects this via its subscription to the
+/// notify-next topic and aborts the download with `UserAbort`.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_mqtt_ota_cancel() {
+    let _ = env_logger::Builder::from_default_env()
+        .filter_module("serial_test", log::LevelFilter::Warn)
+        .try_init();
+
+    log::info!("Starting OTA cancel test...");
+
+    let ctx = match common::aws_ota::setup().await {
+        Some(ctx) => ctx,
+        None => {
+            log::info!(
+                "Skipping OTA cancel test: no valid AWS credentials or role assumption failed"
+            );
+            return;
+        }
+    };
+
+    let job_id = ctx.job_id().to_owned();
+    let iot_creds = ctx.iot_creds();
+    let region = ctx.region().clone();
+
+    let test_result =
+        common::aws_ota::catch_unwind_future(run_ota_cancel(job_id, iot_creds, region)).await;
+
+    // Capture cloud-side status before cleanup
+    let cloud_status = ctx.describe_job_execution().await;
+
+    // Always cleanup
+    ctx.cleanup().await;
+
+    match test_result {
+        Ok(inner) => {
+            inner.unwrap();
+            // Assert cloud-side job is CANCELED (force-cancel transitions immediately)
+            let (status, details) = cloud_status.expect("Failed to describe job execution");
+            assert_eq!(
+                status,
+                aws_sdk_iot::types::JobExecutionStatus::Canceled,
+                "Expected cloud job status CANCELED, got {:?} with details: {:?}",
+                status,
+                details
+            );
+        }
+        Err(panic) => {
+            if let Ok((status, details)) = &cloud_status {
+                log::error!(
+                    "Test panicked! Cloud job status at panic: {:?}, details: {:?}",
+                    status,
+                    details
+                );
+            }
+            std::panic::resume_unwind(panic);
+        }
+    }
+}
+
+async fn run_ota_cancel(
+    job_id: String,
+    iot_creds: SharedCredentialsProvider,
+    region: aws_config::Region,
+) -> Result<(), ota::error::OtaError> {
+    let (thing_name, identity) = credentials::identity();
+
+    let hostname = credentials::HOSTNAME.unwrap();
+
+    static NETWORK: StaticCell<TlsNetwork> = StaticCell::new();
+    let network = NETWORK.init(TlsNetwork::new(hostname.to_owned(), identity));
+
+    // Create the MQTT stack
+    let broker =
+        DomainBroker::<_, 128>::new(format!("{}:8883", hostname).as_str(), network).unwrap();
+    let config = Config::builder()
+        .client_id(thing_name.try_into().unwrap())
+        .keepalive_interval(embassy_time::Duration::from_secs(50))
+        .build();
+
+    static STATE: StaticCell<State<NoopRawMutex, 4096, { 4096 * 20 }>> = StaticCell::new();
+    let state = STATE.init(State::new());
+    let (mut stack, client) = embedded_mqtt::new(state, config);
+
+    let mut file_handler = FileHandler::new("tests/assets/ota_file".to_owned());
+
+    let ota_fut = async {
+        let mut jobs_subscription = client
+            .subscribe::<2>(
+                Subscribe::builder()
+                    .topics(&[
+                        SubscribeTopic::builder()
+                            .topic_path(
+                                jobs::JobTopic::NotifyNext
+                                    .format::<64>(thing_name)?
+                                    .as_str(),
+                            )
+                            .build(),
+                        SubscribeTopic::builder()
+                            .topic_path(
+                                jobs::JobTopic::DescribeAccepted("$next")
+                                    .format::<64>(thing_name)?
+                                    .as_str(),
+                            )
+                            .build(),
+                    ])
+                    .build(),
+            )
+            .await
+            .map_err(|_| ota::error::OtaError::Mqtt)?;
+
+        let mqtt = Mqtt(&client);
+        Updater::check_for_job(&mqtt).await?;
+
+        // Use small block_size + max_blocks_per_request=1 to slow down the
+        // download, giving us a comfortable window to cancel the job
+        // mid-transfer. With block_size=1024 the 386KB file needs ~378 blocks
+        // (~29s at 1 block/request), so cancelling at 3s leaves plenty of
+        // blocks remaining for the device to detect the cancellation.
+        let ota_config = ota::config::Config {
+            block_size: 1024,
+            max_blocks_per_request: 1,
+            ..Default::default()
+        };
+
+        let message = jobs_subscription.next_message().await.unwrap();
+
+        if let Some(file_ctx) = handle_ota(message, &ota_config) {
+            jobs_subscription.unsubscribe().await.unwrap();
+
+            // Run OTA and cancel concurrently
+            let ota_future =
+                Updater::perform_ota(&mqtt, &mqtt, file_ctx, &mut file_handler, &ota_config);
+
+            let cancel_future = async {
+                // Wait for download to start, then force-cancel
+                embassy_time::Timer::after(embassy_time::Duration::from_secs(3)).await;
+                log::info!("Force-cancelling job {} from cloud...", job_id);
+                common::aws_ota::force_cancel_job(&job_id, &iot_creds, &region)
+                    .await
+                    .expect("Failed to force-cancel job");
+            };
+
+            // Wrap in a timeout — if perform_ota doesn't detect cancel, it
+            // will complete the download normally (proving the device doesn't
+            // handle cancellation)
+            let result = embassy_time::with_timeout(
+                embassy_time::Duration::from_secs(60),
+                embassy_futures::join::join(ota_future, cancel_future),
+            )
+            .await;
+
+            match result {
+                Ok((ota_result, ())) => {
+                    // perform_ota returned — it should have detected the cancel
+                    // and returned an error, not completed successfully
+                    assert!(
+                        ota_result.is_err(),
+                        "perform_ota should detect job cancellation and return an error, \
+                         but it completed successfully — the device did not handle the cancel"
+                    );
+                    log::info!(
+                        "perform_ota detected cancellation as expected: {:?}",
+                        ota_result.err()
+                    );
+                }
+                Err(_timeout) => {
+                    panic!(
+                        "perform_ota timed out at 60s — device neither completed \
+                         nor detected the cancellation"
+                    );
+                }
+            }
+
+            return Ok(());
+        }
+
+        Ok::<_, ota::error::OtaError>(())
+    };
+
+    let mut transport = NalTransport::new(network, broker);
+
+    match embassy_time::with_timeout(
+        embassy_time::Duration::from_secs(120),
+        select::select(stack.run(&mut transport), ota_fut),
+    )
+    .await
+    .unwrap()
+    {
+        select::Either::First(_) => {
+            unreachable!()
+        }
+        select::Either::Second(result) => result.unwrap(),
+    };
+
+    Ok(())
 }
 
 async fn run_ota_signature_failure() -> Result<(), ota::error::OtaError> {


### PR DESCRIPTION
## Summary

Enables the device to detect cloud-initiated OTA job cancellations while a file transfer is in progress. Previously, a force-cancelled job would go unnoticed until the download completed or timed out. The device now co-subscribes to the AWS IoT Jobs `notify-next` topic during download and immediately aborts when a job state change notification arrives.

During `init_file_transfer()`, the MQTT data interface subscribes to **two** topics:

1. The OTA data stream topic (for file blocks)
2. `$aws/things/{thingName}/jobs/notify-next` (for job state change notifications)

In `next_block()`, incoming messages are checked: if a message arrives on a topic that doesn't contain `/streams/` (i.e., a notify-next message rather than a data block), the download returns `OtaError::UserAbort`. The OTA state machine handles this by setting the image state to `Aborted(ImageStateReason::UserAbort)` and cleanly terminating.

## Changelog

- Subscribe to both OTA data stream and jobs notify-next topic during file transfer
- Increase MQTT subscription count from 1 to 2 in `MqttTransfer`
- Detect non-data-stream messages as job cancellation signals, return `OtaError::UserAbort`
- Handle `UserAbort` in OTA state machine with `Aborted(ImageStateReason::UserAbort)` image state
- Add `test_mqtt_ota_cancel` integration test with force-cancellation after 3 seconds