### PR TITLE
Fix flaky OTA test: stale notify-next during block transfer

### DIFF
--- a/src/ota/data_interface/mqtt.rs
+++ b/src/ota/data_interface/mqtt.rs
@@ -141,16 +141,35 @@ impl<M: MqttMessage> DerefMut for MessagePayload<M> {
     }
 }
 
-pub struct MqttTransfer<S>(S);
+pub struct MqttTransfer<S> {
+    sub: S,
+    job_name: heapless::String<64>,
+}
 
 impl<S: MqttSubscription> BlockTransfer for MqttTransfer<S> {
     async fn next_block(&mut self) -> Result<Option<impl DerefMut<Target = [u8]>>, OtaError> {
-        match self.0.next_message().await {
+        match self.sub.next_message().await {
             Some(msg) => {
-                if !msg.topic_name().contains("/streams/") {
-                    return Err(OtaError::UserAbort);
+                if msg.topic_name().contains("/streams/") {
+                    return Ok(Some(MessagePayload(msg)));
                 }
-                Ok(Some(MessagePayload(msg)))
+
+                // Non-stream message on the merged subscription (notify-next).
+                // Only treat it as cancellation if our job name is absent from
+                // the payload — that means execution is null (job gone) or a
+                // different job replaced ours. A status update for the same job
+                // (e.g. InProgress) still contains the job name and is harmless;
+                // return Ok(None) to trigger a resubscribe cycle in the caller.
+                if msg
+                    .payload()
+                    .windows(self.job_name.len())
+                    .any(|w| w == self.job_name.as_bytes())
+                {
+                    debug!("Ignoring notify-next status update for current job");
+                    Ok(None)
+                } else {
+                    Err(OtaError::UserAbort)
+                }
             }
             None => Ok(None),
         }
@@ -183,13 +202,14 @@ impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {
             &data_topic, &notify_topic
         );
 
+        let job_name = file_ctx.job_name.clone();
         self.0
             .subscribe(&[
                 (data_topic.as_str(), QoS::AtMostOnce),
                 (notify_topic.as_str(), QoS::AtMostOnce),
             ])
             .await
-            .map(MqttTransfer)
+            .map(|sub| MqttTransfer { sub, job_name })
             .map_err(|_| OtaError::Mqtt)
     }
 


### PR DESCRIPTION
## Summary

- `MqttTransfer::next_block` treated any non-stream message (notify-next) as a job cancellation (`UserAbort`). This is too aggressive — a notify-next can also be a benign status update for the *current* job (e.g., transition to InProgress after the first `perform_ota` completes).
- When `test_mqtt_ota` calls `perform_ota` twice (simulating self-test boot), the first call's final status update triggers a notify-next that the second call's block transfer picks up, causing a spurious `UserAbort`.
- Fix: store the job name in `MqttTransfer` and check the notify-next payload. If our job name is present, it's a status update — return `Ok(None)` to trigger a resubscribe cycle. Only return `UserAbort` when the job name is absent (execution null or replaced by a different job).