### PR TITLE
Add wait_deletion to MultiShadowManager

### DIFF
--- a/src/shadows/multi/manager.rs
+++ b/src/shadows/multi/manager.rs
@@ -318,10 +318,7 @@ where
             if let Some(id) = shadow_name.strip_prefix(T::PATTERN) {
                 let prefix = Self::shadow_name(id);
                 self.store.delete_state(&prefix).await.map_err(|e| {
-                    MultiShadowError::StorageError(format!(
-                        "Failed to delete state: {:?}",
-                        e
-                    ))
+                    MultiShadowError::StorageError(format!("Failed to delete state: {:?}", e))
                 })?;
                 self.shadow_ids.write().await.remove(id);
                 return Ok(Some(id.to_string()));
@@ -536,10 +533,7 @@ where
             Ok(Ok(())) | Err(_) => {
                 let prefix = Self::shadow_name(id);
                 self.store.delete_state(&prefix).await.map_err(|e| {
-                    MultiShadowError::StorageError(format!(
-                        "Failed to delete state: {:?}",
-                        e
-                    ))
+                    MultiShadowError::StorageError(format!("Failed to delete state: {:?}", e))
                 })?;
                 self.shadow_ids.write().await.remove(id);
                 Ok(())

--- a/src/shadows/multi/manager.rs
+++ b/src/shadows/multi/manager.rs
@@ -316,6 +316,13 @@ where
             Topic::from_str(T::PREFIX, topic)
         {
             if let Some(id) = shadow_name.strip_prefix(T::PATTERN) {
+                let prefix = Self::shadow_name(id);
+                self.store.delete_state(&prefix).await.map_err(|e| {
+                    MultiShadowError::StorageError(format!(
+                        "Failed to delete state: {:?}",
+                        e
+                    ))
+                })?;
                 self.shadow_ids.write().await.remove(id);
                 return Ok(Some(id.to_string()));
             }
@@ -527,6 +534,13 @@ where
 
         match result {
             Ok(Ok(())) | Err(_) => {
+                let prefix = Self::shadow_name(id);
+                self.store.delete_state(&prefix).await.map_err(|e| {
+                    MultiShadowError::StorageError(format!(
+                        "Failed to delete state: {:?}",
+                        e
+                    ))
+                })?;
                 self.shadow_ids.write().await.remove(id);
                 Ok(())
             }

--- a/src/shadows/multi/manager.rs
+++ b/src/shadows/multi/manager.rs
@@ -244,6 +244,20 @@ where
         Err(MultiShadowError::Timeout)
     }
 
+    /// Wait for the next shadow deletion from any managed shadow.
+    ///
+    /// Returns the deleted shadow ID, or `None` if the deletion was for
+    /// an unrecognized shadow (not matching the pattern).
+    pub async fn wait_deletion(&self) -> MultiShadowResult<Option<String>> {
+        let mut sub = self.create_deletion_subscription().await?;
+
+        if let Some(msg) = sub.next_message().await {
+            return self.handle_deletion_from_parts(msg.topic_name()).await;
+        }
+
+        Err(MultiShadowError::Timeout)
+    }
+
     /// Parse a delta message from topic and payload.
     ///
     /// Applies the delta to the local state store, reports the updated state,

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -245,16 +245,6 @@ where
         }
     }
 
-    /// Create a new shadow with default state.
-    async fn create_shadow(&self) -> Result<DeltaState<S::Delta, S::Delta>, Error> {
-        debug!(
-            "[{:?}] Creating initial shadow value.",
-            S::NAME.unwrap_or(CLASSIC_SHADOW),
-        );
-
-        self.update_shadow(None, Some(S::Reported::default())).await
-    }
-
     /// Subscribe to accepted/rejected topics and then publish a request.
     ///
     /// This helper handles the subscribe-then-publish pattern used by
@@ -485,6 +475,25 @@ where
         };
 
         Ok(state)
+    }
+
+    /// Create a new shadow in the cloud with default reported state.
+    ///
+    /// Publishes an update request with `S::Reported::default()` and returns
+    /// the resulting delta state from the cloud.
+    ///
+    /// ## Example
+    ///
+    /// ```ignore
+    /// let delta_state = shadow.create_shadow().await?;
+    /// ```
+    pub async fn create_shadow(&self) -> Result<DeltaState<S::Delta, S::Delta>, Error> {
+        debug!(
+            "[{:?}] Creating initial shadow value.",
+            S::NAME.unwrap_or(CLASSIC_SHADOW),
+        );
+
+        self.update_shadow(None, Some(S::Reported::default())).await
     }
 
     /// Delete the shadow from the cloud and remove all persisted state.

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -245,39 +245,6 @@ where
         }
     }
 
