### PR TITLE
Add job-agnostic reject_job, refactor tests to use JobAgent

### DIFF
--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -128,6 +128,7 @@ pub enum JobError {
     Overflow,
     Encoding,
     Mqtt,
+    Timeout,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/jobs/stream.rs
+++ b/src/jobs/stream.rs
@@ -1,10 +1,10 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-use crate::mqtt::{Mqtt, MqttClient, MqttMessage, QoS};
+use crate::mqtt::{Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
 
 use super::{
-    data_types::{DescribeJobExecutionResponse, JobExecution, NextJobExecutionChanged},
-    JobError, JobTopic, Jobs, Topic,
+    data_types::{DescribeJobExecutionResponse, JobExecution, JobStatus, NextJobExecutionChanged},
+    JobError, JobTopic, Jobs, Topic, MAX_JOB_ID_LEN, MAX_THING_NAME_LEN,
 };
 
 /// Helper for the AWS IoT Jobs subscribe/describe lifecycle.
@@ -83,6 +83,75 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
 
         Ok(sub)
     }
+
+    /// Reject a job with a reason string.
+    ///
+    /// Publishes a `REJECTED` status update for the given job and waits for
+    /// the cloud to acknowledge. The reason is placed in `statusDetails` as
+    /// `{"reason": "<value>"}`.
+    ///
+    /// This is job-agnostic — it works for any AWS IoT Jobs execution, not
+    /// only OTA jobs.
+    pub async fn reject_job(&self, job_id: &str, reason: &str) -> Result<(), JobError> {
+        let client_id = self.mqtt.0.client_id();
+
+        // Subscribe to accepted/rejected before publishing so we can confirm
+        // the cloud processed the update.
+        let accepted_topic = JobTopic::UpdateAccepted(job_id)
+            .format::<{ MAX_THING_NAME_LEN + MAX_JOB_ID_LEN + 25 }>(client_id)?;
+        let rejected_topic = JobTopic::UpdateRejected(job_id)
+            .format::<{ MAX_THING_NAME_LEN + MAX_JOB_ID_LEN + 25 }>(client_id)?;
+
+        let mut sub = self
+            .mqtt
+            .0
+            .subscribe(&[
+                (accepted_topic.as_str(), QoS::AtMostOnce),
+                (rejected_topic.as_str(), QoS::AtMostOnce),
+            ])
+            .await
+            .map_err(|_| JobError::Mqtt)?;
+
+        // Publish the rejection with QoS 1
+        let topic = JobTopic::Update(job_id)
+            .format::<{ MAX_THING_NAME_LEN + MAX_JOB_ID_LEN + 25 }>(client_id)?;
+
+        let details = RejectDetails { reason };
+        let payload = Jobs::update(JobStatus::Rejected)
+            .client_token(client_id)
+            .status_details(&details);
+
+        self.mqtt
+            .0
+            .publish_with_options(&topic, payload, PublishOptions::new().qos(QoS::AtLeastOnce))
+            .await
+            .map_err(|_| JobError::Mqtt)?;
+
+        // Wait for the cloud to accept or reject the update
+        loop {
+            let message = match embassy_time::with_timeout(
+                embassy_time::Duration::from_secs(5),
+                sub.next_message(),
+            )
+            .await
+            {
+                Ok(Some(msg)) => msg,
+                Ok(None) => return Err(JobError::Mqtt),
+                Err(_) => return Err(JobError::Timeout),
+            };
+
+            match Topic::from_str(message.topic_name()) {
+                Some(Topic::UpdateAccepted(_)) => return Ok(()),
+                Some(Topic::UpdateRejected(_)) => return Err(JobError::Mqtt),
+                _ => continue,
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct RejectDetails<'a> {
+    reason: &'a str,
 }
 
 /// Parse a job execution from an MQTT message (from `notify-next` or

--- a/src/mqtt/mqttrust.rs
+++ b/src/mqtt/mqttrust.rs
@@ -157,6 +157,79 @@ impl<'a, M: RawMutex> crate::mqtt::MqttClient for mqttrust::MqttClient<'a, M> {
     }
 }
 
+/// Owned copy of an MQTT message, backed by fixed-size `heapless` buffers.
+///
+/// Use this to copy a message out of the mqttrust ring buffer so the
+/// grant is released immediately. Holding a `mqttrust::Message` pins the
+/// pubsub ring buffer and prevents incoming messages from being written —
+/// this type avoids that.
+///
+/// # Type Parameters
+///
+/// * `TOPIC` — max topic length in bytes (default 256)
+/// * `PAYLOAD` — max payload length in bytes (default 2048)
+///
+/// # Example
+///
+/// ```ignore
+/// let message = subscription.next_message().await.unwrap();
+/// let owned = OwnedMessage::from_ref(&message);
+/// drop(message); // release the ring buffer grant
+///
+/// // owned implements MqttMessage — use it anywhere a message is expected
+/// let execution = parse_job_message::<MyJobs>(&mut owned);
+/// ```
+pub struct OwnedMessage<const TOPIC: usize = 256, const PAYLOAD: usize = 2048> {
+    topic: heapless::String<TOPIC>,
+    payload: heapless::Vec<u8, PAYLOAD>,
+    qos: QoS,
+    dup: bool,
+    retain: bool,
+}
+
+impl<const TOPIC: usize, const PAYLOAD: usize> OwnedMessage<TOPIC, PAYLOAD> {
+    /// Copy a mqttrust message into owned buffers, releasing the ring buffer grant.
+    ///
+    /// Returns `None` if the topic or payload exceeds the buffer capacity.
+    pub fn from_ref<M: RawMutex, B: BufferProvider>(
+        msg: &mqttrust::Message<'_, M, B>,
+    ) -> Option<Self> {
+        Some(Self {
+            topic: heapless::String::try_from(msg.topic_name()).ok()?,
+            payload: heapless::Vec::from_slice(msg.payload()).ok()?,
+            qos: from_mqttrust_qos(msg.qos_pid().qos()),
+            dup: msg.dup(),
+            retain: msg.retain(),
+        })
+    }
+}
+
+impl<const TOPIC: usize, const PAYLOAD: usize> MqttMessage for OwnedMessage<TOPIC, PAYLOAD> {
+    fn topic_name(&self) -> &str {
+        &self.topic
+    }
+
+    fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    fn payload_mut(&mut self) -> &mut [u8] {
+        &mut self.payload
+    }
+
+    fn qos(&self) -> QoS {
+        self.qos
+    }
+
+    fn dup(&self) -> bool {
+        self.dup
+    }
+
+    fn retain(&self) -> bool {
+        self.retain
+    }
+}
+
 /// Re-export mqttrust types for convenience.
 pub use mqttrust::{
     Broker, Config, DomainBroker, Error as EmbeddedMqttError, IpBroker, Message,

--- a/src/ota/error.rs
+++ b/src/ota/error.rs
@@ -48,6 +48,7 @@ impl From<JobError> for OtaError {
             JobError::Overflow => Self::Overflow,
             JobError::Encoding => Self::Encoding,
             JobError::Mqtt => Self::Mqtt,
+            JobError::Timeout => Self::Timeout,
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,114 +4,44 @@ pub mod credentials;
 pub mod file_handler;
 pub mod network;
 
-use rustot::ota::StatusDetailsExt;
+use rustot::{
+    jobs::data_types::JobExecution,
+    ota::{
+        encoding::{json::OtaJob, OtaJobContext},
+        error::OtaError,
+        JobEventData, StatusDetailsExt,
+    },
+};
+use serde::Deserialize;
 
+#[derive(Debug, Deserialize)]
+pub enum OtaJobs<'a> {
+    #[serde(rename = "afr_ota")]
+    #[serde(borrow)]
+    Ota(OtaJob<'a>),
+}
+
+/// Convert a parsed [`JobExecution`] into an [`OtaJobContext`].
+///
+/// Extracts the OTA document from the job execution and constructs the
+/// context needed by [`Updater::perform_ota`].
 #[allow(dead_code)]
-pub fn handle_ota<'a, E: StatusDetailsExt>(
-    topic: &str,
-    payload: &'a [u8],
+pub fn ota_context_from_execution<'a, E: StatusDetailsExt>(
+    execution: JobExecution<'a, OtaJobs<'a>>,
     extra_status: E,
-) -> Option<rustot::ota::encoding::OtaJobContext<'a, E>> {
-    use rustot::{
-        jobs::{
-            self,
-            data_types::{DescribeJobExecutionResponse, NextJobExecutionChanged},
-        },
-        ota::{
-            encoding::{json::OtaJob, OtaJobContext},
-            JobEventData,
-        },
-    };
-    use serde::Deserialize;
-
-    #[derive(Debug, Deserialize)]
-    pub enum Jobs<'b> {
-        #[serde(rename = "afr_ota")]
-        #[serde(borrow)]
-        Ota(OtaJob<'b>),
-    }
-
-    impl<'b> Jobs<'b> {
-        pub fn ota_job(self) -> Option<OtaJob<'b>> {
-            match self {
-                Jobs::Ota(ota_job) => Some(ota_job),
-            }
-        }
-    }
-
-    let parsed_topic = jobs::Topic::from_str(topic);
-    log::debug!(
-        "handle_ota: topic={:?} payload_len={}",
-        topic,
-        payload.len()
-    );
-
-    // Use serde_json (std) instead of serde_json_core for test deserialization.
-    // serde_json_core has a fixed-size scratch buffer that overflows on the
-    // long pre-signed S3 URLs in HTTP OTA job documents.
-    let job = match parsed_topic {
-        Some(jobs::Topic::NotifyNext) => {
-            match serde_json::from_slice::<NextJobExecutionChanged<Jobs>>(payload) {
-                Ok(execution_changed) => execution_changed.execution?,
-                Err(e) => {
-                    log::error!("handle_ota: failed to deserialize NotifyNext: {:?}", e);
-                    return None;
-                }
-            }
-        }
-        Some(jobs::Topic::DescribeAccepted(_)) => {
-            match serde_json::from_slice::<DescribeJobExecutionResponse<Jobs>>(payload) {
-                Ok(execution_changed) => {
-                    if execution_changed.execution.is_none() {
-                        if std::env::var("CI").is_ok() {
-                            panic!("No OTA jobs queued?");
-                        }
-                        return None;
-                    }
-                    execution_changed.execution?
-                }
-                Err(e) => {
-                    log::error!(
-                        "handle_ota: failed to deserialize DescribeAccepted: {:?}",
-                        e
-                    );
-                    return None;
-                }
-            }
-        }
-        _ => {
-            log::warn!("handle_ota: unexpected topic: {:?}", topic);
-            return None;
-        }
+) -> Result<OtaJobContext<'a, E>, OtaError> {
+    let ota_doc = match execution.job_document {
+        Some(OtaJobs::Ota(doc)) => doc,
+        None => return Err(OtaError::NoActiveJob),
     };
 
-    let ota_job = match job.job_document {
-        Some(doc) => match doc.ota_job() {
-            Some(job) => job,
-            None => {
-                log::error!("handle_ota: job_document present but not an OTA job");
-                return None;
-            }
-        },
-        None => {
-            log::error!("handle_ota: no job_document in execution");
-            return None;
-        }
-    };
-
-    match OtaJobContext::new_from(
+    OtaJobContext::new_from(
         JobEventData {
-            job_name: job.job_id,
-            ota_document: ota_job,
-            status_details: job.status_details,
+            job_name: execution.job_id,
+            ota_document: ota_doc,
+            status_details: execution.status_details,
         },
         0,
         extra_status,
-    ) {
-        Ok(ctx) => Some(ctx),
-        Err(e) => {
-            log::error!("handle_ota: OtaJobContext::new_from failed: {:?}", e);
-            None
-        }
-    }
+    )
 }

--- a/tests/ota_http.rs
+++ b/tests/ota_http.rs
@@ -8,7 +8,8 @@ use common::file_handler::{FileHandler, State as FileHandlerState};
 use serial_test::serial;
 
 use rustot::{
-    mqtt::{rumqttc::RumqttcClient, Mqtt, MqttClient, MqttMessage, MqttSubscription},
+    jobs::stream::{parse_job_message, JobAgent},
+    mqtt::{rumqttc::RumqttcClient, Mqtt, MqttClient, MqttSubscription},
     ota::{
         self,
         data_interface::http::{HttpInterface, ReqwestClient},
@@ -89,51 +90,18 @@ async fn run_ota_http() -> Result<(), ota::error::OtaError> {
     rumqttc_client.wait_connected().await;
 
     let mqtt = Mqtt(&rumqttc_client);
+    let job_agent = JobAgent::new(&mqtt);
 
-    // Subscribe to job topics
-    let mut jobs_subscription = rumqttc_client
-        .subscribe(&[
-            (
-                &rustot::jobs::JobTopic::NotifyNext
-                    .format::<64>(thing_name)
-                    .map_err(|_| ota::error::OtaError::Overflow)?,
-                rustot::mqtt::QoS::AtMostOnce,
-            ),
-            (
-                &rustot::jobs::JobTopic::DescribeAccepted("$next")
-                    .format::<64>(thing_name)
-                    .map_err(|_| ota::error::OtaError::Overflow)?,
-                rustot::mqtt::QoS::AtMostOnce,
-            ),
-        ])
-        .await
-        .map_err(|_| ota::error::OtaError::Mqtt)?;
+    let mut sub = job_agent.subscribe().await?;
+    let mut message = sub.next_message().await.unwrap();
 
-    Updater::check_for_job(&mqtt).await?;
+    let execution = parse_job_message::<common::OtaJobs>(&mut message)
+        .expect("Failed to parse OTA job document — check logs for details");
 
-    let ota_config = ota::config::Config {
-        block_size: 4096,
-        ..Default::default()
-    };
-
-    let message = jobs_subscription.next_message().await.unwrap();
-
-    // Copy payload to owned buffer, drop message, borrow from buffer
-    let payload = message.payload().to_vec();
-    let topic = message.topic_name().to_string();
-    drop(message);
-
-    let job_ctx = common::handle_ota::<common::file_handler::TestStatusDetails>(
-        &topic,
-        &payload,
+    let job_ctx = common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(
+        execution,
         Default::default(),
-    )
-    .expect("Failed to parse OTA job document — check logs for details");
-
-    jobs_subscription
-        .unsubscribe()
-        .await
-        .map_err(|_| ota::error::OtaError::Mqtt)?;
+    )?;
 
     log::info!(
         "OTA job received! Protocols: {:?}, update_data_url present: {}",
@@ -142,6 +110,11 @@ async fn run_ota_http() -> Result<(), ota::error::OtaError> {
     );
 
     let mut file_handler = FileHandler::new("tests/assets/ota_file".to_owned());
+
+    let ota_config = ota::config::Config {
+        block_size: 4096,
+        ..Default::default()
+    };
 
     // HTTP for data interface (file download via Range requests)
     let http_client = ReqwestClient::new(reqwest::Client::new());

--- a/tests/ota_mqtt.rs
+++ b/tests/ota_mqtt.rs
@@ -10,14 +10,14 @@ use common::network::TlsNetwork;
 use embassy_futures::select;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use mqttrust::transport::embedded_nal::NalTransport;
-use mqttrust::{Config, DomainBroker, State, Subscribe, SubscribeTopic};
+use mqttrust::{Config, DomainBroker, State};
 use serial_test::serial;
 use static_cell::StaticCell;
 
 use aws_credential_types::provider::SharedCredentialsProvider;
 use rustot::{
-    jobs,
-    mqtt::Mqtt,
+    jobs::stream::{parse_job_message, JobAgent},
+    mqtt::{Mqtt, OwnedMessage},
     ota::{self, pal::OtaPalError, Updater},
 };
 
@@ -94,55 +94,27 @@ async fn run_ota_happy_path() -> Result<(), ota::error::OtaError> {
     let mut file_handler = FileHandler::new("tests/assets/ota_file".to_owned());
 
     let ota_fut = async {
-        let mut jobs_subscription = client
-            .subscribe::<2>(
-                Subscribe::builder()
-                    .topics(&[
-                        SubscribeTopic::builder()
-                            .topic_path(
-                                jobs::JobTopic::NotifyNext
-                                    .format::<64>(thing_name)?
-                                    .as_str(),
-                            )
-                            .build(),
-                        SubscribeTopic::builder()
-                            .topic_path(
-                                jobs::JobTopic::DescribeAccepted("$next")
-                                    .format::<64>(thing_name)?
-                                    .as_str(),
-                            )
-                            .build(),
-                    ])
-                    .build(),
-            )
-            .await
-            .map_err(|_| ota::error::OtaError::Mqtt)?;
-
         let mqtt = Mqtt(&client);
-        Updater::check_for_job(&mqtt).await?;
+        let job_agent = JobAgent::new(&mqtt);
+
+        let mut sub = job_agent.subscribe().await?;
+        let message = sub.next_message().await.unwrap();
+        let mut owned = OwnedMessage::<256, 4096>::from_ref(&message).unwrap();
+        drop(message);
+        sub.unsubscribe().await.unwrap();
+
+        let execution = parse_job_message::<common::OtaJobs>(&mut owned)
+            .expect("Failed to parse OTA job document");
+
+        let job_ctx = common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(
+            execution,
+            Default::default(),
+        )?;
 
         let ota_config = ota::config::Config {
             block_size: 4096,
             ..Default::default()
         };
-
-        let message = jobs_subscription.next_message().await.unwrap();
-
-        // Copy payload to owned buffer so we can drop the MQTT message
-        // and borrow from the buffer for OtaJobContext
-        let payload = message.payload().to_vec();
-        let topic = message.topic_name().to_string();
-        drop(message);
-
-        let job_ctx = common::handle_ota::<common::file_handler::TestStatusDetails>(
-            &topic,
-            &payload,
-            Default::default(),
-        )
-        .expect("Failed to parse OTA job document");
-
-        // Nested subscriptions are a problem for mqttrust, so unsubscribe here
-        jobs_subscription.unsubscribe().await.unwrap();
 
         // We have an OTA job, leeeets go!
         Updater::perform_ota(&mqtt, &mqtt, &job_ctx, &mut file_handler, &ota_config).await?;
@@ -329,32 +301,22 @@ async fn run_ota_cancel(
     let mut file_handler = FileHandler::new("tests/assets/ota_file".to_owned());
 
     let ota_fut = async {
-        let mut jobs_subscription = client
-            .subscribe::<2>(
-                Subscribe::builder()
-                    .topics(&[
-                        SubscribeTopic::builder()
-                            .topic_path(
-                                jobs::JobTopic::NotifyNext
-                                    .format::<64>(thing_name)?
-                                    .as_str(),
-                            )
-                            .build(),
-                        SubscribeTopic::builder()
-                            .topic_path(
-                                jobs::JobTopic::DescribeAccepted("$next")
-                                    .format::<64>(thing_name)?
-                                    .as_str(),
-                            )
-                            .build(),
-                    ])
-                    .build(),
-            )
-            .await
-            .map_err(|_| ota::error::OtaError::Mqtt)?;
-
         let mqtt = Mqtt(&client);
-        Updater::check_for_job(&mqtt).await?;
+        let job_agent = JobAgent::new(&mqtt);
+
+        let mut sub = job_agent.subscribe().await?;
+        let message = sub.next_message().await.unwrap();
+        let mut owned = OwnedMessage::<256, 4096>::from_ref(&message).unwrap();
+        drop(message);
+        sub.unsubscribe().await.unwrap();
+
+        let execution = parse_job_message::<common::OtaJobs>(&mut owned)
+            .expect("Failed to parse OTA job document");
+
+        let job_ctx = common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(
+            execution,
+            Default::default(),
+        )?;
 
         // Use small block_size + max_blocks_per_request=1 to slow down the
         // download, giving us a comfortable window to cancel the job
@@ -367,63 +329,48 @@ async fn run_ota_cancel(
             ..Default::default()
         };
 
-        let message = jobs_subscription.next_message().await.unwrap();
-        let payload = message.payload().to_vec();
-        let topic = message.topic_name().to_string();
-        drop(message);
+        // Run OTA and cancel concurrently
+        let ota_future =
+            Updater::perform_ota(&mqtt, &mqtt, &job_ctx, &mut file_handler, &ota_config);
 
-        if let Some(job_ctx) = common::handle_ota::<common::file_handler::TestStatusDetails>(
-            &topic,
-            &payload,
-            Default::default(),
-        ) {
-            jobs_subscription.unsubscribe().await.unwrap();
+        let cancel_future = async {
+            // Wait for download to start, then force-cancel
+            embassy_time::Timer::after(embassy_time::Duration::from_secs(3)).await;
+            log::info!("Force-cancelling job {} from cloud...", job_id);
+            common::aws_ota::force_cancel_job(&job_id, &iot_creds, &region)
+                .await
+                .expect("Failed to force-cancel job");
+        };
 
-            // Run OTA and cancel concurrently
-            let ota_future =
-                Updater::perform_ota(&mqtt, &mqtt, &job_ctx, &mut file_handler, &ota_config);
+        // Wrap in a timeout — if perform_ota doesn't detect cancel, it
+        // will complete the download normally (proving the device doesn't
+        // handle cancellation)
+        let result = embassy_time::with_timeout(
+            embassy_time::Duration::from_secs(60),
+            embassy_futures::join::join(ota_future, cancel_future),
+        )
+        .await;
 
-            let cancel_future = async {
-                // Wait for download to start, then force-cancel
-                embassy_time::Timer::after(embassy_time::Duration::from_secs(3)).await;
-                log::info!("Force-cancelling job {} from cloud...", job_id);
-                common::aws_ota::force_cancel_job(&job_id, &iot_creds, &region)
-                    .await
-                    .expect("Failed to force-cancel job");
-            };
-
-            // Wrap in a timeout — if perform_ota doesn't detect cancel, it
-            // will complete the download normally (proving the device doesn't
-            // handle cancellation)
-            let result = embassy_time::with_timeout(
-                embassy_time::Duration::from_secs(60),
-                embassy_futures::join::join(ota_future, cancel_future),
-            )
-            .await;
-
-            match result {
-                Ok((ota_result, ())) => {
-                    // perform_ota returned — it should have detected the cancel
-                    // and returned an error, not completed successfully
-                    assert!(
-                        ota_result.is_err(),
-                        "perform_ota should detect job cancellation and return an error, \
-                         but it completed successfully — the device did not handle the cancel"
-                    );
-                    log::info!(
-                        "perform_ota detected cancellation as expected: {:?}",
-                        ota_result.err()
-                    );
-                }
-                Err(_timeout) => {
-                    panic!(
-                        "perform_ota timed out at 60s — device neither completed \
-                         nor detected the cancellation"
-                    );
-                }
+        match result {
+            Ok((ota_result, ())) => {
+                // perform_ota returned — it should have detected the cancel
+                // and returned an error, not completed successfully
+                assert!(
+                    ota_result.is_err(),
+                    "perform_ota should detect job cancellation and return an error, \
+                     but it completed successfully — the device did not handle the cancel"
+                );
+                log::info!(
+                    "perform_ota detected cancellation as expected: {:?}",
+                    ota_result.err()
+                );
             }
-
-            return Ok(());
+            Err(_timeout) => {
+                panic!(
+                    "perform_ota timed out at 60s — device neither completed \
+                     nor detected the cancellation"
+                );
+            }
         }
 
         Ok::<_, ota::error::OtaError>(())
@@ -434,6 +381,124 @@ async fn run_ota_cancel(
     match embassy_time::with_timeout(
         embassy_time::Duration::from_secs(120),
         select::select(stack.run(&mut transport), ota_fut),
+    )
+    .await
+    .unwrap()
+    {
+        select::Either::First(_) => {
+            unreachable!()
+        }
+        select::Either::Second(result) => result.unwrap(),
+    };
+
+    Ok(())
+}
+
+/// Test rejecting a job with a reason via JobAgent::reject_job.
+///
+/// Creates an OTA job (reusing the OTA test infrastructure), but instead of
+/// performing the OTA, immediately rejects it with a reason string. Verifies
+/// that the cloud-side job status is REJECTED and the reason appears in
+/// statusDetails.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_mqtt_job_reject() {
+    let _ = env_logger::Builder::from_default_env()
+        .filter_module("serial_test", log::LevelFilter::Warn)
+        .try_init();
+
+    log::info!("Starting job reject test...");
+
+    let ctx = match common::aws_ota::setup().await {
+        Some(ctx) => ctx,
+        None => {
+            log::info!(
+                "Skipping job reject test: no valid AWS credentials or role assumption failed"
+            );
+            return;
+        }
+    };
+
+    let test_result = common::aws_ota::catch_unwind_future(run_job_reject()).await;
+
+    let cloud_status = ctx.describe_job_execution().await;
+
+    ctx.cleanup().await;
+
+    match test_result {
+        Ok(inner) => {
+            inner.unwrap();
+            let (status, details) = cloud_status.expect("Failed to describe job execution");
+            assert_eq!(
+                status,
+                aws_sdk_iot::types::JobExecutionStatus::Rejected,
+                "Expected cloud job status REJECTED, got {:?} with details: {:?}",
+                status,
+                details
+            );
+            assert_eq!(
+                details.get("reason").map(|s| s.as_str()),
+                Some("unsupported job type"),
+                "Expected reject reason in status details, got: {:?}",
+                details
+            );
+        }
+        Err(panic) => {
+            if let Ok((status, details)) = &cloud_status {
+                log::error!(
+                    "Test panicked! Cloud job status at panic: {:?}, details: {:?}",
+                    status,
+                    details
+                );
+            }
+            std::panic::resume_unwind(panic);
+        }
+    }
+}
+
+async fn run_job_reject() -> Result<(), ota::error::OtaError> {
+    let (thing_name, identity) = credentials::identity();
+
+    let hostname = credentials::HOSTNAME.unwrap();
+
+    static NETWORK: StaticCell<TlsNetwork> = StaticCell::new();
+    let network = NETWORK.init(TlsNetwork::new(hostname.to_owned(), identity));
+
+    let broker = DomainBroker::<_, 128>::new_with_port(hostname, 8883, network).unwrap();
+    let config = Config::builder()
+        .client_id(thing_name.try_into().unwrap())
+        .keepalive_interval(embassy_time::Duration::from_secs(50))
+        .build();
+
+    static STATE: StaticCell<State<NoopRawMutex, 4096, { 4096 * 20 }>> = StaticCell::new();
+    let state = STATE.init(State::new());
+    let (mut stack, client) = mqttrust::new(state, config);
+
+    let reject_fut = async {
+        let mqtt = Mqtt(&client);
+        let job_agent = JobAgent::new(&mqtt);
+
+        let mut sub = job_agent.subscribe().await?;
+        let message = sub.next_message().await.unwrap();
+        let mut owned = OwnedMessage::<256, 4096>::from_ref(&message).unwrap();
+        drop(message);
+        sub.unsubscribe().await.unwrap();
+
+        let execution =
+            parse_job_message::<common::OtaJobs>(&mut owned).expect("Failed to parse job document");
+
+        job_agent
+            .reject_job(execution.job_id, "unsupported job type")
+            .await?;
+
+        Ok::<_, ota::error::OtaError>(())
+    };
+
+    let mut transport = NalTransport::new(network, broker);
+
+    match embassy_time::with_timeout(
+        embassy_time::Duration::from_secs(30),
+        select::select(stack.run(&mut transport), reject_fut),
     )
     .await
     .unwrap()
@@ -472,70 +537,45 @@ async fn run_ota_signature_failure() -> Result<(), ota::error::OtaError> {
         .with_close_failure(OtaPalError::SignatureCheckFailed);
 
     let ota_fut = async {
-        let mut jobs_subscription = client
-            .subscribe::<2>(
-                Subscribe::builder()
-                    .topics(&[
-                        SubscribeTopic::builder()
-                            .topic_path(
-                                jobs::JobTopic::NotifyNext
-                                    .format::<64>(thing_name)?
-                                    .as_str(),
-                            )
-                            .build(),
-                        SubscribeTopic::builder()
-                            .topic_path(
-                                jobs::JobTopic::DescribeAccepted("$next")
-                                    .format::<64>(thing_name)?
-                                    .as_str(),
-                            )
-                            .build(),
-                    ])
-                    .build(),
-            )
-            .await
-            .map_err(|_| ota::error::OtaError::Mqtt)?;
-
         let mqtt = Mqtt(&client);
-        Updater::check_for_job(&mqtt).await?;
+        let job_agent = JobAgent::new(&mqtt);
+
+        let mut sub = job_agent.subscribe().await?;
+        let message = sub.next_message().await.unwrap();
+        let mut owned = OwnedMessage::<256, 4096>::from_ref(&message).unwrap();
+        drop(message);
+        sub.unsubscribe().await.unwrap();
+
+        let execution = parse_job_message::<common::OtaJobs>(&mut owned)
+            .expect("Failed to parse OTA job document");
+
+        let job_ctx = common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(
+            execution,
+            Default::default(),
+        )?;
 
         let ota_config = ota::config::Config {
             block_size: 4096,
             ..Default::default()
         };
 
-        let message = jobs_subscription.next_message().await.unwrap();
-        let payload = message.payload().to_vec();
-        let topic = message.topic_name().to_string();
-        drop(message);
+        // This should fail with SignatureCheckFailed
+        let result =
+            Updater::perform_ota(&mqtt, &mqtt, &job_ctx, &mut file_handler, &ota_config).await;
 
-        if let Some(job_ctx) = common::handle_ota::<common::file_handler::TestStatusDetails>(
-            &topic,
-            &payload,
-            Default::default(),
-        ) {
-            jobs_subscription.unsubscribe().await.unwrap();
+        // Verify the OTA failed as expected
+        assert!(
+            result.is_err(),
+            "OTA should have failed with SignatureCheckFailed"
+        );
+        log::info!("OTA failed as expected: {:?}", result.err());
 
-            // This should fail with SignatureCheckFailed
-            let result =
-                Updater::perform_ota(&mqtt, &mqtt, &job_ctx, &mut file_handler, &ota_config).await;
-
-            // Verify the OTA failed as expected
-            assert!(
-                result.is_err(),
-                "OTA should have failed with SignatureCheckFailed"
-            );
-            log::info!("OTA failed as expected: {:?}", result.err());
-
-            // Platform state should still be Boot (not Swap) since we failed
-            assert_eq!(
-                file_handler.plateform_state,
-                FileHandlerState::Boot,
-                "Platform state should remain Boot after failure"
-            );
-
-            return Ok(());
-        }
+        // Platform state should still be Boot (not Swap) since we failed
+        assert_eq!(
+            file_handler.plateform_state,
+            FileHandlerState::Boot,
+            "Platform state should remain Boot after failure"
+        );
 
         Ok::<_, ota::error::OtaError>(())
     };


### PR DESCRIPTION
## Summary

- Add `JobAgent::reject_job(job_id, reason)` — a job-agnostic method for rejecting any AWS IoT Jobs execution with a reason string in `statusDetails`. Parallel to `Updater::perform_ota` but works for any job type, not just OTA.
- Add `OwnedMessage` to the mqttrust module for copying messages out of the ring buffer so `parse_job_message` can operate on owned data after unsubscribing.
- Refactor all OTA integration tests (MQTT and HTTP) to use the `JobAgent` + `parse_job_message` pattern from #99, replacing the manual subscription + `handle_ota` helper.
- Add `test_mqtt_job_reject` integration test exercising the reject path end-to-end.
- Add `JobError::Timeout` variant and map it to `OtaError::Timeout`.