### PR TITLE
Add builder-based multi-shadow API, from_ipc, and multi_shadow_root derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ log = ["dep:log"]
 
 # Multi-shadow manager (runtime-named shadows with wildcard subscriptions)
 # Requires std for tokio, AWS SDK, etc.
-shadows_multi = ["std", "dep:aws-config", "dep:aws-sdk-iotdataplane", "dep:uuid", "tokio/time"]
+shadows_multi = ["std", "dep:aws-config", "dep:aws-sdk-iotdataplane", "dep:uuid", "tokio/time", "rustot-derive/multi"]
 
 # MQTT client implementations (all optional, feature-gated)
 mqttrust = ["dep:mqttrust"]

--- a/rustot_derive/Cargo.toml
+++ b/rustot_derive/Cargo.toml
@@ -19,6 +19,8 @@ kv_persist = []
 std = []
 # When enabled, generates bon-based builder methods (desired(), reported()) on shadow structs
 builders = []
+# When enabled, generates the #[multi_shadow_root] attribute macro
+multi = []
 
 [dependencies]
 syn = { version = "2", features = ["extra-traits"] }

--- a/rustot_derive/src/attr/mod.rs
+++ b/rustot_derive/src/attr/mod.rs
@@ -7,4 +7,6 @@ pub use field_attr::{
     apply_rename_all, get_serde_rename, get_serde_rename_all, get_serde_tag_content,
     get_variant_serde_name, has_default_attr, FieldAttrs,
 };
+#[cfg(feature = "multi")]
+pub use shadow_attr::MultiShadowRootParams;
 pub use shadow_attr::{ShadowNodeParams, ShadowRootParams};

--- a/rustot_derive/src/attr/shadow_attr.rs
+++ b/rustot_derive/src/attr/shadow_attr.rs
@@ -17,6 +17,23 @@ pub struct ShadowRootParams {
     pub max_payload_len: Option<usize>,
 }
 
+/// Parameters for the #[multi_shadow_root(pattern = "...")] macro
+///
+/// This macro marks a struct as a multi-shadow root with pattern-based naming.
+/// It implements both `MultiShadowRoot` and `ShadowNode` traits.
+#[cfg(feature = "multi")]
+#[derive(FromMeta)]
+pub struct MultiShadowRootParams {
+    /// Shadow pattern prefix (e.g., "flow-" matches "flow-pump-01", "flow-valve-02")
+    pub pattern: String,
+    /// Topic prefix for MQTT topics (e.g., "$aws" for AWS IoT)
+    #[darling(default)]
+    pub topic_prefix: Option<String>,
+    /// Maximum payload size for shadow documents
+    #[darling(default)]
+    pub max_payload_len: Option<usize>,
+}
+
 /// Parameters for the #[shadow_node] macro (no parameters currently)
 ///
 /// This macro marks a struct or enum as a nested shadow type with KV persistence

--- a/rustot_derive/src/lib.rs
+++ b/rustot_derive/src/lib.rs
@@ -6,6 +6,8 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::DeriveInput;
 
+#[cfg(feature = "multi")]
+use attr::MultiShadowRootParams;
 use attr::{FieldAttrs, ShadowNodeParams, ShadowRootParams};
 use codegen::generate_shadow_node;
 
@@ -115,6 +117,41 @@ pub fn shadow_node(
         .into()
 }
 