-    /// Delete the shadow from the cloud.
-    async fn delete_from_cloud(&self) -> Result<(), Error> {
-        // Wait for mqtt to connect
-        self.mqtt.wait_connected().await;
-
-        let mut sub = self.publish_and_subscribe(Topic::Delete, b"").await?;
-
-        let message = sub.next_message().await.ok_or(Error::InvalidPayload)?;
-
-        // Check if topic is DeleteAccepted
-        match Topic::from_str(S::PREFIX, message.topic_name()) {
-            Some((Topic::DeleteAccepted, _, _)) => Ok(()),
-            Some((Topic::DeleteRejected, _, _)) => {
-                let mut buf = [0u8; 64];
-                let (error_response, _) = serde_json_core::from_slice_escaped::<ErrorResponse>(
-                    message.payload(),
-                    &mut buf,
-                )
-                .map_err(|_| Error::ShadowError(ShadowError::NotFound))?;
-
-                Err(Error::ShadowError(
-                    error_response.try_into().unwrap_or(ShadowError::NotFound),
-                ))
-            }
-            _ => {
-                error!(
-                    "Expected Topic name DeleteRejected or DeleteAccepted but got something else"
-                );
-                Err(Error::WrongShadowName)
-            }
-        }
-    }
-
     /// Create a new shadow with default state.
     async fn create_shadow(&self) -> Result<DeltaState<S::Delta, S::Delta>, Error> {
         debug!(
@@ -520,25 +487,47 @@ where
         Ok(state)
     }
 
-    /// Delete the shadow from the cloud and reset local state to defaults.
+    /// Delete the shadow from the cloud and remove all persisted state.
     ///
-    /// This removes the shadow from the cloud and resets the local state
-    /// to defaults in storage.
+    /// Publishes a delete request via MQTT, waits for acceptance, then
+    /// removes all stored KV entries for this shadow's prefix.
     ///
     /// ## Example
     ///
     /// ```ignore
-    /// shadow.delete_shadow().await?;  // Gone from cloud, local reset to defaults
+    /// shadow.delete_shadow().await?;  // Gone from cloud, storage cleaned up
     /// ```
     pub async fn delete_shadow(&self) -> Result<(), Error> {
-        // Delete from cloud
-        self.delete_from_cloud().await?;
+        self.mqtt.wait_connected().await;
 
-        // Reset state to default in storage
-        let prefix = Self::prefix();
-        let state = S::default();
+        let mut sub = self.publish_and_subscribe(Topic::Delete, b"").await?;
+
+        let message = sub.next_message().await.ok_or(Error::InvalidPayload)?;
+
+        match Topic::from_str(S::PREFIX, message.topic_name()) {
+            Some((Topic::DeleteAccepted, _, _)) => {}
+            Some((Topic::DeleteRejected, _, _)) => {
+                let mut buf = [0u8; 64];
+                let (error_response, _) = serde_json_core::from_slice_escaped::<ErrorResponse>(
+                    message.payload(),
+                    &mut buf,
+                )
+                .map_err(|_| Error::ShadowError(ShadowError::NotFound))?;
+
+                return Err(Error::ShadowError(
+                    error_response.try_into().unwrap_or(ShadowError::NotFound),
+                ));
+            }
+            _ => {
+                error!(
+                    "Expected Topic name DeleteRejected or DeleteAccepted but got something else"
+                );
+                return Err(Error::WrongShadowName);
+            }
+        }
+
         self.store
-            .set_state(prefix, &state)
+            .delete_state(Self::prefix())
             .await
             .map_err(|_| Error::DaoWrite)?;
 

--- a/src/shadows/store/file.rs
+++ b/src/shadows/store/file.rs
@@ -270,6 +270,11 @@ impl<St: KVPersist> StateStore<St> for FileKVStore {
             })
     }
 
+    async fn delete_state(&self, prefix: &str) -> Result<(), Self::Error> {
+        self.remove_if(prefix, |_| true).await?;
+        Ok(())
+    }
+
     async fn apply_delta(&self, prefix: &str, delta: &St::Delta) -> Result<St, Self::Error> {
         let mut key_buf = heapless::String::<128>::new();
         key_buf

--- a/src/shadows/store/in_memory.rs
+++ b/src/shadows/store/in_memory.rs
@@ -76,6 +76,11 @@ impl<S: ShadowNode> StateStore<S> for InMemory<S> {
         Ok(())
     }
 
+    async fn delete_state(&self, _prefix: &str) -> Result<(), Self::Error> {
+        *self.state.lock().await = None;
+        Ok(())
+    }
+
     async fn apply_delta(&self, _prefix: &str, delta: &S::Delta) -> Result<S, Self::Error> {
         let mut guard = self.state.lock().await;
         let state = guard.get_or_insert_with(S::default);

--- a/src/shadows/store/mod.rs
+++ b/src/shadows/store/mod.rs
@@ -83,6 +83,12 @@ pub trait StateStore<S: ShadowNode> {
     /// Returns the updated state after applying the delta.
     async fn apply_delta(&self, prefix: &str, delta: &S::Delta) -> Result<S, Self::Error>;
 
+    /// Delete all stored state for a shadow prefix.
+    ///
+    /// Removes all keys associated with the given prefix from storage.
+    /// For `InMemory<S>`, this resets the state to `None`.
+    async fn delete_state(&self, prefix: &str) -> Result<(), Self::Error>;
+
     /// Load state from storage, handling first boot and schema migrations.
     ///
     /// ## Behavior

--- a/src/shadows/store/sequential.rs
+++ b/src/shadows/store/sequential.rs
@@ -294,6 +294,11 @@ impl<
             })
     }
 
+    async fn delete_state(&self, prefix: &str) -> Result<(), Self::Error> {
+        self.remove_if(prefix, |_| true).await?;
+        Ok(())
+    }
+
     async fn apply_delta(&self, prefix: &str, delta: &St::Delta) -> Result<St, Self::Error> {
         info!("KV apply_delta: prefix={}", prefix);
         let mut key_buf: String<MAX_KEY_LEN> = String::new();


### PR DESCRIPTION
## Summary

- Adds `wait_deletion()` to `MultiShadowManager`, parallel to `wait_delta()` — creates a wildcard deletion subscription and waits for the next shadow deletion event
- Adds `StateStore::delete_state()` to remove all persisted KV entries for a shadow prefix
- `MultiShadowManager::delete_shadow()` and `handle_deletion_from_parts()` now clean up the store on deletion
- `Shadow::delete_shadow()` inlines `delete_from_cloud` (single callsite) and uses `delete_state` instead of resetting to defaults
- `Shadow::create_shadow()` is now public, moved to the public API section