### PR TITLE
Add HTTP OTA data interface with reqwest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
   actions: read
 
 env:
-  ALL_FEATURES: "ota_mqtt_data,ota_http_data"
+  ALL_FEATURES: "ota_mqtt_data,ota_http_data,ota_http_reqwest"
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -121,7 +121,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --test '*' --features "ota_mqtt_data,log,std,shadows_kv_persist,shadows_builders" --target x86_64-unknown-linux-gnu
+          args: --test '*' --features "ota_mqtt_data,ota_http_reqwest,mqtt_rumqttc,log,std,shadows_kv_persist,shadows_builders" --target x86_64-unknown-linux-gnu
         env:
           IDENTITY_PASSWORD: ${{ secrets.IDENTITY_PASSWORD }}
           AWS_HOSTNAME: a1vq3mi5y3c6j5-ats.iot.eu-west-1.amazonaws.com

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ sequential-storage = { version = "7.0", features = ["heapless-09"], optional = t
 serde-json-core = { version = "0.6" }
 rustot-derive = { path = "rustot_derive", version = "0.2.1" }
 embedded-storage-async = "0.4"
-mqttrust = { git = "https://github.com/FactbirdHQ/mqttrust", rev = "cc55012", optional = true }
+mqttrust = { git = "https://github.com/FactbirdHQ/mqttrust", rev = "629e3bb", optional = true }
 
 embassy-time = { version = "0.5.0" }
 embassy-sync = "0.7.2"
@@ -58,6 +58,7 @@ rumqttc = { version = "0.24", optional = true }
 greengrass-ipc-rust = { git = "https://github.com/FactbirdHQ/greengrass-ipc-rust", rev = "0f0469e", optional = true }
 bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"], optional = true }
 
 # Multi-shadow manager dependencies (optional, feature-gated)
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"], optional = true }
@@ -98,10 +99,12 @@ aws-credential-types = "1"
 uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 serial_test = "3"
+rumqttc = { version = "0.24", features = ["use-native-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 
 [features]
-default = ["ota_mqtt_data", "metric_cbor", "provision_cbor", "shadows_kv_persist", "mqttrust"]
+default = ["ota_mqtt_data", "metric_cbor", "provision_cbor", "shadows_kv_persist", "mqtt_mqttrust"]
 
 metric_cbor = ["dep:minicbor", "dep:minicbor-serde"]
 
@@ -110,6 +113,7 @@ provision_cbor = ["dep:minicbor", "dep:minicbor-serde"]
 ota_mqtt_data = ["dep:minicbor", "dep:minicbor-serde"]
 
 ota_http_data = []
+ota_http_reqwest = ["ota_http_data", "std", "dep:reqwest"]
 
 std = ["serde/std", "minicbor-serde?/std", "dep:tokio", "dep:serde_json", "dep:base64", "postcard/alloc", "rustot-derive/std", "embassy-time/std", "embassy-time/generic-queue-8"]
 
@@ -131,9 +135,9 @@ log = ["dep:log"]
 shadows_multi = ["std", "dep:aws-config", "dep:aws-sdk-iotdataplane", "dep:uuid", "tokio/time", "rustot-derive/multi"]
 
 # MQTT client implementations (all optional, feature-gated)
-mqttrust = ["dep:mqttrust"]
-rumqttc = ["std", "dep:rumqttc", "tokio/time"]
-greengrass = ["std", "dep:greengrass-ipc-rust", "dep:bytes", "dep:futures"]
+mqtt_mqttrust = ["dep:mqttrust"]
+mqtt_rumqttc = ["std", "dep:rumqttc", "tokio/time"]
+mqtt_greengrass = ["std", "dep:greengrass-ipc-rust", "dep:bytes", "dep:futures"]
 
 [patch.crates-io]
 serde-json-core = { git = "https://github.com/rust-embedded-community/serde-json-core", rev = "a435f78" }

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -127,8 +127,7 @@ pub type StatusDetailsOwned = heapless::LinearMap<heapless::String<15>, heapless
 pub enum JobError {
     Overflow,
     Encoding,
-    #[cfg(feature = "mqttrust")]
-    Mqtt(mqttrust::Error),
+    Mqtt,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -15,25 +15,25 @@
 use core::fmt::Debug;
 use core::future::Future;
 
-#[cfg(feature = "mqttrust")]
+#[cfg(feature = "mqtt_mqttrust")]
 mod mqttrust;
 
-#[cfg(feature = "rumqttc")]
-mod rumqttc;
+#[cfg(feature = "mqtt_rumqttc")]
+pub mod rumqttc;
 
-#[cfg(feature = "greengrass")]
+#[cfg(feature = "mqtt_greengrass")]
 mod greengrass;
 
 #[cfg(test)]
 pub mod mock;
 
-#[cfg(feature = "mqttrust")]
+#[cfg(feature = "mqtt_mqttrust")]
 pub use self::mqttrust::*;
 
-#[cfg(feature = "rumqttc")]
+#[cfg(feature = "mqtt_rumqttc")]
 pub use self::rumqttc::*;
 
-#[cfg(feature = "greengrass")]
+#[cfg(feature = "mqtt_greengrass")]
 pub use self::greengrass::*;
 
 /// Newtype wrapper for implementing service-specific traits

--- a/src/ota/data_interface/http.rs
+++ b/src/ota/data_interface/http.rs
@@ -1,30 +1,232 @@
+use core::fmt::Debug;
+
 use crate::ota::{
-    config::Config,
-    data_interface::{DataInterface, FileBlock, Protocol},
-    encoding::FileContext,
+    data_interface::{FileBlock, RawBlock},
     error::OtaError,
 };
 
-pub struct HttpInterface {}
+/// Minimal HTTP client trait for OTA Range-based downloads.
+///
+/// No_std compatible — the caller provides the buffer. Implementations
+/// for `reqwest` (std) and `reqless` (no_std) can be provided via feature flags.
+pub trait HttpClient {
+    type Error: Debug;
 
-impl HttpInterface {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl DataInterface for HttpInterface {
-    const PROTOCOL: Protocol = Protocol::Http;
-
-    fn init_file_transfer(&self, _file_ctx: &mut FileContext) -> Result<(), OtaError> {
-        Ok(())
-    }
-
-    fn request_file_blocks(
+    /// Fetch bytes from `url` in the byte range `[start, end)`.
+    ///
+    /// Writes the response body into `buf` and returns the number of bytes
+    /// written. The caller guarantees `buf.len() >= (end - start)`.
+    async fn get_range(
         &self,
-        _file_ctx: &mut FileContext,
-        _config: &Config,
-    ) -> Result<(), OtaError> {
-        Ok(())
+        url: &str,
+        start: usize,
+        end: usize,
+        buf: &mut [u8],
+    ) -> Result<usize, Self::Error>;
+}
+
+impl<C: HttpClient> HttpClient for &C {
+    type Error = C::Error;
+
+    async fn get_range(
+        &self,
+        url: &str,
+        start: usize,
+        end: usize,
+        buf: &mut [u8],
+    ) -> Result<usize, Self::Error> {
+        C::get_range(self, url, start, end, buf).await
     }
 }
+
+/// Raw block from an HTTP Range response. Borrows from the transfer's
+/// internal buffer — no extra allocation per block.
+pub struct HttpRawBlock<'a> {
+    payload: &'a [u8],
+    file_id: u8,
+    block_id: usize,
+}
+
+impl RawBlock for HttpRawBlock<'_> {
+    fn decode(&mut self) -> Result<FileBlock<'_>, OtaError> {
+        Ok(FileBlock {
+            client_token: None,
+            file_id: self.file_id,
+            block_size: self.payload.len(),
+            block_id: self.block_id,
+            block_payload: self.payload,
+        })
+    }
+}
+
+// --- reqwest implementation (requires std) ---
+
+#[cfg(feature = "ota_http_reqwest")]
+mod reqwest_impl {
+    use super::*;
+
+    pub struct ReqwestClient {
+        client: reqwest::Client,
+    }
+
+    impl ReqwestClient {
+        pub fn new(client: reqwest::Client) -> Self {
+            Self { client }
+        }
+    }
+
+    impl HttpClient for ReqwestClient {
+        type Error = reqwest::Error;
+
+        async fn get_range(
+            &self,
+            url: &str,
+            start: usize,
+            end: usize,
+            buf: &mut [u8],
+        ) -> Result<usize, Self::Error> {
+            let response = self
+                .client
+                .get(url)
+                .header("Range", format!("bytes={}-{}", start, end - 1))
+                .send()
+                .await?
+                .error_for_status()?;
+
+            let bytes = response.bytes().await?;
+            let len = bytes.len();
+            buf[..len].copy_from_slice(&bytes);
+            Ok(len)
+        }
+    }
+}
+
+#[cfg(feature = "ota_http_reqwest")]
+pub use reqwest_impl::ReqwestClient;
+
+// --- Concrete transfer implementation (requires std for Vec) ---
+
+#[cfg(feature = "std")]
+mod transfer {
+    extern crate alloc;
+
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use super::*;
+    use crate::ota::{
+        config::Config,
+        data_interface::{BlockProgress, DataInterface, Protocol},
+        encoding::{Bitmap, FileContext},
+    };
+
+    use super::super::BlockTransfer;
+
+    pub struct HttpInterface<C> {
+        client: C,
+    }
+
+    impl<C: HttpClient> HttpInterface<C> {
+        pub fn new(client: C) -> Self {
+            Self { client }
+        }
+    }
+
+    pub struct HttpTransfer<C> {
+        client: C,
+        url: heapless::String<2048>,
+        file_id: u8,
+        block_size: usize,
+        file_size: usize,
+        bitmap: Bitmap,
+        block_offset: u32,
+        buf: Vec<u8>,
+    }
+
+    impl<C: HttpClient> BlockTransfer for HttpTransfer<C> {
+        type RawBlock<'b>
+            = HttpRawBlock<'b>
+        where
+            Self: 'b;
+
+        async fn next_block(&mut self) -> Result<Option<Self::RawBlock<'_>>, OtaError> {
+            // Find the next block we need from the bitmap
+            let local_id = match self.bitmap.first_index() {
+                Some(id) => id,
+                None => return Ok(None),
+            };
+            let block_id = self.block_offset as usize + local_id;
+
+            let start = block_id * self.block_size;
+            let end = (start + self.block_size).min(self.file_size);
+
+            // Destructure for split borrows across the async client call
+            let HttpTransfer {
+                client, url, buf, ..
+            } = self;
+
+            let len = client
+                .get_range(url.as_str(), start, end, buf)
+                .await
+                .map_err(|e| {
+                    error!("HTTP range request failed: {:?}", e);
+                    OtaError::Http
+                })?;
+
+            Ok(Some(HttpRawBlock {
+                payload: &self.buf[..len],
+                file_id: self.file_id,
+                block_id,
+            }))
+        }
+
+        async fn on_block_written(&mut self, progress: &BlockProgress) -> Result<(), OtaError> {
+            self.bitmap = progress.bitmap.clone();
+            self.block_offset = progress.block_offset;
+            Ok(())
+        }
+    }
+
+    impl<C: HttpClient> DataInterface for HttpInterface<C> {
+        const PROTOCOL: Protocol = Protocol::Http;
+
+        type Transfer<'t>
+            = HttpTransfer<&'t C>
+        where
+            Self: 't;
+
+        async fn begin_transfer(
+            &self,
+            file_ctx: &FileContext,
+            config: &Config,
+            progress: &BlockProgress,
+        ) -> Result<Self::Transfer<'_>, OtaError> {
+            let url = file_ctx
+                .update_data_url
+                .as_ref()
+                .ok_or(OtaError::InvalidFile)?
+                .clone();
+
+            info!(
+                "[OTA-HTTP] Beginning transfer: url_len={} block_size={} file_size={}",
+                url.len(),
+                config.block_size,
+                file_ctx.filesize
+            );
+
+            Ok(HttpTransfer {
+                client: &self.client,
+                url,
+                file_id: file_ctx.fileid,
+                block_size: config.block_size,
+                file_size: file_ctx.filesize,
+                bitmap: progress.bitmap.clone(),
+                block_offset: progress.block_offset,
+                buf: vec![0u8; config.block_size],
+            })
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+pub use transfer::{HttpInterface, HttpTransfer};

--- a/src/ota/data_interface/mod.rs
+++ b/src/ota/data_interface/mod.rs
@@ -1,16 +1,15 @@
-// #[cfg(feature = "ota_http_data")]
-// pub mod http;
+#[cfg(feature = "ota_http_data")]
+pub mod http;
 #[cfg(feature = "ota_mqtt_data")]
 pub mod mqtt;
-
-use core::ops::DerefMut;
 
 use serde::Deserialize;
 
 use crate::ota::config::Config;
-use crate::ota::status_details::StatusDetailsExt;
 
-use super::{encoding::FileContext, error::OtaError, ProgressState};
+use super::{encoding::FileContext, error::OtaError};
+
+use super::encoding::Bitmap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -45,28 +44,60 @@ impl FileBlock<'_> {
     }
 }
 
+/// Current download progress, passed to the transfer so it can make
+/// protocol-specific decisions (which blocks to request/fetch).
+pub struct BlockProgress {
+    pub bitmap: Bitmap,
+    pub block_offset: u32,
+}
+
+/// Protocol-specific raw block data that can be decoded into a [`FileBlock`].
+///
+/// For MQTT, decoding performs in-place CBOR deserialization (zero-copy).
+/// For HTTP, decoding is trivial (the metadata was known at fetch time).
+pub trait RawBlock {
+    fn decode(&mut self) -> Result<FileBlock<'_>, OtaError>;
+}
+
 pub trait BlockTransfer {
-    async fn next_block(&mut self) -> Result<Option<impl DerefMut<Target = [u8]>>, OtaError>;
+    type RawBlock<'b>: RawBlock
+    where
+        Self: 'b;
+
+    /// Receive the next block.
+    ///
+    /// Returns `Ok(Some(raw))` with protocol-specific raw block data.
+    /// Returns `Ok(None)` if the transfer session was interrupted and needs
+    /// to be re-established via [`DataInterface::begin_transfer`].
+    ///
+    /// For pull-based protocols (HTTP), this fetches the next needed block.
+    /// For push-based protocols (MQTT), this waits for the next pushed block
+    /// and handles momentum/timeout internally.
+    async fn next_block(&mut self) -> Result<Option<Self::RawBlock<'_>>, OtaError>;
+
+    /// Notify the transfer that a block was successfully written to flash.
+    ///
+    /// Passes the updated progress so the transfer can request more blocks
+    /// when a batch is exhausted (MQTT) or advance its internal cursor (HTTP).
+    async fn on_block_written(&mut self, progress: &BlockProgress) -> Result<(), OtaError>;
 }
 
 pub trait DataInterface {
     const PROTOCOL: Protocol;
 
-    type ActiveTransfer<'t>: BlockTransfer
+    type Transfer<'t>: BlockTransfer
     where
         Self: 't;
 
-    async fn init_file_transfer(
+    /// Establish a transfer session.
+    ///
+    /// For MQTT: subscribes to data stream + notify-next topics and publishes
+    /// the initial block request.
+    /// For HTTP: validates the pre-signed URL and prepares the range fetcher.
+    async fn begin_transfer(
         &self,
         file_ctx: &FileContext,
-    ) -> Result<Self::ActiveTransfer<'_>, OtaError>;
-
-    async fn request_file_blocks<E: StatusDetailsExt>(
-        &self,
-        file_ctx: &FileContext,
-        progress_state: &mut ProgressState<E>,
         config: &Config,
-    ) -> Result<(), OtaError>;
-
-    fn decode_file_block<'a>(&self, payload: &'a mut [u8]) -> Result<FileBlock<'a>, OtaError>;
+        progress: &BlockProgress,
+    ) -> Result<Self::Transfer<'_>, OtaError>;
 }

--- a/src/ota/data_interface/mqtt.rs
+++ b/src/ota/data_interface/mqtt.rs
@@ -1,19 +1,18 @@
 use core::fmt::{Display, Write};
-use core::ops::{Deref, DerefMut};
 use core::str::FromStr;
+
+use embassy_time::Duration;
 
 use crate::mqtt::{Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
 
 use crate::jobs::JobTopic;
 use crate::ota::error::OtaError;
-use crate::ota::status_details::StatusDetailsExt;
-use crate::ota::ProgressState;
 use crate::{
     jobs::{MAX_STREAM_ID_LEN, MAX_THING_NAME_LEN},
     ota::{
         config::Config,
-        data_interface::{DataInterface, FileBlock, Protocol},
-        encoding::{cbor, FileContext},
+        data_interface::{BlockProgress, DataInterface, FileBlock, Protocol, RawBlock},
+        encoding::{cbor, Bitmap, FileContext},
     },
 };
 
@@ -126,108 +125,53 @@ impl OtaTopic<'_> {
     }
 }
 
-struct MessagePayload<M>(M);
+/// Raw block wrapping an MQTT message. Decoding performs in-place CBOR
+/// deserialization — zero-copy, the [`FileBlock`] payload borrows directly
+/// from the message buffer.
+pub struct MqttRawBlock<M> {
+    message: M,
+}
 
-impl<M: MqttMessage> Deref for MessagePayload<M> {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        self.0.payload()
+impl<M: MqttMessage> RawBlock for MqttRawBlock<M> {
+    fn decode(&mut self) -> Result<FileBlock<'_>, OtaError> {
+        Ok(
+            minicbor_serde::from_slice::<cbor::GetStreamResponse>(self.message.payload_mut())
+                .map_err(|_| OtaError::Encoding)?
+                .into(),
+        )
     }
 }
 
-impl<M: MqttMessage> DerefMut for MessagePayload<M> {
-    fn deref_mut(&mut self) -> &mut [u8] {
-        self.0.payload_mut()
-    }
-}
-
-pub struct MqttTransfer<S> {
+pub struct MqttTransfer<'t, S, C: MqttClient> {
     sub: S,
+    client: &'t C,
     job_name: heapless::String<64>,
+    stream_name: heapless::String<64>,
+    file_id: u8,
+    block_size: usize,
+    // Batch tracking
+    batch_remaining: u32,
+    max_blocks_per_request: u32,
+    // Momentum tracking
+    request_wait: Duration,
+    max_momentum: u8,
+    momentum: u8,
+    // Block request state (updated via on_block_written)
+    bitmap: Bitmap,
+    block_offset: u32,
 }
 
-impl<S: MqttSubscription> BlockTransfer for MqttTransfer<S> {
-    async fn next_block(&mut self) -> Result<Option<impl DerefMut<Target = [u8]>>, OtaError> {
-        match self.sub.next_message().await {
-            Some(msg) => {
-                if msg.topic_name().contains("/streams/") {
-                    return Ok(Some(MessagePayload(msg)));
-                }
+impl<'t, S, C: MqttClient> MqttTransfer<'t, S, C> {
+    /// Publish a CBOR-encoded GetStreamRequest to request file blocks.
+    async fn publish_block_request(&mut self) -> Result<(), OtaError> {
+        let blocks_available = self.bitmap.len() as u32;
+        let blocks_to_request = blocks_available.min(self.max_blocks_per_request);
+        self.batch_remaining = blocks_to_request;
 
-                // Non-stream message on the merged subscription (notify-next).
-                // Only treat it as cancellation if our job name is absent from
-                // the payload — that means execution is null (job gone) or a
-                // different job replaced ours. A status update for the same job
-                // (e.g. InProgress) still contains the job name and is harmless;
-                // return Ok(None) to trigger a resubscribe cycle in the caller.
-                if msg
-                    .payload()
-                    .windows(self.job_name.len())
-                    .any(|w| w == self.job_name.as_bytes())
-                {
-                    debug!("Ignoring notify-next status update for current job");
-                    Ok(None)
-                } else {
-                    Err(OtaError::UserAbort)
-                }
-            }
-            None => Ok(None),
-        }
-    }
-}
-
-impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {
-    const PROTOCOL: Protocol = Protocol::Mqtt;
-
-    type ActiveTransfer<'t>
-        = MqttTransfer<C::Subscription<'t, 2>>
-    where
-        Self: 't;
-
-    /// Init file transfer by subscribing to the OTA data stream topic
-    /// and the jobs notify-next topic (to detect cancellation).
-    async fn init_file_transfer(
-        &self,
-        file_ctx: &FileContext,
-    ) -> Result<Self::ActiveTransfer<'_>, OtaError> {
-        let data_topic = OtaTopic::Data(Encoding::Cbor, file_ctx.stream_name.as_str())
-            .format::<256>(self.0.client_id())?;
-
-        let notify_topic: heapless::String<256> = JobTopic::NotifyNext
-            .format::<256>(self.0.client_id())
-            .map_err(|_| OtaError::Overflow)?;
-
-        debug!(
-            "Subscribing to: [{:?}] and [{:?}]",
-            &data_topic, &notify_topic
-        );
-
-        let job_name = file_ctx.job_name.clone();
-        self.0
-            .subscribe(&[
-                (data_topic.as_str(), QoS::AtMostOnce),
-                (notify_topic.as_str(), QoS::AtMostOnce),
-            ])
-            .await
-            .map(|sub| MqttTransfer { sub, job_name })
-            .map_err(|_| OtaError::Mqtt)
-    }
-
-    /// Request file block by publishing to the get stream topic
-    async fn request_file_blocks<E: StatusDetailsExt>(
-        &self,
-        file_ctx: &FileContext,
-        progress_state: &mut ProgressState<E>,
-        config: &Config,
-    ) -> Result<(), OtaError> {
-        let blocks_available = progress_state.bitmap.len() as u32;
-        let blocks_to_request = blocks_available.min(config.max_blocks_per_request);
-        progress_state.request_block_remaining = blocks_to_request;
-
-        let topic = OtaTopic::Get(Encoding::Cbor, file_ctx.stream_name.as_str()).format::<{
+        let topic = OtaTopic::Get(Encoding::Cbor, self.stream_name.as_str()).format::<{
             MAX_STREAM_ID_LEN + MAX_THING_NAME_LEN + 30
         }>(
-            self.0.client_id(),
+            self.client.client_id(),
         )?;
 
         let mut buf = [0u8; 256];
@@ -235,10 +179,10 @@ impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {
             &cbor::GetStreamRequest {
                 client_token: None,
                 stream_version: None,
-                file_id: file_ctx.fileid,
-                block_size: config.block_size,
-                block_offset: Some(progress_state.block_offset),
-                block_bitmap: Some(&progress_state.bitmap),
+                file_id: self.file_id,
+                block_size: self.block_size,
+                block_offset: Some(self.block_offset),
+                block_bitmap: Some(&self.bitmap),
                 number_of_blocks: Some(blocks_to_request),
             },
             &mut buf,
@@ -250,7 +194,7 @@ impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {
             blocks_to_request, blocks_available
         );
 
-        self.0
+        self.client
             .publish_with_options(
                 topic.as_str(),
                 &buf[..len],
@@ -259,13 +203,204 @@ impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {
             .await
             .map_err(|_| OtaError::Mqtt)
     }
+}
 
-    /// Decode a cbor encoded fileblock received from streaming service
-    fn decode_file_block<'c>(&self, payload: &'c mut [u8]) -> Result<FileBlock<'c>, OtaError> {
-        Ok(
-            minicbor_serde::from_slice::<cbor::GetStreamResponse>(payload)
-                .map_err(|_| OtaError::Encoding)?
-                .into(),
+impl<'t, S: MqttSubscription, C: MqttClient> BlockTransfer for MqttTransfer<'t, S, C> {
+    type RawBlock<'b>
+        = MqttRawBlock<S::Message<'b>>
+    where
+        Self: 'b;
+
+    async fn next_block(&mut self) -> Result<Option<Self::RawBlock<'_>>, OtaError> {
+        // Destructure for split borrows: the message branch borrows `sub`,
+        // while the timer branch borrows `client` and other fields. Without
+        // destructuring the compiler treats all field access as &mut self.
+        //
+        // No internal loop — if the timer fires (momentum), we return
+        // Err(Momentum) and let the orchestrator retry. This avoids a GAT
+        // lifetime conflict where the returned RawBlock (borrowing from sub)
+        // would overlap with the next iteration's borrow of sub.
+        let MqttTransfer {
+            sub,
+            client,
+            job_name,
+            stream_name,
+            file_id,
+            block_size,
+            batch_remaining,
+            max_blocks_per_request,
+            request_wait,
+            max_momentum,
+            momentum,
+            bitmap,
+            block_offset,
+        } = self;
+
+        match embassy_futures::select::select(
+            sub.next_message(),
+            embassy_time::Timer::after(*request_wait),
         )
+        .await
+        {
+            // Message received
+            embassy_futures::select::Either::First(Some(msg)) => {
+                if msg.topic_name().contains("/streams/") {
+                    *momentum = 0;
+                    return Ok(Some(MqttRawBlock { message: msg }));
+                }
+
+                // Non-stream message on the merged subscription (notify-next).
+                // Only treat it as cancellation if our job name is absent from
+                // the payload — that means execution is null (job gone) or a
+                // different job replaced ours.
+                if msg
+                    .payload()
+                    .windows(job_name.len())
+                    .any(|w| w == job_name.as_bytes())
+                {
+                    debug!("Ignoring notify-next status update for current job");
+                    Ok(None)
+                } else {
+                    Err(OtaError::UserAbort)
+                }
+            }
+
+            // Subscription ended
+            embassy_futures::select::Either::First(None) => Ok(None),
+
+            // Timer expired — handle momentum and signal the orchestrator to retry
+            embassy_futures::select::Either::Second(()) => {
+                *momentum += 1;
+
+                if *momentum <= 1 {
+                    // Grace period — just retry
+                    return Err(OtaError::Momentum);
+                }
+
+                if *momentum <= *max_momentum {
+                    warn!("Momentum requesting more blocks!");
+
+                    // Inline block request publish (can't call &mut self method
+                    // because `sub` is destructured separately)
+                    let blocks_available = bitmap.len() as u32;
+                    let blocks_to_request = blocks_available.min(*max_blocks_per_request);
+                    *batch_remaining = blocks_to_request;
+
+                    let topic = OtaTopic::Get(Encoding::Cbor, stream_name.as_str()).format::<{
+                        MAX_STREAM_ID_LEN + MAX_THING_NAME_LEN + 30
+                    }>(
+                        client.client_id(),
+                    )?;
+
+                    let mut buf = [0u8; 256];
+                    let len = cbor::to_slice(
+                        &cbor::GetStreamRequest {
+                            client_token: None,
+                            stream_version: None,
+                            file_id: *file_id,
+                            block_size: *block_size,
+                            block_offset: Some(*block_offset),
+                            block_bitmap: Some(bitmap),
+                            number_of_blocks: Some(blocks_to_request),
+                        },
+                        &mut buf,
+                    )
+                    .map_err(|_| OtaError::Encoding)?;
+
+                    debug!(
+                        "Requesting {} file blocks (of {} remaining)",
+                        blocks_to_request, blocks_available
+                    );
+
+                    client
+                        .publish_with_options(
+                            topic.as_str(),
+                            &buf[..len],
+                            PublishOptions::new().qos(QoS::AtMostOnce),
+                        )
+                        .await
+                        .map_err(|_| OtaError::Mqtt)?;
+
+                    Err(OtaError::Momentum)
+                } else {
+                    Err(OtaError::MomentumAbort)
+                }
+            }
+        }
+    }
+
+    async fn on_block_written(&mut self, progress: &BlockProgress) -> Result<(), OtaError> {
+        // Update internal state from orchestrator's progress
+        self.bitmap = progress.bitmap.clone();
+        self.block_offset = progress.block_offset;
+
+        self.batch_remaining = self.batch_remaining.saturating_sub(1);
+        if self.batch_remaining == 0 {
+            self.publish_block_request().await?;
+        }
+        Ok(())
+    }
+}
+
+impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {
+    const PROTOCOL: Protocol = Protocol::Mqtt;
+
+    type Transfer<'t>
+        = MqttTransfer<'t, C::Subscription<'t, 2>, C>
+    where
+        Self: 't;
+
+    /// Begin a file transfer by subscribing to the OTA data stream topic
+    /// and the jobs notify-next topic (to detect cancellation), then publishing
+    /// the initial block request.
+    async fn begin_transfer(
+        &self,
+        file_ctx: &FileContext,
+        config: &Config,
+        progress: &BlockProgress,
+    ) -> Result<Self::Transfer<'_>, OtaError> {
+        let stream_name = file_ctx.stream_name.as_ref().ok_or(OtaError::InvalidFile)?;
+
+        let data_topic = OtaTopic::Data(Encoding::Cbor, stream_name.as_str())
+            .format::<256>(self.0.client_id())?;
+
+        let notify_topic: heapless::String<256> = JobTopic::NotifyNext
+            .format::<256>(self.0.client_id())
+            .map_err(|_| OtaError::Overflow)?;
+
+        debug!(
+            "Subscribing to: [{:?}] and [{:?}]",
+            &data_topic, &notify_topic
+        );
+
+        let sub = self
+            .0
+            .subscribe(&[
+                (data_topic.as_str(), QoS::AtMostOnce),
+                (notify_topic.as_str(), QoS::AtMostOnce),
+            ])
+            .await
+            .map_err(|_| OtaError::Mqtt)?;
+
+        let mut transfer = MqttTransfer {
+            sub,
+            client: self.0,
+            job_name: file_ctx.job_name.clone(),
+            stream_name: stream_name.clone(),
+            file_id: file_ctx.fileid,
+            block_size: config.block_size,
+            batch_remaining: 0,
+            max_blocks_per_request: config.max_blocks_per_request,
+            request_wait: config.request_wait,
+            max_momentum: config.max_request_momentum,
+            momentum: 0,
+            bitmap: progress.bitmap.clone(),
+            block_offset: progress.block_offset,
+        };
+
+        // Publish initial block request
+        transfer.publish_block_request().await?;
+
+        Ok(transfer)
     }
 }

--- a/src/ota/encoding/json.rs
+++ b/src/ota/encoding/json.rs
@@ -8,7 +8,8 @@ use serde::Deserialize;
 #[serde(rename = "afr_ota")]
 pub struct OtaJob<'a> {
     pub protocols: heapless::Vec<Protocol, 2>,
-    pub streamname: &'a str,
+    #[serde(default)]
+    pub streamname: Option<&'a str>,
     pub files: heapless::Vec<FileDescription<'a>, 1>,
 }
 

--- a/src/ota/encoding/mod.rs
+++ b/src/ota/encoding/mod.rs
@@ -61,6 +61,9 @@ pub struct FileContext {
     pub filesize: usize,
     pub fileid: u8,
     pub certfile: Option<heapless::String<64>>,
+    #[cfg(feature = "ota_http_data")]
+    pub update_data_url: Option<heapless::String<2048>>,
+    #[cfg(not(feature = "ota_http_data"))]
     pub update_data_url: Option<heapless::String<64>>,
     pub auth_scheme: Option<heapless::String<64>>,
     pub signature: Option<Signature>,
@@ -70,9 +73,8 @@ pub struct FileContext {
     pub status_details: StatusDetailsOwned,
     pub block_offset: u32,
     pub blocks_remaining: usize,
-    pub request_block_remaining: u32,
     pub job_name: heapless::String<64>,
-    pub stream_name: heapless::String<64>,
+    pub stream_name: Option<heapless::String<64>>,
     pub bitmap: Bitmap,
 }
 
@@ -113,9 +115,10 @@ impl FileContext {
             certfile: file_desc
                 .certfile
                 .map(|cert| heapless::String::try_from(cert).unwrap()),
-            update_data_url: file_desc
-                .update_data_url
-                .map(|s| heapless::String::try_from(s).unwrap()),
+            update_data_url: match file_desc.update_data_url {
+                Some(s) => Some(heapless::String::try_from(s).map_err(|_| OtaError::Overflow)?),
+                None => None,
+            },
             auth_scheme: file_desc
                 .auth_scheme
                 .map(|s| heapless::String::try_from(s).unwrap()),
@@ -138,9 +141,11 @@ impl FileContext {
 
             job_name: heapless::String::try_from(job_data.job_name).unwrap(),
             block_offset,
-            request_block_remaining: (bitmap.len() as u32).min(config.max_blocks_per_request),
             blocks_remaining: file_desc.filesize.div_ceil(config.block_size),
-            stream_name: heapless::String::try_from(job_data.ota_document.streamname).unwrap(),
+            stream_name: job_data
+                .ota_document
+                .streamname
+                .map(|s| heapless::String::try_from(s).unwrap()),
             bitmap,
         })
     }

--- a/src/ota/error.rs
+++ b/src/ota/error.rs
@@ -22,6 +22,8 @@ pub enum OtaError {
         embedded_storage_async::nor_flash::NorFlashErrorKind,
     ),
     Mqtt,
+    #[cfg(feature = "ota_http_data")]
+    Http,
     Encoding,
     Pal(OtaPalError),
     Timeout,
@@ -30,7 +32,7 @@ pub enum OtaError {
 
 impl OtaError {
     pub fn is_retryable(&self) -> bool {
-        matches!(self, Self::Encoding | Self::Timeout)
+        matches!(self, Self::Encoding | Self::Timeout | Self::Momentum)
     }
 }
 
@@ -45,8 +47,7 @@ impl From<JobError> for OtaError {
         match e {
             JobError::Overflow => Self::Overflow,
             JobError::Encoding => Self::Encoding,
-            #[cfg(feature = "mqttrust")]
-            JobError::Mqtt(_) => Self::Mqtt,
+            JobError::Mqtt => Self::Mqtt,
         }
     }
 }

--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -6,7 +6,7 @@ pub mod error;
 pub mod pal;
 pub mod status_details;
 
-use core::{future::Future, ops::DerefMut as _};
+use core::future::Future;
 
 #[cfg(feature = "ota_mqtt_data")]
 pub use data_interface::mqtt::{Encoding, Topic};
@@ -14,14 +14,11 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex, signal::Sign
 use embedded_storage_async::nor_flash::{NorFlash, NorFlashError as _};
 pub use status_details::{OtaStatusDetails, StatusDetailsExt};
 
-use crate::{
-    jobs::data_types::JobStatus,
-    ota::{data_interface::BlockTransfer, encoding::json::JobStatusReason},
-};
+use crate::{jobs::data_types::JobStatus, ota::encoding::json::JobStatusReason};
 
 use self::{
     control_interface::ControlInterface,
-    data_interface::DataInterface,
+    data_interface::{BlockProgress, BlockTransfer, DataInterface, FileBlock, RawBlock},
     encoding::{Bitmap, FileContext},
     pal::{ImageState, ImageStateReason},
 };
@@ -51,7 +48,9 @@ impl Updater {
     ) -> Result<(), error::OtaError> {
         info!(
             "[OTA] Starting perform_ota for job={} stream={} size={}",
-            file_ctx.job_name, file_ctx.stream_name, file_ctx.filesize
+            file_ctx.job_name,
+            file_ctx.stream_name.as_deref().unwrap_or("N/A"),
+            file_ctx.filesize
         );
         // Initialize status details, preserving self_test state if present
         let mut initial_status = OtaStatusDetails::new();
@@ -66,11 +65,8 @@ impl Updater {
             total_blocks: file_ctx.filesize.div_ceil(config.block_size),
             blocks_remaining: file_ctx.filesize.div_ceil(config.block_size),
             block_offset: file_ctx.block_offset,
-            request_block_remaining: (file_ctx.bitmap.len() as u32)
-                .min(config.max_blocks_per_request),
             bitmap: file_ctx.bitmap.clone(),
             file_size: file_ctx.filesize,
-            request_momentum: None,
             status_details: initial_status,
             extra_status: pal.status_details(),
         });
@@ -84,14 +80,6 @@ impl Updater {
         };
 
         info!("Job document was accepted. Attempting to begin the update");
-
-        // Signal used to wake the momentum handler when the download completes,
-        // so it doesn't have to wait for its full sleep timer to expire.
-        let done_signal: Signal<NoopRawMutex, ()> = Signal::new();
-
-        // Spawn the request momentum future
-        let momentum_fut =
-            Self::handle_momentum(data, config, &file_ctx, &progress_state, &done_signal);
 
         // Spawn the status update future
         let status_update_fut = job_updater.handle_status_updates();
@@ -115,135 +103,147 @@ impl Updater {
             };
 
             info!("Initialized file handler! Requesting file blocks");
-            {
-                let mut progress = progress_state.lock().await;
-                progress.request_momentum = Some(0);
-            }
 
-            // Outer loop to handle resubscription on clean session
+            // Outer loop to handle re-establishment on clean session
             loop {
-                // Prepare the storage layer on receiving a new file
-                let mut subscription = data.init_file_transfer(&file_ctx).await?;
+                let block_progress = {
+                    let progress = progress_state.lock().await;
+                    BlockProgress {
+                        bitmap: progress.bitmap.clone(),
+                        block_offset: progress.block_offset,
+                    }
+                };
 
-                {
-                    let mut progress = progress_state.lock().await;
-                    data.request_file_blocks(&file_ctx, &mut progress, config)
-                        .await?;
-                }
+                let mut transfer = data
+                    .begin_transfer(&file_ctx, config, &block_progress)
+                    .await?;
 
                 info!("Awaiting file blocks!");
 
-                // Inner loop to process blocks
+                // Inner loop to process blocks.
+                //
+                // The block processing is split into two phases to satisfy
+                // the borrow checker: the match on `transfer.next_block()`
+                // borrows `transfer`, so `on_block_written` must be called
+                // after the match scope ends.
                 loop {
-                    // Select over the futures
-                    match subscription.next_block().await {
-                        Ok(Some(mut payload)) => {
-                            // Decode the file block received
-                            let mut progress = progress_state.lock().await;
+                    let notify_progress = {
+                        let result = transfer.next_block().await;
+                        match result {
+                            Ok(Some(mut raw)) => {
+                                let mut progress = progress_state.lock().await;
 
-                            match Self::ingest_data_block(
-                                data,
-                                &mut block_writer,
-                                config,
-                                &mut progress,
-                                payload.deref_mut(),
-                            )
-                            .await
-                            {
-                                Ok(true) => {
-                                    // ... (Handle end of file) ...
-                                    match pal.close_file(&file_ctx).await {
-                                        Err(e) => {
-                                            // FIXME: This seems like duplicate status update, as it will also report during cleanup
-                                            // job_updater.signal_update(
-                                            //     JobStatus::Failed,
-                                            //     JobStatusReason::Pal(0),
-                                            // );
-
-                                            return Err(e.into());
-                                        }
-                                        Ok(_) if file_ctx.file_type == Some(0) => {
-                                            job_updater.signal_update(
-                                                JobStatus::InProgress,
-                                                JobStatusReason::SigCheckPassed,
-                                            );
-                                            return Ok(());
-                                        }
-                                        Ok(_) => {
-                                            job_updater.signal_update(
-                                                JobStatus::Succeeded,
-                                                JobStatusReason::Accepted,
-                                            );
-                                            return Ok(());
+                                match raw.decode() {
+                                    Ok(block) => {
+                                        match Self::ingest_data_block(
+                                            &block,
+                                            &mut block_writer,
+                                            config,
+                                            &mut progress,
+                                        )
+                                        .await
+                                        {
+                                            Ok(true) => {
+                                                // All blocks received — close file
+                                                drop(progress);
+                                                match pal.close_file(&file_ctx).await {
+                                                    Err(e) => {
+                                                        return Err(e.into());
+                                                    }
+                                                    Ok(_) if file_ctx.file_type == Some(0) => {
+                                                        job_updater.signal_update(
+                                                            JobStatus::InProgress,
+                                                            JobStatusReason::SigCheckPassed,
+                                                        );
+                                                        return Ok(());
+                                                    }
+                                                    Ok(_) => {
+                                                        job_updater.signal_update(
+                                                            JobStatus::Succeeded,
+                                                            JobStatusReason::Accepted,
+                                                        );
+                                                        return Ok(());
+                                                    }
+                                                }
+                                            }
+                                            Ok(false) => {
+                                                // Block ingested — signal status if milestone
+                                                if progress.blocks_remaining
+                                                    % config.status_update_frequency as usize
+                                                    == 0
+                                                {
+                                                    job_updater.signal_update(
+                                                        JobStatus::InProgress,
+                                                        JobStatusReason::Receiving,
+                                                    );
+                                                }
+                                                Some(BlockProgress {
+                                                    bitmap: progress.bitmap.clone(),
+                                                    block_offset: progress.block_offset,
+                                                })
+                                            }
+                                            Err(e) if e.is_retryable() => {
+                                                error!(
+                                                    "Failed block validation: {:?}! Retrying",
+                                                    e
+                                                );
+                                                None
+                                            }
+                                            Err(e) => return Err(e),
                                         }
                                     }
-                                }
-                                Ok(false) => {
-                                    // ... (Handle successful block processing) ...
-                                    progress.request_momentum = Some(0);
-
-                                    // Update the job status to reflect the download progress
-                                    if progress.blocks_remaining
-                                        % config.status_update_frequency as usize
-                                        == 0
-                                    {
-                                        job_updater.signal_update(
-                                            JobStatus::InProgress,
-                                            JobStatusReason::Receiving,
-                                        );
+                                    Err(e) if e.is_retryable() => {
+                                        error!("Failed block decode: {:?}! Retrying", e);
+                                        None
                                     }
-
-                                    if progress.request_block_remaining > 1 {
-                                        progress.request_block_remaining -= 1;
-                                    } else {
-                                        data.request_file_blocks(&file_ctx, &mut progress, config)
-                                            .await?;
-                                    }
-                                }
-                                Err(e) if e.is_retryable() => {
-                                    // ... (Handle retryable errors) ...
-                                    error!("Failed block validation: {:?}! Retrying", e);
-                                }
-                                Err(e) => {
-                                    // ... (Handle fatal errors) ...
-                                    return Err(e);
+                                    Err(e) => return Err(e),
                                 }
                             }
+                            Ok(None) => {
+                                warn!("[OTA] Data stream ended (clean session/disconnect). Re-establishing and resuming...");
+
+                                let blocks_remaining = {
+                                    let progress = progress_state.lock().await;
+                                    progress.blocks_remaining
+                                };
+
+                                info!("[OTA] Resuming OTA: {} blocks remaining", blocks_remaining);
+
+                                // Break inner loop to trigger re-establishment
+                                break;
+                            }
+
+                            Err(e) if e.is_retryable() => {
+                                // Momentum timeout or transient error — retry
+                                continue;
+                            }
+                            Err(e) => {
+                                error!("Block transfer error: {:?}", e);
+                                return Err(e);
+                            }
                         }
-                        Ok(None) => {
-                            warn!("[OTA] Data stream subscription ended (clean session/disconnect). Resubscribing and resuming...");
+                    };
 
-                            let blocks_remaining = {
-                                let progress = progress_state.lock().await;
-                                progress.blocks_remaining
-                            };
-
-                            info!("[OTA] Resuming OTA: {} blocks remaining", blocks_remaining);
-
-                            // Break inner loop to trigger resubscription in outer loop
-                            break;
-                        }
-
-                        Err(e) => {
-                            error!("Block transfer error: {:?}", e);
-                            return Err(e);
-                        }
+                    // Notify the transfer outside the match scope so the
+                    // borrow from next_block() is released.
+                    if let Some(bp) = notify_progress {
+                        transfer.on_block_written(&bp).await?;
                     }
                 } // End of inner block processing loop
-            } // End of outer resubscribe loop
+            } // End of outer re-establish loop
         };
 
-        let data_fut = async {
-            let res = data_fut.await;
-            done_signal.signal(());
-            res
+        // select: when data_fut completes, status_update_fut is dropped.
+        // The final status update is sent directly below, not via the
+        // signal/handler — the handler loop would block forever otherwise.
+        let data_res = match embassy_futures::select::select(data_fut, status_update_fut).await {
+            embassy_futures::select::Either::First(res) => res,
+            embassy_futures::select::Either::Second(res) => {
+                // status_update_fut returned first — this means a status publish
+                // error occurred. Propagate it.
+                return res;
+            }
         };
-
-        let (data_res, _) = embassy_futures::join::join(
-            data_fut,
-            embassy_futures::select::select(status_update_fut, momentum_fut),
-        )
-        .await;
 
         // Cleanup and update the job status accordingly
         match data_res {
@@ -315,15 +315,12 @@ impl Updater {
         }
     }
 
-    async fn ingest_data_block<D: DataInterface, E: StatusDetailsExt>(
-        data: &D,
+    async fn ingest_data_block<E: StatusDetailsExt>(
+        block: &FileBlock<'_>,
         block_writer: &mut impl NorFlash,
         config: &config::Config,
         progress: &mut ProgressState<E>,
-        payload: &mut [u8],
     ) -> Result<bool, error::OtaError> {
-        let block = data.decode_file_block(payload)?;
-
         if block.validate(config.block_size, progress.file_size) {
             if block.block_id < progress.block_offset as usize
                 || !progress
@@ -385,59 +382,6 @@ impl Updater {
             Err(error::OtaError::BlockOutOfRange)
         }
     }
-
-    async fn handle_momentum<D: DataInterface, E: StatusDetailsExt>(
-        data: &D,
-        config: &config::Config,
-        file_ctx: &FileContext,
-        progress_state: &Mutex<NoopRawMutex, ProgressState<E>>,
-        done_signal: &Signal<NoopRawMutex, ()>,
-    ) -> Result<(), error::OtaError> {
-        loop {
-            match embassy_futures::select::select(
-                embassy_time::Timer::after(config.request_wait),
-                done_signal.wait(),
-            )
-            .await
-            {
-                // Timer expired — check momentum
-                embassy_futures::select::Either::First(()) => {}
-                // Download completed — exit immediately
-                embassy_futures::select::Either::Second(()) => break,
-            }
-
-            let mut progress = progress_state.lock().await;
-
-            if progress.blocks_remaining == 0 {
-                // No more blocks to request
-                break;
-            }
-
-            let Some(request_momentum) = &mut progress.request_momentum else {
-                continue;
-            };
-
-            // Increment momentum
-            *request_momentum += 1;
-
-            if *request_momentum == 1 {
-                continue;
-            }
-
-            if *request_momentum <= config.max_request_momentum {
-                warn!("Momentum requesting more blocks!");
-
-                // Request data blocks
-                data.request_file_blocks(file_ctx, &mut progress, config)
-                    .await?;
-            } else {
-                // Too much momentum, abort
-                return Err(error::OtaError::MomentumAbort);
-            }
-        }
-
-        Ok(())
-    }
 }
 
 #[derive(Debug)]
@@ -447,8 +391,6 @@ pub struct ProgressState<E: StatusDetailsExt = ()> {
     pub blocks_remaining: usize,
     pub file_size: usize,
     pub block_offset: u32,
-    pub request_block_remaining: u32,
-    pub request_momentum: Option<u8>,
     #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
     pub bitmap: Bitmap,
     #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
@@ -595,19 +537,6 @@ impl<'a, C: ControlInterface, E: StatusDetailsExt> JobUpdater<'a, C, E> {
         // Call the platform specific code to set the image state
         let image_state = match pal.set_platform_image_state(image_state).await {
             Err(e) if !matches!(image_state, ImageState::Aborted(_)) => {
-                // If the platform image state couldn't be set correctly, force
-                // fail the update by setting the image state to "Rejected"
-                // unless it's already in "Aborted".
-
-                // Capture the failure reason if not already set (and we're not
-                // already Aborted as checked above). Otherwise Keep the
-                // original reject reason code since it is possible for the PAL
-                // to fail to update the image state in some cases (e.g. a reset
-                // already caused the bundle rollback and we failed to rollback
-                // again).
-
-                // Intentionally override reason since we failed within this
-                // function
                 ImageState::Rejected(ImageStateReason::Pal(e))
             }
             _ => image_state,
@@ -618,8 +547,6 @@ impl<'a, C: ControlInterface, E: StatusDetailsExt> JobUpdater<'a, C, E> {
 
         match image_state {
             ImageState::Testing(_) => {
-                // We discovered we're ready for test mode, put job status
-                // in self_test active
                 self.control
                     .update_job_status(
                         self.file_ctx,
@@ -630,8 +557,6 @@ impl<'a, C: ControlInterface, E: StatusDetailsExt> JobUpdater<'a, C, E> {
                     .await?;
             }
             ImageState::Accepted => {
-                // Now that we have accepted the firmware update, we can
-                // complete the job
                 self.control
                     .update_job_status(
                         self.file_ctx,
@@ -642,10 +567,6 @@ impl<'a, C: ControlInterface, E: StatusDetailsExt> JobUpdater<'a, C, E> {
                     .await?;
             }
             ImageState::Rejected(reason) => {
-                // The firmware update was rejected, complete the job as
-                // FAILED (Job service will not allow us to set REJECTED
-                // after the job has been started already).
-
                 self.control
                     .update_job_status(
                         self.file_ctx,
@@ -656,10 +577,6 @@ impl<'a, C: ControlInterface, E: StatusDetailsExt> JobUpdater<'a, C, E> {
                     .await?;
             }
             ImageState::Aborted(reason) => {
-                // The firmware update was aborted, complete the job as
-                // FAILED (Job service will not allow us to set REJECTED
-                // after the job has been started already).
-
                 self.control
                     .update_job_status(
                         self.file_ctx,
@@ -670,8 +587,6 @@ impl<'a, C: ControlInterface, E: StatusDetailsExt> JobUpdater<'a, C, E> {
                     .await?;
             }
             ImageState::Unknown => {
-                // Unknown state, abort with no reason
-
                 self.control
                     .update_job_status(
                         self.file_ctx,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,87 +1,67 @@
-# AWS IoT Rust Examples
+# Integration Tests
 
-This repository contains examples demonstrating how to use the AWS IoT SDK for Rust. These examples are also integrated into our CI pipeline as integration tests.
+These integration tests run against real AWS IoT infrastructure. They require AWS credentials, a provisioned IoT thing, and device certificates.
 
-## Examples
+## Prerequisites
 
-### AWS IoT Fleet Provisioning (`provisioning.rs`)
+All tests require:
 
-This example demonstrates how to use the AWS IoT Fleet Provisioning service to provision a device.
+* A PKCS #12 (.pfx) identity file in `tests/secrets/identity.pfx`
+* A root CA certificate in `tests/secrets/root-ca.pem`
+* Environment variables:
+  * `IDENTITY_PASSWORD` — password for the .pfx file
+  * `AWS_HOSTNAME` — your AWS IoT endpoint (e.g. `xxxxx-ats.iot.eu-west-1.amazonaws.com`)
 
-**Requirements:**
+To create the .pfx file from PEM certificates:
 
-* An AWS account with AWS IoT Core and AWS IoT Fleet Provisioning configured.
-* A device certificate and private key. You can generate these using OpenSSL or your preferred method.
-* A provisioning template configured in your AWS account.
+```bash
+openssl pkcs12 -export -out identity.pfx -inkey private.pem.key -in certificate.pem.crt -certfile root-ca.pem
+```
 
-**To run the example:**
+Fleet provisioning additionally requires `tests/secrets/claim_identity.pfx` with claim credentials.
 
-1. **Create a PKCS #12 (.pfx) identity file:**
-   If you haven't already, create a PKCS #12 (.pfx) file containing your device certificate and private key.  You can use OpenSSL for this:
+## Tests
 
-   ```bash
-   openssl pkcs12 -export -out claim_identity.pfx -inkey private.pem.key -in certificate.pem.crt -certfile root-ca.pem
-   ```
-   Replace `private.pem.key`, `certificate.pem.crt`, and `root-ca.pem` with your actual file names.
+### OTA via MQTT (`ota_mqtt.rs`)
 
-2. **Store the Identity File:**
-    Place the `claim_identity.pfx` file in the `tests/secrets/` directory.
+OTA firmware update using MQTT for both control and data planes. Uses `mqttrust` (no_std/embassy MQTT client). Creates an OTA job with MQTT protocol, downloads the file as CBOR-encoded blocks over MQTT streams, verifies file integrity and signature, then runs the self-test commit flow.
 
-3. **Set Environment Variables:**
-    Set the following environment variables:
-   * `IDENTITY_PASSWORD`: The password you set for the `claim_identity.pfx` file.
-   * `AWS_HOSTNAME`: Your AWS IoT endpoint. You can find this in the AWS IoT console.
+```bash
+cargo test --test ota_mqtt --features "ota_mqtt_data,log,std"
+```
 
-4. **Run the Test:**
+### OTA via HTTP (`ota_http.rs`)
 
-   ```bash
-   cargo test --test provisioning --features "log,std"
-   ```
+OTA firmware update using MQTT for the control plane and HTTP for the data plane. Uses `rumqttc` (std/tokio MQTT client) for job management and `reqwest` for downloading the file via HTTP Range requests against a pre-signed S3 URL. Same verification and self-test flow as the MQTT variant.
 
-### AWS IoT OTA (`ota_mqtt.rs`)
+```bash
+cargo test --test ota_http --features "ota_http_reqwest,mqtt_rumqttc,log,std"
+```
 
-This example demonstrates how to perform an over-the-air (OTA) firmware update using AWS IoT Jobs.
+### Device Defender Metrics (`metric.rs`)
 
-**Requirements:**
+Publishes device defender metrics and verifies an accepted response from AWS IoT.
 
-* An AWS account with AWS IoT Core and AWS IoT Jobs configured.
-* A device certificate and private key.
-* A PKCS #12 (.pfx) file containing the device certificate and private key (see previous example for creation instructions).
-* An OTA update job created in your AWS account.
+```bash
+cargo test --test metric --features "metric_cbor,log,std"
+```
 
-**To run the example:**
+### Fleet Provisioning (`provisioning.rs`)
 
-1. **Create an OTA Job:** Create an OTA update job.  You can find instructions on how to do this in the AWS IoT documentation or refer to the `scripts/create_ota.sh` script for inspiration.
-2. **Store the Identity File:** Ensure the `identity.pfx` file (containing your device certificate and private key) is located in the `tests/secrets/` directory.
-3. **Set Environment Variables:**
-   * `IDENTITY_PASSWORD`: The password for your `identity.pfx` file.
-   * `AWS_HOSTNAME`: Your AWS IoT endpoint.
+Provisions a device using AWS IoT Fleet Provisioning with claim-based workflow and certificate signing.
 
-4. **Run the Test:**
+```bash
+cargo test --test provisioning --features "provision_cbor,log,std"
+```
 
-   ```bash
-   cargo test --test ota_mqtt --features "log,std"
-   ```
+### Device Shadows (`shadows.rs`)
 
-### AWS IoT Shadows (`shadows.rs`)
+Tests device shadow operations — create, update, get, and delete — including named shadows and KV-persist integration.
 
-This example demonstrates how to interact with AWS IoT device shadows. Device shadows allow you to store and retrieve the latest state of your devices even when they are offline.
+```bash
+cargo test --test shadows --features "std,log,shadows_kv_persist,shadows_builders"
+```
 
-**Requirements:**
+## CI
 
-* An AWS account with AWS IoT Core and AWS IoT Device Shadows configured.
-* A device certificate and private key.
-* A PKCS #12 (.pfx) file containing the device certificate and private key (see previous examples for creation instructions).
-
-**To run the example:**
-
-1. **Store the Identity File:** Ensure the `claim_identity.pfx` file (containing your device certificate and private key) is in the `tests/secrets/` directory.
-2. **Set Environment Variables:**
-   * `IDENTITY_PASSWORD`: The password for your `claim_identity.pfx` file.
-   * `AWS_HOSTNAME`: Your AWS IoT endpoint.
-
-3. **Run the Test:**
-
-   ```bash
-   cargo test --test shadows --features "log,std"
-   ```
+All integration tests run in CI after build, unit tests, fmt, and clippy pass. See `.github/workflows/ci.yml` for the full feature set used.

--- a/tests/common/aws_ota.rs
+++ b/tests/common/aws_ota.rs
@@ -148,11 +148,18 @@ impl OtaTestContext {
     }
 }
 
-/// Set up AWS OTA test resources.
+/// Set up AWS OTA test resources using MQTT protocol.
 ///
 /// Returns `Some(OtaTestContext)` if credentials are available and role
 /// assumption succeeds, or `None` if the test should be skipped.
 pub async fn setup() -> Option<OtaTestContext> {
+    setup_with_protocols(&[aws_sdk_iot::types::Protocol::Mqtt]).await
+}
+
+/// Set up AWS OTA test resources with the given protocol(s).
+pub async fn setup_with_protocols(
+    protocols: &[aws_sdk_iot::types::Protocol],
+) -> Option<OtaTestContext> {
     let region = aws_config::Region::new(REGION);
 
     // Load default MGMT credentials from environment
@@ -286,7 +293,7 @@ pub async fn setup() -> Option<OtaTestContext> {
 
     let signature = base64::Engine::encode(
         &base64::engine::general_purpose::STANDARD,
-        b"This is my custom signature\n",
+        b"This is my custom signature",
     );
 
     let ota_update_role_arn = format!("arn:aws:iam::{TARGET_ACCOUNT_ID}:role/{OTA_UPDATE_ROLE}");
@@ -339,7 +346,7 @@ pub async fn setup() -> Option<OtaTestContext> {
         .ota_update_id(&update_id)
         .description("RustOT OTA integration test")
         .targets(&thing_arn)
-        .protocols(aws_sdk_iot::types::Protocol::Mqtt)
+        .set_protocols(Some(protocols.to_vec()))
         .target_selection(aws_sdk_iot::types::TargetSelection::Snapshot)
         .role_arn(&ota_update_role_arn)
         .files(ota_file)

--- a/tests/common/file_handler.rs
+++ b/tests/common/file_handler.rs
@@ -184,7 +184,7 @@ impl OtaPal for FileHandler {
                 sig => panic!("Unexpected signature format! {:?}", sig),
             };
 
-            assert_eq!(signature, "This is my custom signature\\n");
+            assert_eq!(signature, "This is my custom signature");
 
             self.plateform_state = State::Swap;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,3 +3,113 @@ pub mod aws_ota;
 pub mod credentials;
 pub mod file_handler;
 pub mod network;
+
+#[allow(dead_code)]
+pub fn handle_ota(
+    message: impl rustot::mqtt::MqttMessage,
+    config: &rustot::ota::config::Config,
+) -> Option<rustot::ota::encoding::FileContext> {
+    use rustot::{
+        jobs::{
+            self,
+            data_types::{DescribeJobExecutionResponse, NextJobExecutionChanged},
+        },
+        ota::{
+            encoding::{json::OtaJob, FileContext},
+            JobEventData,
+        },
+    };
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    pub enum Jobs<'b> {
+        #[serde(rename = "afr_ota")]
+        #[serde(borrow)]
+        Ota(OtaJob<'b>),
+    }
+
+    impl<'b> Jobs<'b> {
+        pub fn ota_job(self) -> Option<OtaJob<'b>> {
+            match self {
+                Jobs::Ota(ota_job) => Some(ota_job),
+            }
+        }
+    }
+
+    let topic = jobs::Topic::from_str(message.topic_name());
+    log::debug!(
+        "handle_ota: topic={:?} payload_len={}",
+        message.topic_name(),
+        message.payload().len()
+    );
+
+    // Use serde_json (std) instead of serde_json_core for test deserialization.
+    // serde_json_core has a fixed-size scratch buffer that overflows on the
+    // long pre-signed S3 URLs in HTTP OTA job documents (~1000+ chars with
+    // JSON-escaped forward slashes).
+    let job = match topic {
+        Some(jobs::Topic::NotifyNext) => {
+            match serde_json::from_slice::<NextJobExecutionChanged<Jobs>>(message.payload()) {
+                Ok(execution_changed) => execution_changed.execution?,
+                Err(e) => {
+                    log::error!("handle_ota: failed to deserialize NotifyNext: {:?}", e);
+                    return None;
+                }
+            }
+        }
+        Some(jobs::Topic::DescribeAccepted(_)) => {
+            match serde_json::from_slice::<DescribeJobExecutionResponse<Jobs>>(message.payload()) {
+                Ok(execution_changed) => {
+                    if execution_changed.execution.is_none() {
+                        if std::env::var("CI").is_ok() {
+                            panic!("No OTA jobs queued?");
+                        }
+                        return None;
+                    }
+                    execution_changed.execution?
+                }
+                Err(e) => {
+                    log::error!(
+                        "handle_ota: failed to deserialize DescribeAccepted: {:?}",
+                        e
+                    );
+                    return None;
+                }
+            }
+        }
+        _ => {
+            log::warn!("handle_ota: unexpected topic: {:?}", message.topic_name());
+            return None;
+        }
+    };
+
+    let ota_job = match job.job_document {
+        Some(doc) => match doc.ota_job() {
+            Some(job) => job,
+            None => {
+                log::error!("handle_ota: job_document present but not an OTA job");
+                return None;
+            }
+        },
+        None => {
+            log::error!("handle_ota: no job_document in execution");
+            return None;
+        }
+    };
+
+    match FileContext::new_from(
+        JobEventData {
+            job_name: job.job_id,
+            ota_document: ota_job,
+            status_details: job.status_details,
+        },
+        0,
+        config,
+    ) {
+        Ok(ctx) => Some(ctx),
+        Err(e) => {
+            log::error!("handle_ota: FileContext::new_from failed: {:?}", e);
+            None
+        }
+    }
+}

--- a/tests/ota_http.rs
+++ b/tests/ota_http.rs
@@ -1,0 +1,176 @@
+#![cfg(all(feature = "ota_http_reqwest", feature = "mqtt_rumqttc"))]
+#![allow(async_fn_in_trait)]
+
+mod common;
+
+use common::credentials;
+use common::file_handler::{FileHandler, State as FileHandlerState};
+use serial_test::serial;
+
+use rustot::{
+    mqtt::{rumqttc::RumqttcClient, Mqtt, MqttClient, MqttSubscription},
+    ota::{
+        self,
+        data_interface::http::{HttpInterface, ReqwestClient},
+        Updater,
+    },
+};
+
+#[tokio::test]
+#[serial]
+async fn test_http_ota() {
+    let _ = env_logger::Builder::from_default_env()
+        .filter_module("serial_test", log::LevelFilter::Warn)
+        .try_init();
+
+    log::info!("Starting HTTP OTA test...");
+
+    let ctx =
+        match common::aws_ota::setup_with_protocols(&[aws_sdk_iot::types::Protocol::Http]).await {
+            Some(ctx) => ctx,
+            None => {
+                log::info!(
+                    "Skipping HTTP OTA test: no valid AWS credentials or role assumption failed"
+                );
+                return;
+            }
+        };
+
+    let test_result = common::aws_ota::catch_unwind_future(run_ota_http()).await;
+
+    // Capture cloud-side status before cleanup changes it
+    let cloud_status = ctx.describe_job_execution().await;
+
+    // Always cleanup
+    ctx.cleanup().await;
+
+    match test_result {
+        Ok(inner) => {
+            inner.unwrap();
+            // Assert cloud-side job succeeded
+            let (status, details) = cloud_status.expect("Failed to describe job execution");
+            assert_eq!(
+                status,
+                aws_sdk_iot::types::JobExecutionStatus::Succeeded,
+                "Expected cloud job status SUCCEEDED, got {:?} with details: {:?}",
+                status,
+                details
+            );
+        }
+        Err(panic) => {
+            if let Ok((status, details)) = &cloud_status {
+                log::error!(
+                    "Test panicked! Cloud job status at panic: {:?}, details: {:?}",
+                    status,
+                    details
+                );
+            }
+            std::panic::resume_unwind(panic);
+        }
+    }
+}
+
+async fn run_ota_http() -> Result<(), ota::error::OtaError> {
+    let thing_name = option_env!("THING_NAME").unwrap_or("rustot-test");
+    let hostname = credentials::HOSTNAME.unwrap();
+    let pw = std::env::var("IDENTITY_PASSWORD").unwrap_or_default();
+
+    // Set up rumqttc with native-tls (PKCS12 client cert + PEM CA)
+    let mut mqtt_options = rumqttc::MqttOptions::new(thing_name, hostname, 8883);
+    mqtt_options.set_keep_alive(std::time::Duration::from_secs(50));
+    mqtt_options.set_transport(rumqttc::Transport::tls_with_config(
+        rumqttc::TlsConfiguration::SimpleNative {
+            ca: include_bytes!("secrets/root-ca.pem").to_vec(),
+            client_auth: Some((include_bytes!("secrets/identity.pfx").to_vec(), pw)),
+        },
+    ));
+
+    let (rumqttc_client, _eventloop_handle) = RumqttcClient::new(mqtt_options, 10);
+    rumqttc_client.wait_connected().await;
+
+    let mqtt = Mqtt(&rumqttc_client);
+
+    // Subscribe to job topics
+    let mut jobs_subscription = rumqttc_client
+        .subscribe(&[
+            (
+                &rustot::jobs::JobTopic::NotifyNext
+                    .format::<64>(thing_name)
+                    .map_err(|_| ota::error::OtaError::Overflow)?,
+                rustot::mqtt::QoS::AtMostOnce,
+            ),
+            (
+                &rustot::jobs::JobTopic::DescribeAccepted("$next")
+                    .format::<64>(thing_name)
+                    .map_err(|_| ota::error::OtaError::Overflow)?,
+                rustot::mqtt::QoS::AtMostOnce,
+            ),
+        ])
+        .await
+        .map_err(|_| ota::error::OtaError::Mqtt)?;
+
+    Updater::check_for_job(&mqtt).await?;
+
+    let ota_config = ota::config::Config {
+        block_size: 4096,
+        ..Default::default()
+    };
+
+    let message = jobs_subscription.next_message().await.unwrap();
+
+    let mut file_ctx = common::handle_ota(message, &ota_config)
+        .expect("Failed to parse OTA job document — check logs for details");
+
+    jobs_subscription
+        .unsubscribe()
+        .await
+        .map_err(|_| ota::error::OtaError::Mqtt)?;
+
+    log::info!(
+        "OTA job received! Protocols: {:?}, update_data_url present: {}",
+        file_ctx.protocols,
+        file_ctx.update_data_url.is_some()
+    );
+
+    let mut file_handler = FileHandler::new("tests/assets/ota_file".to_owned());
+
+    // HTTP for data interface (file download via Range requests)
+    let http_client = ReqwestClient::new(reqwest::Client::new());
+    let http_interface = HttpInterface::new(http_client);
+
+    // MQTT (rumqttc) for control, HTTP (reqwest) for data
+    Updater::perform_ota(
+        &mqtt,
+        &http_interface,
+        file_ctx.clone(),
+        &mut file_handler,
+        &ota_config,
+    )
+    .await?;
+
+    assert_eq!(file_handler.plateform_state, FileHandlerState::Swap);
+
+    log::info!("Running OTA handler second time to verify state match...");
+
+    // Run it twice to simulate image commit after bootloader swap
+    file_ctx
+        .status_details
+        .insert(
+            heapless::String::try_from("self_test").unwrap(),
+            heapless::String::try_from("active").unwrap(),
+        )
+        .unwrap();
+
+    Updater::perform_ota(
+        &mqtt,
+        &http_interface,
+        file_ctx,
+        &mut file_handler,
+        &ota_config,
+    )
+    .await?;
+
+    assert_eq!(file_handler.plateform_state, FileHandlerState::Boot);
+
+    Ok(())
+}

--- a/tests/ota_mqtt.rs
+++ b/tests/ota_mqtt.rs
@@ -10,87 +10,16 @@ use common::network::TlsNetwork;
 use embassy_futures::select;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use mqttrust::transport::embedded_nal::NalTransport;
-use mqttrust::{
-    Config, DomainBroker, Message, SliceBufferProvider, State, Subscribe, SubscribeTopic,
-};
-use serde::Deserialize;
+use mqttrust::{Config, DomainBroker, State, Subscribe, SubscribeTopic};
 use serial_test::serial;
 use static_cell::StaticCell;
 
 use aws_credential_types::provider::SharedCredentialsProvider;
 use rustot::{
-    jobs::{
-        self,
-        data_types::{DescribeJobExecutionResponse, NextJobExecutionChanged},
-    },
+    jobs,
     mqtt::Mqtt,
-    ota::{
-        self,
-        encoding::{json::OtaJob, FileContext},
-        pal::OtaPalError,
-        JobEventData, Updater,
-    },
+    ota::{self, pal::OtaPalError, Updater},
 };
-
-#[derive(Debug, Deserialize)]
-pub enum Jobs<'a> {
-    #[serde(rename = "afr_ota")]
-    #[serde(borrow)]
-    Ota(OtaJob<'a>),
-}
-
-impl<'a> Jobs<'a> {
-    pub fn ota_job(self) -> Option<OtaJob<'a>> {
-        match self {
-            Jobs::Ota(ota_job) => Some(ota_job),
-        }
-    }
-}
-
-fn handle_ota<'a>(
-    message: Message<'a, NoopRawMutex, SliceBufferProvider<'a>>,
-    config: &ota::config::Config,
-) -> Option<FileContext> {
-    let job = match jobs::Topic::from_str(message.topic_name()) {
-        Some(jobs::Topic::NotifyNext) => {
-            let (execution_changed, _) =
-                serde_json_core::from_slice::<NextJobExecutionChanged<Jobs>>(message.payload())
-                    .ok()?;
-            execution_changed.execution?
-        }
-        Some(jobs::Topic::DescribeAccepted(_)) => {
-            let (execution_changed, _) = serde_json_core::from_slice::<
-                DescribeJobExecutionResponse<Jobs>,
-            >(message.payload())
-            .ok()?;
-
-            if execution_changed.execution.is_none() {
-                if std::env::var("CI").is_ok() {
-                    panic!("No OTA jobs queued?");
-                }
-                return None;
-            }
-
-            execution_changed.execution?
-        }
-        _ => {
-            return None;
-        }
-    };
-
-    let ota_job = job.job_document?.ota_job()?;
-
-    FileContext::new_from(
-        JobEventData {
-            job_name: job.job_id,
-            ota_document: ota_job,
-            status_details: job.status_details,
-        },
-        0,
-        config,
-    )
-    .ok()
-}
 
 #[tokio::test(flavor = "current_thread")]
 #[serial]
@@ -199,7 +128,7 @@ async fn run_ota_happy_path() -> Result<(), ota::error::OtaError> {
 
         let message = jobs_subscription.next_message().await.unwrap();
 
-        if let Some(mut file_ctx) = handle_ota(message, &ota_config) {
+        if let Some(mut file_ctx) = common::handle_ota(message, &ota_config) {
             // Nested subscriptions are a problem for mqttrust, so unsubscribe here
             jobs_subscription.unsubscribe().await.unwrap();
 
@@ -438,7 +367,7 @@ async fn run_ota_cancel(
 
         let message = jobs_subscription.next_message().await.unwrap();
 
-        if let Some(file_ctx) = handle_ota(message, &ota_config) {
+        if let Some(file_ctx) = common::handle_ota(message, &ota_config) {
             jobs_subscription.unsubscribe().await.unwrap();
 
             // Run OTA and cancel concurrently
@@ -568,7 +497,7 @@ async fn run_ota_signature_failure() -> Result<(), ota::error::OtaError> {
 
         let message = jobs_subscription.next_message().await.unwrap();
 
-        if let Some(file_ctx) = handle_ota(message, &ota_config) {
+        if let Some(file_ctx) = common::handle_ota(message, &ota_config) {
             jobs_subscription.unsubscribe().await.unwrap();
 
             // This should fail with SignatureCheckFailed


### PR DESCRIPTION
## Summary

- Redesign `DataInterface`/`BlockTransfer` traits to support both push-based (MQTT) and pull-based (HTTP) protocols. Introduces `RawBlock` GAT to fold protocol-specific decoding into the transfer while preserving zero-copy CBOR deserialization for MQTT.
- Add `HttpClient` trait (no_std compatible) with `reqwest` implementation behind `ota_http_reqwest` feature. The trait is designed to also support future `reqless` (no_std HTTP) implementations.
- Move momentum/batch tracking from the orchestrator into `MqttTransfer`, simplifying `perform_ota` by removing the parallel momentum future and done_signal.
- Add HTTP OTA integration test using `rumqttc` for MQTT control plane and `reqwest` for HTTP data plane, testing a realistic std deployment setup.
- Fix `JobError::Mqtt` leaking `mqttrust::Error` — now a unit variant.
- Make `OtaJob::streamname` optional (absent in HTTP-only OTA job documents).
- Update mqttrust to 629e3bb (fixes `write_in_progress` pubsub bug that blocked incoming messages when subscriber_count was zero).