+/// The `#[multi_shadow_root(pattern = "...")]` attribute macro for multi-shadow root types.
+///
+/// This is the multi-shadow counterpart to [`shadow_root`]. It generates:
+/// - `MultiShadowRoot` trait implementation (includes the shadow pattern)
+/// - `ShadowNode` trait implementation (persistence support)
+/// - `Delta{Name}` struct for applying partial updates
+/// - `Reported{Name}` struct with serde skip_serializing_if
+/// - `ReportedUnionFields` implementation
+/// - `desired()` / `reported()` builder methods (requires `shadows_builders` feature)
+///
+/// # Attributes
+///
+/// - `pattern = "string"` - Shadow pattern prefix (e.g., "flow-" for "flow-pump-01")
+///
+/// # Example
+///
+/// ```ignore
+/// #[multi_shadow_root(pattern = "flow-")]
+/// #[derive(Clone, Default, Serialize, Deserialize)]
+/// struct FlowState {
+///     pub flow_rate: f64,
+///     pub temperature: f64,
+/// }
+/// ```
+#[cfg(feature = "multi")]
+#[proc_macro_attribute]
+pub fn multi_shadow_root(
+    attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    multi_shadow_root_impl(attr.into(), input.into())
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
 fn shadow_root_impl(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
     let derive_input = syn::parse2::<DeriveInput>(input)?;
 
@@ -160,6 +197,49 @@ fn shadow_node_impl(attr: TokenStream, input: TokenStream) -> syn::Result<TokenS
     Ok(quote! {
         #original
         #shadow_code
+    })
+}
+
+#[cfg(feature = "multi")]
+fn multi_shadow_root_impl(attr: TokenStream, input: TokenStream) -> syn::Result<TokenStream> {
+    let derive_input = syn::parse2::<DeriveInput>(input)?;
+
+    let meta_list = darling::ast::NestedMeta::parse_meta_list(attr)
+        .map_err(|e| syn::Error::new(proc_macro2::Span::call_site(), e))?;
+    let params = MultiShadowRootParams::from_list(&meta_list)
+        .map_err(|e| syn::Error::new(proc_macro2::Span::call_site(), e))?;
+
+    // Strip shadow_attr from the original definition
+    let original = strip_shadow_attrs(&derive_input);
+
+    // Generate shadow node code (without ShadowRoot impl)
+    let shadow_code = generate_shadow_node(&derive_input, None)?;
+
+    // Generate MultiShadowRoot impl
+    let name = &derive_input.ident;
+    let krate = codegen::rustot_crate_path();
+    let pattern = &params.pattern;
+
+    let prefix_const = params.topic_prefix.as_ref().map(|p| {
+        quote! { const PREFIX: &'static str = #p; }
+    });
+
+    let max_payload_const = params.max_payload_len.map(|s| {
+        quote! { const MAX_PAYLOAD_SIZE: usize = #s; }
+    });
+
+    let multi_root_impl = quote! {
+        impl #krate::shadows::multi::MultiShadowRoot for #name {
+            const PATTERN: &'static str = #pattern;
+            #prefix_const
+            #max_payload_const
+        }
+    };
+
+    Ok(quote! {
+        #original
+        #shadow_code
+        #multi_root_impl
     })
 }
 

--- a/src/mqtt/greengrass.rs
+++ b/src/mqtt/greengrass.rs
@@ -37,6 +37,15 @@ impl GreengrassClient {
         })
     }
 
