### PR TITLE
Replace NorFlash bound with BlockWriter trait on OtaPal

### DIFF
--- a/src/ota/error.rs
+++ b/src/ota/error.rs
@@ -17,10 +17,7 @@ pub enum OtaError {
     UnexpectedTopic,
     InvalidFile,
     UpdateRejected(ErrorCode),
-    Write(
-        #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
-        embedded_storage_async::nor_flash::NorFlashErrorKind,
-    ),
+    WriteFailed,
     Mqtt,
     #[cfg(feature = "ota_http_data")]
     Http,

--- a/src/ota/mod.rs
+++ b/src/ota/mod.rs
@@ -11,7 +11,6 @@ use core::future::Future;
 #[cfg(feature = "ota_mqtt_data")]
 pub use data_interface::mqtt::{Encoding, Topic};
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex, signal::Signal};
-use embedded_storage_async::nor_flash::{NorFlash, NorFlashError as _};
 pub use status_details::{OtaStatusDetails, StatusDetailsExt};
 
 use crate::{jobs::data_types::JobStatus, ota::encoding::json::JobStatusReason};
@@ -88,7 +87,7 @@ impl Updater {
         // Spawn the data handling future
         let data_fut = async {
             // Create/Open the OTA file on the file system
-            let mut block_writer = match pal.create_file_for_rx(job).await {
+            let block_writer = match pal.create_file_for_rx(job).await {
                 Ok(block_writer) => block_writer,
                 Err(e) => {
                     job_updater
@@ -136,7 +135,7 @@ impl Updater {
                                     Ok(block) => {
                                         match Self::ingest_data_block(
                                             &block,
-                                            &mut block_writer,
+                                            block_writer,
                                             config,
                                             &mut progress,
                                         )
@@ -321,7 +320,7 @@ impl Updater {
 
     async fn ingest_data_block<E: StatusDetailsExt>(
         block: &FileBlock<'_>,
-        block_writer: &mut impl NorFlash,
+        block_writer: &mut impl pal::BlockWriter,
         config: &config::Config,
         progress: &mut ProgressState<E>,
     ) -> Result<IngestResult, error::OtaError> {
@@ -350,7 +349,10 @@ impl Updater {
                     block.block_payload,
                 )
                 .await
-                .map_err(|e| error::OtaError::Write(e.kind()))?;
+                .map_err(|e| {
+                    error!("Block write failed: {:?}", e);
+                    error::OtaError::WriteFailed
+                })?;
 
             let block_offset = progress.block_offset;
             progress

--- a/src/ota/pal.rs
+++ b/src/ota/pal.rs
@@ -1,6 +1,4 @@
 //! Platform abstraction trait for OTA updates
-use embedded_storage_async::nor_flash::NorFlash;
-
 use super::encoding::OtaJobContext;
 use super::StatusDetailsExt;
 
@@ -140,9 +138,77 @@ pub enum OtaEvent {
     UpdateComplete,
 }
 
+/// Trait for writing OTA data blocks to storage.
+///
+/// This is the abstraction between the OTA orchestrator and the storage
+/// backend. The orchestrator calls `write(offset, data)` for each received
+/// block.
+///
+/// A blanket implementation is provided for all [`NorFlash`] types, so
+/// embedded users can pass their flash partition directly. `std` users can
+/// implement this for files, IPC streams, or any other target.
+pub trait BlockWriter {
+    type Error: core::fmt::Debug;
+
+    /// Write `data` at the given byte `offset`.
+    ///
+    /// For random-access backends (flash, files): seek to `offset` and write.
+    /// For streaming backends (swupdate IPC): `offset` may be ignored if the
+    /// data interface delivers blocks sequentially (e.g. HTTP Range requests).
+    async fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), Self::Error>;
+}
+
+/// Blanket implementation: any [`NorFlash`] is a [`BlockWriter`].
+impl<T: embedded_storage_async::nor_flash::NorFlash> BlockWriter for T {
+    type Error = T::Error;
+
+    async fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), Self::Error> {
+        embedded_storage_async::nor_flash::NorFlash::write(self, offset, data).await
+    }
+}
+
+/// File-based block writer for `std` targets.
+///
+/// Writes OTA blocks to a file on disk using tokio. Suitable for testing
+/// or Linux-based OTA targets.
+#[cfg(feature = "std")]
+pub struct FileWriter {
+    file: tokio::fs::File,
+}
+
+#[cfg(feature = "std")]
+impl FileWriter {
+    /// Create a new `FileWriter` for the given file path.
+    ///
+    /// Creates or truncates the file.
+    pub async fn create(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
+        Ok(Self {
+            file: tokio::fs::File::create(path).await?,
+        })
+    }
+
+    /// Create from an already-opened tokio file.
+    pub fn from_file(file: tokio::fs::File) -> Self {
+        Self { file }
+    }
+}
+
+#[cfg(feature = "std")]
+impl BlockWriter for FileWriter {
+    type Error = std::io::Error;
+
+    async fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), Self::Error> {
+        use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+        self.file
+            .seek(std::io::SeekFrom::Start(offset as u64))
+            .await?;
+        self.file.write_all(data).await
+    }
+}
+
 /// Platform abstraction layer for OTA jobs
 pub trait OtaPal {
-    type BlockWriter: NorFlash;
+    type BlockWriter: BlockWriter;
 
     /// Extra status details to include in job status updates.
     ///

--- a/tests/common/file_handler.rs
+++ b/tests/common/file_handler.rs
@@ -1,16 +1,12 @@
 use core::ops::Deref;
-use embedded_storage_async::nor_flash::{ErrorType, NorFlash, ReadNorFlash};
 use rustot::ota::{
     encoding::json,
-    pal::{OtaPal, OtaPalError, PalImageState},
+    pal::{BlockWriter, OtaPal, OtaPalError, PalImageState},
     StatusDetailsExt,
 };
 use serde::ser::SerializeMap;
 use sha2::{Digest, Sha256};
-use std::{
-    convert::Infallible,
-    io::{Cursor, Write},
-};
+use std::io::{Cursor, Write};
 
 /// Custom status details to test StatusDetailsExt integration.
 #[derive(Debug, Clone, Default)]
@@ -31,44 +27,34 @@ pub enum State {
     Boot,
 }
 
-pub struct BlockFile {
-    filebuf: Cursor<Vec<u8>>,
+/// In-memory block writer backed by a `Vec<u8>`.
+pub struct MemWriter {
+    buf: Cursor<Vec<u8>>,
 }
 
-impl NorFlash for BlockFile {
-    const WRITE_SIZE: usize = 1;
-
-    const ERASE_SIZE: usize = 1;
-
-    async fn erase(&mut self, _from: u32, _to: u32) -> Result<(), Self::Error> {
-        Ok(())
+impl MemWriter {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buf: Cursor::new(Vec::with_capacity(capacity)),
+        }
     }
 
-    async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
-        self.filebuf.set_position(offset as u64);
-        self.filebuf.write_all(bytes).unwrap();
-        Ok(())
+    pub fn data(&self) -> &[u8] {
+        self.buf.get_ref()
     }
 }
 
-impl ReadNorFlash for BlockFile {
-    const READ_SIZE: usize = 1;
+impl BlockWriter for MemWriter {
+    type Error = std::io::Error;
 
-    async fn read(&mut self, _offset: u32, _bytes: &mut [u8]) -> Result<(), Self::Error> {
-        todo!()
+    async fn write(&mut self, offset: u32, data: &[u8]) -> Result<(), Self::Error> {
+        self.buf.set_position(offset as u64);
+        self.buf.write_all(data)
     }
-
-    fn capacity(&self) -> usize {
-        self.filebuf.get_ref().capacity()
-    }
-}
-
-impl ErrorType for BlockFile {
-    type Error = Infallible;
 }
 
 pub struct FileHandler {
-    filebuf: Option<BlockFile>,
+    writer: Option<MemWriter>,
     compare_file_path: String,
     pub plateform_state: State,
     /// If set, `close_file` will return this error instead of succeeding
@@ -80,7 +66,7 @@ impl FileHandler {
     #[allow(dead_code)]
     pub fn new(compare_file_path: String) -> Self {
         FileHandler {
-            filebuf: None,
+            writer: None,
             compare_file_path,
             plateform_state: State::Boot,
             fail_close_with: None,
@@ -99,7 +85,7 @@ impl FileHandler {
 }
 
 impl OtaPal for FileHandler {
-    type BlockWriter = BlockFile;
+    type BlockWriter = MemWriter;
     type StatusDetails = TestStatusDetails;
 
     fn status_details(&self) -> Self::StatusDetails {
@@ -117,9 +103,7 @@ impl OtaPal for FileHandler {
         &mut self,
         file: &rustot::ota::encoding::OtaJobContext<'_, impl rustot::ota::StatusDetailsExt>,
     ) -> Result<&mut Self::BlockWriter, OtaPalError> {
-        Ok(self.filebuf.get_or_insert(BlockFile {
-            filebuf: Cursor::new(Vec::with_capacity(file.filesize)),
-        }))
+        Ok(self.writer.get_or_insert(MemWriter::new(file.filesize)))
     }
 
     async fn get_platform_image_state(&mut self) -> Result<PalImageState, OtaPalError> {
@@ -154,10 +138,10 @@ impl OtaPal for FileHandler {
             return Err(error);
         }
 
-        if let Some(ref mut buf) = &mut self.filebuf {
+        if let Some(ref writer) = self.writer {
             log::debug!(
                 "Closing completed file. Len: {}/{} -> {}",
-                buf.filebuf.get_ref().len(),
+                writer.data().len(),
                 file.filesize,
                 file.filepath
             );
@@ -172,10 +156,10 @@ impl OtaPal for FileHandler {
                 self.compare_file_path,
                 file.filepath
             );
-            assert_eq!(buf.filebuf.get_ref().len(), file.filesize);
+            assert_eq!(writer.data().len(), file.filesize);
 
             let mut hasher = <Sha256 as Digest>::new();
-            hasher.update(buf.filebuf.get_ref());
+            hasher.update(writer.data());
             assert_eq!(hasher.finalize().deref(), expected_hash.deref());
 
             // Check file signature


### PR DESCRIPTION
## Summary

- Add `BlockWriter` trait with a single `async fn write(offset, data)` — decouples OTA storage from embedded flash semantics
- Blanket impl for all `NorFlash` types — zero change for existing embedded users
- Add `FileWriter` (tokio fs, behind `std` feature) for file-based std targets
- `OtaError::Write(NorFlashErrorKind)` simplified to `OtaError::WriteFailed` — no longer tied to flash error types
- Enables std users to implement any storage backend (files, swupdate IPC, etc.) without NorFlash indirection