+    /// Create a client from an existing IPC client.
+    ///
+    /// The client ID is retrieved from the `AWS_IOT_THING_NAME` environment variable.
+    pub fn from_ipc(client: Arc<greengrass_ipc_rust::GreengrassCoreIPCClient>) -> Self {
+        let client_id =
+            std::env::var("AWS_IOT_THING_NAME").unwrap_or_else(|_| "unknown".to_string());
+        Self { client, client_id }
+    }
+
     /// Create a new client with a custom client ID.
     pub async fn connect_with_client_id(
         client_id: impl Into<String>,

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -93,9 +93,10 @@ use core::future::Future;
 /// Without cleanup, stale desired fields persist after variant switches and
 /// cause infinite delta loops (AWS computes delta from desired keys not in
 /// reported).
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub enum DeltaContent<T> {
     /// No content — field skipped by `skip_serializing_if`.
+    #[default]
     Absent,
     /// Actual delta value — delegates to T's Serialize.
     Value(T),
@@ -104,12 +105,6 @@ pub enum DeltaContent<T> {
     /// Each inner slice is a `FIELD_NAMES` from a `ReportedUnionFields` impl,
     /// allowing multiple variants' fields to be combined.
     NullFields(&'static [&'static [&'static str]]),
-}
-
-impl<T> Default for DeltaContent<T> {
-    fn default() -> Self {
-        DeltaContent::Absent
-    }
 }
 
 impl<T> From<Option<T>> for DeltaContent<T> {
@@ -148,7 +143,7 @@ impl<T: Serialize> Serialize for DeltaContent<T> {
                 use serde::ser::SerializeMap;
                 let mut map = serializer.serialize_map(None)?;
                 for fields in *field_slices {
-                    serialize_null_fields(*fields, &mut map)?;
+                    serialize_null_fields(fields, &mut map)?;
                 }
                 map.end()
             }
@@ -171,9 +166,10 @@ pub fn delta_content_is_absent<T>(dc: &DeltaContent<T>) -> bool {
 /// via fallback after an unknown variant tag was encountered. Both serialize
 /// identically, but `Fallback` signals `desired_cleanup` to overwrite the
 /// invalid desired mode on the cloud so the delta clears itself.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub enum DeltaMode<T> {
     /// No mode in delta — skipped during serialization.
+    #[default]
     Absent,
     /// Mode parsed directly from JSON tag.
     Known(T),
@@ -181,12 +177,6 @@ pub enum DeltaMode<T> {
     /// Serialized identically to Known. Signals desired_cleanup
     /// to overwrite the invalid desired mode.
     Fallback(T),
-}
-
-impl<T> Default for DeltaMode<T> {
-    fn default() -> Self {
-        DeltaMode::Absent
-    }
 }
 
 impl<T> DeltaMode<T> {

--- a/src/shadows/multi/manager.rs
+++ b/src/shadows/multi/manager.rs
@@ -3,6 +3,8 @@
 //! Manages multiple runtime-named shadows using a single wildcard
 //! MQTT subscription per operation type.
 
+use serde::Serialize;
+
 use crate::mqtt::{MqttClient, MqttMessage, MqttSubscription, QoS};
 use crate::shadows::data_types::{
     AcceptedResponse, DeltaResponse, DeltaState, ErrorResponse, Request, RequestState,
@@ -366,67 +368,95 @@ where
     // Update
     // =========================================================================
 
-    /// Update reported state for a specific shadow by ID.
+    /// Report state changes to the cloud for a specific shadow.
     ///
-    /// The closure receives the current state and a mutable reported struct.
-    /// Set fields on the reported struct to report them to the cloud.
-    pub async fn update<F>(&self, id: &str, f: F) -> MultiShadowResult<T>
-    where
-        F: FnOnce(&T, &mut T::Reported),
-    {
+    /// Accepts anything convertible to `T::Reported` via `Into`, including
+    /// the state type `T` itself (reports all fields) or a builder result.
+    ///
+    /// If the cloud responds with a delta (because reported differs from
+    /// desired), the delta is automatically applied and persisted.
+    ///
+    /// ## Example
+    ///
+    /// ```ignore
+    /// // Report specific fields using builder (requires "builders" feature)
+    /// manager.update_reported("pump-01",
+    ///     FlowState::reported().flow_rate(42.0).build()
+    /// ).await?;
+    /// ```
+    pub async fn update_reported(
+        &self,
+        id: &str,
+        reported: impl Into<T::Reported>,
+    ) -> MultiShadowResult<T> {
         if !self.shadow_ids.read().await.contains(id) {
             return Err(MultiShadowError::ShadowNotManaged(id.to_string()));
         }
 
-        let prefix = Self::shadow_name(id);
-        let state: T =
-            self.store.get_state(&prefix).await.map_err(|e| {
-                MultiShadowError::StorageError(format!("Failed to get state: {:?}", e))
-            })?;
-
-        let mut reported = T::Reported::default();
-        f(&state, &mut reported);
-
+        let reported: T::Reported = reported.into();
         let response = self.report(id, reported).await?;
 
-        let state = if let Some(ref delta) = response.delta {
+        let prefix = Self::shadow_name(id);
+        if let Some(ref delta) = response.delta {
             self.store.apply_delta(&prefix, delta).await.map_err(|e| {
                 MultiShadowError::StorageError(format!("Failed to apply delta: {:?}", e))
-            })?
+            })
         } else {
-            state
-        };
-
-        Ok(state)
+            self.store.get_state(&prefix).await.map_err(|e| {
+                MultiShadowError::StorageError(format!("Failed to get state: {:?}", e))
+            })
+        }
     }
 
-    /// Update desired state for a specific shadow by ID.
+    /// Request state changes from the cloud for a specific shadow.
     ///
-    /// The closure receives the current state (mutable) and a mutable reported struct.
-    /// Modify the state to set the desired values, and set reported fields to acknowledge.
-    pub async fn update_desired<F>(&self, id: &str, f: F) -> MultiShadowResult<()>
-    where
-        F: FnOnce(&mut T, &mut T::Reported),
-    {
+    /// Accepts anything convertible to `T::Delta` via `Into`, including
+    /// builder results and `DesiredFoo` types for adjacently-tagged enums.
+    ///
+    /// If the cloud accepts the change and returns a delta, it is
+    /// automatically applied and persisted.
+    ///
+    /// ## Example
+    ///
+    /// ```ignore
+    /// // Request changes using builder (requires "builders" feature)
+    /// manager.update_desired("pump-01",
+    ///     FlowState::desired().flow_rate(42.0).build()
+    /// ).await?;
+    /// ```
+    pub async fn update_desired(
+        &self,
+        id: &str,
+        desired: impl Into<T::Delta>,
+    ) -> MultiShadowResult<()> {
         if !self.shadow_ids.read().await.contains(id) {
             return Err(MultiShadowError::ShadowNotManaged(id.to_string()));
         }
 
-        let prefix = Self::shadow_name(id);
-        let mut state: T =
-            self.store.get_state(&prefix).await.map_err(|e| {
-                MultiShadowError::StorageError(format!("Failed to get state: {:?}", e))
+        let desired: T::Delta = desired.into();
+
+        let shadow_name = Self::shadow_name(id);
+        let client_token = uuid::Uuid::new_v4().to_string();
+
+        let request: Request<'_, T::Delta, T::Reported> = Request {
+            state: RequestState {
+                desired: Some(desired),
+                reported: None,
+            },
+            client_token: Some(&client_token),
+            version: None,
+        };
+
+        let response = self
+            .publish_and_wait_response(&shadow_name, &request, Some(&client_token))
+            .await?;
+
+        if let Some(ref delta) = response.delta {
+            let prefix = Self::shadow_name(id);
+            self.store.apply_delta(&prefix, delta).await.map_err(|e| {
+                MultiShadowError::StorageError(format!("Failed to apply delta: {:?}", e))
             })?;
-
-        let mut reported = T::Reported::default();
-        f(&mut state, &mut reported);
-
-        self.desired(id, state.clone(), reported).await?;
-
-        self.store
-            .set_state(&prefix, &state)
-            .await
-            .map_err(|e| MultiShadowError::StorageError(format!("Failed to set state: {:?}", e)))?;
+        }
 
         Ok(())
     }
@@ -559,34 +589,11 @@ where
             .await
     }
 
-    /// Update both desired and reported state.
-    async fn desired(
-        &self,
-        id: &str,
-        desired: T,
-        reported: T::Reported,
-    ) -> MultiShadowResult<DeltaState<T::Delta, T::Delta>> {
-        let shadow_name = Self::shadow_name(id);
-        let client_token = uuid::Uuid::new_v4().to_string();
-
-        let request: Request<'_, T, T::Reported> = Request {
-            state: RequestState {
-                desired: Some(desired),
-                reported: Some(reported),
-            },
-            client_token: Some(&client_token),
-            version: None,
-        };
-
-        self.publish_and_wait_response(&shadow_name, &request, Some(&client_token))
-            .await
-    }
-
     /// Subscribe to update accepted/rejected, publish a request, and wait for response.
-    async fn publish_and_wait_response(
+    async fn publish_and_wait_response<D: Serialize + Sync, R: Serialize + Sync>(
         &self,
         shadow_name: &str,
-        request: &Request<'_, T, T::Reported>,
+        request: &Request<'_, D, R>,
         client_token: Option<&str>,
     ) -> MultiShadowResult<DeltaState<T::Delta, T::Delta>> {
         let accepted_topic = Topic::UpdateAccepted


### PR DESCRIPTION
## Summary

- **MultiShadowManager**: Replace closure-based `update`/`update_desired` with builder-based `update_reported(id, impl Into<T::Reported>)` and `update_desired(id, impl Into<T::Delta>)`, matching the single `Shadow` convention from #91.
- **GreengrassClient**: Add `from_ipc(client: Arc<GreengrassCoreIPCClient>)` constructor for wrapping an existing IPC client.
- **Derive crate**: Add `#[multi_shadow_root(pattern = "PATTERN")]` attribute macro (behind `shadows_multi` feature) as the multi-shadow counterpart to `#[shadow_root(name = "NAME")]`. Generates `ShadowNode` + `MultiShadowRoot` impls.
- **Clippy**: Fix pre-existing `derivable_impls` and `explicit_auto_deref` warnings in `DeltaContent`/`DeltaMode`.