### PR TITLE
Improve ShadowNode trait ergonomics and add ReportedDiff

### DIFF
--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -138,6 +138,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
 
     // For async parse_delta config arms (uses parse_delta instead of serde)
     let mut parse_delta_config_arms: Vec<TokenStream> = Vec::new();
+    let mut reported_diff_arms: Vec<TokenStream> = Vec::new();
 
     for variant in variants {
         let variant_ident = &variant.ident;
@@ -178,6 +179,11 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 // into_partial_reported: unit variant has no inner state
                 into_partial_reported_arms.push(quote! {
                     Self::#variant_ident => Self::Reported::#variant_ident,
+                });
+
+                // reported_diff: unit variants with same discriminant → no change
+                reported_diff_arms.push(quote! {
+                    (#reported_name::#variant_ident, #reported_name::#variant_ident) => false,
                 });
 
                 // Schema hash for unit variant
@@ -238,6 +244,13 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                         };
                         Self::Reported::#variant_ident(inner.into_partial_reported(&inner_delta))
                     }
+                });
+
+                // reported_diff: same newtype variant → recurse into inner
+                reported_diff_arms.push(quote! {
+                    (#reported_name::#variant_ident(ref mut new_inner), #reported_name::#variant_ident(ref old_inner)) => {
+                        #krate::shadows::ReportedDiff::diff(new_inner, old_inner)
+                    },
                 });
 
                 // For flat union serialize - use ReportedUnionFields
@@ -1014,6 +1027,18 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
             ) -> Result<(), S::Error> {
                 // Adjacently-tagged enums serialize via their custom Serialize impl
                 Ok(())
+            }
+        }
+
+        impl #krate::shadows::ReportedDiff for #reported_name {
+            fn diff(&mut self, old: &Self) -> bool {
+                if ::core::mem::discriminant(self) != ::core::mem::discriminant(old) {
+                    return true;
+                }
+                match (self, old) {
+                    #(#reported_diff_arms)*
+                    _ => false,
+                }
             }
         }
     };

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -127,6 +127,7 @@ pub(crate) fn generate_simple_enum_code(
     let mut into_reported_arms = Vec::new();
     let mut into_partial_reported_arms = Vec::new();
     let mut schema_hash_code = Vec::new();
+    let mut reported_diff_arms = Vec::new();
 
     for variant in variants {
         let variant_ident = &variant.ident;
@@ -169,6 +170,11 @@ pub(crate) fn generate_simple_enum_code(
                 let variant_bytes = serde_name.as_bytes();
                 schema_hash_code.push(quote! {
                     h = #krate::shadows::fnv1a_bytes(h, &[#(#variant_bytes),*]);
+                });
+
+                // reported_diff: unit variants with same discriminant → no change
+                reported_diff_arms.push(quote! {
+                    (#reported_name::#variant_ident, #reported_name::#variant_ident) => false,
                 });
 
                 // parse_delta arm for unit variant
@@ -231,6 +237,13 @@ pub(crate) fn generate_simple_enum_code(
                             }
                         }
                     }
+                });
+
+                // reported_diff: same newtype variant → recurse into inner
+                reported_diff_arms.push(quote! {
+                    (#reported_name::#variant_ident(ref mut new_inner), #reported_name::#variant_ident(ref old_inner)) => {
+                        #krate::shadows::ReportedDiff::diff(new_inner, old_inner)
+                    },
                 });
 
                 // Schema hash for newtype variant
@@ -738,6 +751,18 @@ pub(crate) fn generate_simple_enum_code(
             ) -> Result<(), S::Error> {
                 // Enums serialize their variant directly, not as individual fields
                 Ok(())
+            }
+        }
+
+        impl #krate::shadows::ReportedDiff for #reported_name {
+            fn diff(&mut self, old: &Self) -> bool {
+                if ::core::mem::discriminant(self) != ::core::mem::discriminant(old) {
+                    return true;
+                }
+                match (self, old) {
+                    #(#reported_diff_arms)*
+                    _ => false,
+                }
             }
         }
     };

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -96,6 +96,9 @@ struct FieldCodegen {
     reported_builder_param: TokenStream,
     /// Builder field assignment for reported()
     reported_builder_assign: TokenStream,
+
+    /// ReportedDiff::diff() arm for this field
+    reported_diff_arm: TokenStream,
 }
 
 /// Process a single struct field and generate all code fragments.
@@ -338,6 +341,40 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
 
     let reported_builder_assign = quote! { #field_name, };
 
+    // --- ReportedDiff arm ---
+    let reported_diff_arm = if is_leaf {
+        // Leaf fields use PartialEq directly — no ReportedDiff bound needed
+        quote! {
+            {
+                let changed = match (&self.#field_name, &old.#field_name) {
+                    (Some(a), Some(b)) => a != b,
+                    (Some(_), _) => true,
+                    _ => false,
+                };
+                if changed {
+                    has_changes = true;
+                } else {
+                    self.#field_name = None;
+                }
+            }
+        }
+    } else {
+        // Nested fields use ReportedDiff for recursive diff
+        quote! {
+            match (&mut self.#field_name, &old.#field_name) {
+                (Some(new_val), Some(old_val)) => {
+                    if #krate::shadows::ReportedDiff::diff(new_val, old_val) {
+                        has_changes = true;
+                    } else {
+                        self.#field_name = None;
+                    }
+                }
+                (Some(_), _) => has_changes = true,
+                _ => {}
+            }
+        }
+    };
+
     FieldCodegen {
         serde_name,
         delta_field,
@@ -355,6 +392,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
         desired_builder_assign,
         reported_builder_param,
         reported_builder_assign,
+        reported_diff_arm,
     }
 }
 
@@ -437,6 +475,10 @@ pub(crate) fn generate_struct_code(
     let desired_cleanup_arms: Vec<_> = field_codegens
         .iter()
         .filter_map(|f| f.desired_cleanup_arm.clone())
+        .collect();
+    let reported_diff_arms: Vec<_> = field_codegens
+        .iter()
+        .map(|f| f.reported_diff_arm.clone())
         .collect();
 
     // Generate Delta type - always use FieldScanner, no Deserialize needed
@@ -834,6 +876,14 @@ pub(crate) fn generate_struct_code(
             ) -> Result<(), S::Error> {
                 #(#reported_serialize_arms)*
                 Ok(())
+            }
+        }
+
+        impl #krate::shadows::ReportedDiff for #reported_name {
+            fn diff(&mut self, old: &Self) -> bool {
+                let mut has_changes = false;
+                #(#reported_diff_arms)*
+                has_changes
             }
         }
     };

--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -59,6 +59,12 @@ impl<const N: usize> ReportedUnionFields for heapless::String<N> {
     }
 }
 
+impl<const N: usize> crate::shadows::ReportedDiff for heapless::String<N> {
+    fn diff(&mut self, old: &Self) -> bool {
+        *self != *old
+    }
+}
+
 #[cfg(feature = "shadows_kv_persist")]
 #[allow(incomplete_features)]
 impl<const N: usize> KVPersist for heapless::String<N>
@@ -186,6 +192,12 @@ where
     }
 }
 
+impl<T: PartialEq, const N: usize> crate::shadows::ReportedDiff for heapless::Vec<T, N> {
+    fn diff(&mut self, old: &Self) -> bool {
+        *self != *old
+    }
+}
+
 /// `heapless::Vec<T, N>` is stored as an atomic blob value because AWS IoT Shadows
 /// treat arrays as normal values — an update to an array replaces the whole array,
 /// and it is not possible to update part of an array. This is why `Delta = Self`
@@ -298,16 +310,16 @@ where
 /// for JSON parsing to support value types with adjacently-tagged enums
 /// (which require alloc for serde Deserialize).
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
-pub struct LinearMapDelta<K: Eq, D, const N: usize>(
+pub struct DeltaLinearMap<K: Eq, D, const N: usize>(
     pub Option<heapless::LinearMap<K, Patch<D>, N>>,
 );
 
 /// Reported type for `heapless::LinearMap`-based shadow fields.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
-pub struct LinearMapReported<K: Eq, R, const N: usize>(pub heapless::LinearMap<K, R, N>);
+pub struct ReportedLinearMap<K: Eq, R, const N: usize>(pub heapless::LinearMap<K, R, N>);
 
 impl<K: Eq + serde::Serialize, R: serde::Serialize, const N: usize> ReportedUnionFields
-    for LinearMapReported<K, R, N>
+    for ReportedLinearMap<K, R, N>
 {
     const FIELD_NAMES: &'static [&'static str] = &[];
 
@@ -316,13 +328,35 @@ impl<K: Eq + serde::Serialize, R: serde::Serialize, const N: usize> ReportedUnio
     }
 }
 
+impl<K: Eq + Clone, R: crate::shadows::ReportedDiff, const N: usize> crate::shadows::ReportedDiff
+    for ReportedLinearMap<K, R, N>
+{
+    fn diff(&mut self, old: &Self) -> bool {
+        // Collect keys to remove (unchanged entries)
+        let remove_keys: heapless::Vec<K, N> = self
+            .0
+            .iter_mut()
+            .filter_map(|(k, v)| match old.0.get(k) {
+                Some(old_v) if !v.diff(old_v) => Some(k.clone()),
+                _ => None,
+            })
+            .collect();
+
+        for k in &remove_keys {
+            self.0.remove(k);
+        }
+
+        !self.0.is_empty()
+    }
+}
+
 impl<K, V, const N: usize> ShadowNode for heapless::LinearMap<K, V, N>
 where
     K: Clone + Eq + Default + serde::Serialize + serde::de::DeserializeOwned + core::fmt::Display,
-    V: ShadowNode,
+    V: ShadowNode + Default,
 {
-    type Delta = LinearMapDelta<K, V::Delta, N>;
-    type Reported = LinearMapReported<K, V::Reported, N>;
+    type Delta = DeltaLinearMap<K, V::Delta, N>;
+    type Reported = ReportedLinearMap<K, V::Reported, N>;
 
     const SCHEMA_HASH: u64 = fnv1a_hash(b"heapless::LinearMap");
 
@@ -335,7 +369,7 @@ where
 
         // Check for null (no changes)
         if ObjectScanner::is_null_or_empty(json) {
-            return Ok(LinearMapDelta(None));
+            return Ok(DeltaLinearMap(None));
         }
 
         let mut scanner = ObjectScanner::new(json).map_err(|_| ParseError::Deserialize)?;
@@ -371,7 +405,7 @@ where
             let _ = result.insert(key, patch);
         }
 
-        Ok(LinearMapDelta(Some(result)))
+        Ok(DeltaLinearMap(Some(result)))
     }
 
     fn apply_delta(&mut self, delta: &Self::Delta) {
@@ -400,7 +434,7 @@ where
         for (key, value) in self.iter() {
             let _ = reported.insert(key.clone(), value.into_reported());
         }
-        LinearMapReported(reported)
+        ReportedLinearMap(reported)
     }
 
     fn into_partial_reported(&self, delta: &Self::Delta) -> Self::Reported {
@@ -416,13 +450,13 @@ where
                         }
                     }
                     Patch::Unset => {
-                        // Unset entries cannot be represented in LinearMapReported
+                        // Unset entries cannot be represented in ReportedLinearMap
                         // The user must handle explicit null reporting separately
                     }
                 }
             }
         }
-        LinearMapReported(reported)
+        ReportedLinearMap(reported)
     }
 
     fn desired_cleanup(&self, delta: &Self::Delta) -> Option<Self::Delta> {
@@ -442,7 +476,7 @@ where
             }
 
             if has_cleanup {
-                Some(LinearMapDelta(Some(result)))
+                Some(DeltaLinearMap(Some(result)))
             } else {
                 None
             }
@@ -467,7 +501,7 @@ where
 impl<K, V, const N: usize> KVPersist for heapless::LinearMap<K, V, N>
 where
     K: MapKey + Default + Serialize + DeserializeOwned,
-    V: KVPersist,
+    V: KVPersist + Default,
 {
     // "/{key}" + sub-key length
     const MAX_KEY_LEN: usize = 1 + K::MAX_KEY_DISPLAY_LEN + V::MAX_KEY_LEN;
@@ -883,7 +917,7 @@ mod tests {
 
         let mut patches = heapless::LinearMap::new();
         let _ = patches.insert(heapless::String::try_from("a").unwrap(), Patch::Set(42u32));
-        let delta = LinearMapDelta(Some(patches));
+        let delta = DeltaLinearMap(Some(patches));
 
         map.apply_delta(&delta);
         assert_eq!(
@@ -902,7 +936,7 @@ mod tests {
             heapless::String::try_from("a").unwrap(),
             Patch::<u32>::Unset,
         );
-        let delta = LinearMapDelta(Some(patches));
+        let delta = DeltaLinearMap(Some(patches));
 
         map.apply_delta(&delta);
         assert!(map
@@ -915,7 +949,7 @@ mod tests {
         let mut map: heapless::LinearMap<heapless::String<4>, u32, 4> = heapless::LinearMap::new();
         let _ = map.insert(heapless::String::try_from("a").unwrap(), 42);
 
-        let delta = LinearMapDelta::<heapless::String<4>, u32, 4>(None);
+        let delta = DeltaLinearMap::<heapless::String<4>, u32, 4>(None);
         map.apply_delta(&delta);
         assert_eq!(
             map.get(&heapless::String::<4>::try_from("a").unwrap()),
@@ -987,7 +1021,7 @@ mod tests {
                 heapless::String::try_from("a").unwrap(),
                 Patch::<u32>::Unset,
             );
-            let delta = LinearMapDelta(Some(patches));
+            let delta = DeltaLinearMap(Some(patches));
 
             let mut key_buf = heapless::String::<128>::new();
             let _ = key_buf.push_str("test");

--- a/src/shadows/impls/mod.rs
+++ b/src/shadows/impls/mod.rs
@@ -1,6 +1,6 @@
 //! ShadowNode implementations for built-in types.
 //!
-//! - `opaque`: Primitive types via `impl_opaque!` macro
+//! - `opaque`: Primitive types via `impl_opaque!` macro (with optional explicit buffer size)
 //! - `heapless`: `heapless::String<N>`, `heapless::Vec<T, N>`, `heapless::LinearMap<K, V, N>`
 //! - `std`: `String`, `Vec<T>`, `HashMap<K, V>` (behind `std` feature)
 
@@ -12,7 +12,7 @@ mod heapless_impls;
 mod std_impls;
 
 // Re-export wrapper types for map collections
-pub use heapless_impls::{LinearMapDelta, LinearMapReported};
+pub use heapless_impls::{DeltaLinearMap, ReportedLinearMap};
 
 #[cfg(feature = "std")]
-pub use std_impls::{HashMapDelta, HashMapReported};
+pub use std_impls::{DeltaHashMap, ReportedHashMap};

--- a/src/shadows/impls/opaque.rs
+++ b/src/shadows/impls/opaque.rs
@@ -1,6 +1,6 @@
 //! ShadowNode implementations for opaque/leaf types.
 //!
-//! This module provides the `impl_opaque!` macro and ShadowNode implementations
+//! This module provides the [`impl_opaque!`] macro and ShadowNode implementations
 //! for all primitive types.
 //!
 //! ## Why This Exists
@@ -13,25 +13,36 @@
 //! it works transparently for both primitives and nested `ShadowNode` types,
 //! eliminating the need for `is_primitive()` checks in the derive macro.
 
-/// Implement ShadowNode for opaque/leaf types.
+/// Implement `ShadowNode`, `ReportedUnionFields`, and (with `shadows_kv_persist`)
+/// `KVPersist` for opaque/leaf types.
 ///
-/// This macro generates ShadowNode implementations where:
-/// - `Delta = Self` (the type is its own delta)
-/// - `Reported = Self` (the type is its own reported form)
-/// - `SCHEMA_HASH = fnv1a_hash(type_name)` (type identity)
-///
-/// With `shadows_kv_persist` feature, also generates KVPersist impl:
-/// - `MAX_KEY_LEN = 0` (no sub-keys)
-/// - `ValueBuf = [u8; POSTCARD_MAX_SIZE]` (serialization buffer)
-///
-/// # Example
+/// # Forms
 ///
 /// ```ignore
-/// impl_opaque!(MyCustomType);
+/// // Infer KVPersist buffer size from postcard::MaxSize (type must implement it)
+/// impl_opaque!(u32, bool, f64);
+///
+/// // Explicit buffer size — for types without postcard::MaxSize
+/// impl_opaque!(core::time::Duration => 15);
 /// ```
+///
+/// When no size is given, the `shadows_kv_persist` impl uses
+/// `<T as postcard::MaxSize>::POSTCARD_MAX_SIZE` for the `ValueBuf`.
+/// When a size is given, it is used directly.
 #[macro_export]
 macro_rules! impl_opaque {
-    ($($ty:ty),* $(,)?) => {$(
+    // Multiple types without explicit size (comma-separated list)
+    ($($ty:ty),+ $(,)?) => {
+        $($crate::impl_opaque!(@single $ty, <$ty as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE);)+
+    };
+
+    // Single type with explicit buffer size
+    ($ty:ty => $size:expr) => {
+        $crate::impl_opaque!(@single $ty, $size);
+    };
+
+    // Internal: generate all impls for a single type with a resolved size expression
+    (@single $ty:ty, $size:expr) => {
         impl $crate::shadows::ShadowNode for $ty {
             type Delta = $ty;
             type Reported = $ty;
@@ -74,11 +85,17 @@ macro_rules! impl_opaque {
             }
         }
 
+        impl $crate::shadows::ReportedDiff for $ty {
+            fn diff(&mut self, old: &Self) -> bool {
+                *self != *old
+            }
+        }
+
         #[cfg(feature = "shadows_kv_persist")]
         impl $crate::shadows::KVPersist for $ty {
             const MAX_KEY_LEN: usize = 0;
-            type ValueBuf = [u8; <$ty as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE];
-            fn zero_value_buf() -> Self::ValueBuf { [0u8; <$ty as ::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE] }
+            type ValueBuf = [u8; $size];
+            fn zero_value_buf() -> Self::ValueBuf { [0u8; $size] }
 
             fn migration_sources(_field_path: &str) -> &'static [$crate::shadows::MigrationSource] {
                 &[]
@@ -153,7 +170,7 @@ macro_rules! impl_opaque {
                 rel_key.is_empty()
             }
         }
-    )*};
+    };
 }
 
 // =============================================================================
@@ -164,132 +181,32 @@ impl_opaque!((), bool, char);
 impl_opaque!(u8, u16, u32, u64, u128, usize);
 impl_opaque!(i8, i16, i32, i64, i128, isize);
 impl_opaque!(f32, f64);
-// core::time::Duration — manual impl because it lacks postcard::MaxSize.
-// Serialized as (u64, u32) = secs + nanos, max postcard size = 10 + 5 = 15 bytes.
+// postcard: u64 varint (max 10) + u32 varint (max 5) = 15 bytes
+impl_opaque!(core::time::Duration => 15);
 
-impl crate::shadows::ShadowNode for core::time::Duration {
-    type Delta = core::time::Duration;
-    type Reported = core::time::Duration;
-
-    const SCHEMA_HASH: u64 = crate::shadows::fnv1a_hash(b"core::time::Duration");
-
-    async fn parse_delta<R: crate::shadows::VariantResolver>(
-        json: &[u8],
-        _path: &str,
-        _resolver: &R,
-    ) -> Result<Self::Delta, crate::shadows::ParseError> {
-        ::serde_json_core::from_slice(json)
-            .map(|(v, _)| v)
-            .map_err(|_| crate::shadows::ParseError::Deserialize)
-    }
-
-    fn apply_delta(&mut self, delta: &Self::Delta) {
-        *self = *delta;
-    }
-
-    fn into_reported(&self) -> Self::Reported {
-        *self
-    }
-
-    fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
-        *self
-    }
-}
-
-impl crate::shadows::ReportedUnionFields for core::time::Duration {
-    const FIELD_NAMES: &'static [&'static str] = &[];
-
-    fn serialize_into_map<S: ::serde::ser::SerializeMap>(
-        &self,
-        _map: &mut S,
-    ) -> Result<(), S::Error> {
-        Ok(())
-    }
-}
-
-#[cfg(feature = "shadows_kv_persist")]
-impl crate::shadows::KVPersist for core::time::Duration {
-    const MAX_KEY_LEN: usize = 0;
-    // postcard: u64 varint (max 10) + u32 varint (max 5) = 15 bytes
-    type ValueBuf = [u8; 15];
-    fn zero_value_buf() -> Self::ValueBuf {
-        [0u8; 15]
-    }
-
-    fn migration_sources(_field_path: &str) -> &'static [crate::shadows::MigrationSource] {
-        &[]
-    }
-
-    fn all_migration_keys() -> impl Iterator<Item = &'static str> {
-        core::iter::empty()
-    }
-
-    fn apply_field_default(&mut self, _field_path: &str) -> bool {
-        false
-    }
-
-    async fn load_from_kv<K: crate::shadows::KVStore, const KEY_LEN: usize>(
-        &mut self,
-        key_buf: &mut heapless::String<KEY_LEN>,
-        kv: &K,
-    ) -> Result<crate::shadows::LoadFieldResult, crate::shadows::KvError<K::Error>> {
-        let mut result = crate::shadows::LoadFieldResult::default();
-        let mut buf = Self::zero_value_buf();
-        match kv
-            .fetch(key_buf.as_str(), buf.as_mut())
-            .await
-            .map_err(crate::shadows::KvError::Kv)?
-        {
-            Some(data) => {
-                *self = ::postcard::from_bytes(data)
-                    .map_err(|_| crate::shadows::KvError::Serialization)?;
-                result.loaded += 1;
-            }
-            None => result.defaulted += 1,
+impl<T: crate::shadows::ReportedDiff> crate::shadows::ReportedDiff for Option<T> {
+    fn diff(&mut self, old: &Self) -> bool {
+        match (self, old) {
+            (Some(new_val), Some(old_val)) => new_val.diff(old_val),
+            (None, None) => false,
+            _ => true,
         }
-        Ok(result)
-    }
-
-    async fn load_from_kv_with_migration<K: crate::shadows::KVStore, const KEY_LEN: usize>(
-        &mut self,
-        key_buf: &mut heapless::String<KEY_LEN>,
-        kv: &K,
-    ) -> Result<crate::shadows::LoadFieldResult, crate::shadows::KvError<K::Error>> {
-        self.load_from_kv::<K, KEY_LEN>(key_buf, kv).await
-    }
-
-    async fn persist_to_kv<K: crate::shadows::KVStore, const KEY_LEN: usize>(
-        &self,
-        key_buf: &mut heapless::String<KEY_LEN>,
-        kv: &K,
-    ) -> Result<(), crate::shadows::KvError<K::Error>> {
-        let mut buf = Self::zero_value_buf();
-        let bytes = ::postcard::to_slice(self, buf.as_mut())
-            .map_err(|_| crate::shadows::KvError::Serialization)?;
-        kv.store(key_buf.as_str(), bytes)
-            .await
-            .map_err(crate::shadows::KvError::Kv)
-    }
-
-    async fn persist_delta<K: crate::shadows::KVStore, const KEY_LEN: usize>(
-        delta: &Self::Delta,
-        kv: &K,
-        key_buf: &mut heapless::String<KEY_LEN>,
-    ) -> Result<(), crate::shadows::KvError<K::Error>> {
-        let mut buf = Self::zero_value_buf();
-        let bytes = ::postcard::to_slice(delta, buf.as_mut())
-            .map_err(|_| crate::shadows::KvError::Serialization)?;
-        kv.store(key_buf.as_str(), bytes)
-            .await
-            .map_err(crate::shadows::KvError::Kv)
-    }
-
-    const FIELD_COUNT: usize = 1;
-
-    fn is_valid_key(rel_key: &str) -> bool {
-        rel_key.is_empty()
     }
 }
+
+// core::net types — postcard sizes based on non-human-readable serde encoding:
+// Ipv4Addr: newtype([u8; 4]) = 4
+// Ipv6Addr: newtype([u8; 16]) = 16
+// IpAddr: enum(1) + Ipv6Addr(16) = 17
+// SocketAddrV4: Ipv4Addr(4) + u16 varint(3) = 7
+// SocketAddrV6: Ipv6Addr(16) + u16(3) + u32(5) + u32(5) = 29
+// SocketAddr: enum(1) + SocketAddrV6(29) = 30
+impl_opaque!(core::net::Ipv4Addr => 4);
+impl_opaque!(core::net::Ipv6Addr => 16);
+impl_opaque!(core::net::IpAddr => 17);
+impl_opaque!(core::net::SocketAddrV4 => 7);
+impl_opaque!(core::net::SocketAddrV6 => 29);
+impl_opaque!(core::net::SocketAddr => 30);
 
 #[cfg(test)]
 mod tests {

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -57,6 +57,12 @@ impl ReportedUnionFields for String {
     }
 }
 
+impl crate::shadows::ReportedDiff for String {
+    fn diff(&mut self, old: &Self) -> bool {
+        *self != *old
+    }
+}
+
 #[cfg(feature = "shadows_kv_persist")]
 impl KVPersist for String {
     const MAX_KEY_LEN: usize = 0;
@@ -180,6 +186,12 @@ where
     }
 }
 
+impl<T: PartialEq> crate::shadows::ReportedDiff for Vec<T> {
+    fn diff(&mut self, old: &Self) -> bool {
+        *self != *old
+    }
+}
+
 /// `std::Vec<T>` is stored as an atomic blob value because AWS IoT Shadows
 /// treat arrays as normal values — an update to an array replaces the whole array,
 /// and it is not possible to update part of an array. This is why `Delta = Self`
@@ -280,19 +292,31 @@ where
 /// `None` means "no changes to the map" (the map field itself was absent
 /// from the delta). `Some(map)` contains per-entry patches.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct HashMapDelta<K: Eq + Hash, D>(pub Option<HashMap<K, Patch<D>>>);
+pub struct DeltaHashMap<K: Eq + Hash, D>(pub Option<HashMap<K, Patch<D>>>);
 
 /// Reported type for `HashMap`-based shadow fields.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
-pub struct HashMapReported<K: Eq + Hash, R>(pub HashMap<K, R>);
+pub struct ReportedHashMap<K: Eq + Hash, R>(pub HashMap<K, R>);
 
 impl<K: Eq + Hash + serde::Serialize, R: serde::Serialize> ReportedUnionFields
-    for HashMapReported<K, R>
+    for ReportedHashMap<K, R>
 {
     const FIELD_NAMES: &'static [&'static str] = &[];
 
     fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
         Ok(())
+    }
+}
+
+impl<K: Eq + Hash, R: crate::shadows::ReportedDiff> crate::shadows::ReportedDiff
+    for ReportedHashMap<K, R>
+{
+    fn diff(&mut self, old: &Self) -> bool {
+        self.0.retain(|k, v| match old.0.get(k) {
+            Some(old_v) => v.diff(old_v),
+            None => true,
+        });
+        !self.0.is_empty()
     }
 }
 
@@ -305,10 +329,10 @@ where
         + serde::Serialize
         + serde::de::DeserializeOwned
         + core::fmt::Display,
-    V: ShadowNode,
+    V: ShadowNode + Default,
 {
-    type Delta = HashMapDelta<K, V::Delta>;
-    type Reported = HashMapReported<K, V::Reported>;
+    type Delta = DeltaHashMap<K, V::Delta>;
+    type Reported = ReportedHashMap<K, V::Reported>;
 
     const SCHEMA_HASH: u64 = fnv1a_hash(b"HashMap");
 
@@ -321,7 +345,7 @@ where
 
         // Check for null (no changes)
         if ObjectScanner::is_null_or_empty(json) {
-            return Ok(HashMapDelta(None));
+            return Ok(DeltaHashMap(None));
         }
 
         let mut scanner = ObjectScanner::new(json).map_err(|_| ParseError::Deserialize)?;
@@ -350,7 +374,7 @@ where
             result.insert(key, patch);
         }
 
-        Ok(HashMapDelta(Some(result)))
+        Ok(DeltaHashMap(Some(result)))
     }
 
     fn apply_delta(&mut self, delta: &Self::Delta) {
@@ -379,7 +403,7 @@ where
         for (key, value) in self.iter() {
             reported.insert(key.clone(), value.into_reported());
         }
-        HashMapReported(reported)
+        ReportedHashMap(reported)
     }
 
     fn into_partial_reported(&self, delta: &Self::Delta) -> Self::Reported {
@@ -394,13 +418,13 @@ where
                         }
                     }
                     Patch::Unset => {
-                        // Unset entries cannot be represented in HashMapReported
+                        // Unset entries cannot be represented in ReportedHashMap
                         // The user must handle explicit null reporting separately
                     }
                 }
             }
         }
-        HashMapReported(reported)
+        ReportedHashMap(reported)
     }
 
     fn desired_cleanup(&self, delta: &Self::Delta) -> Option<Self::Delta> {
@@ -420,7 +444,7 @@ where
             }
 
             if has_cleanup {
-                Some(HashMapDelta(Some(result)))
+                Some(DeltaHashMap(Some(result)))
             } else {
                 None
             }
@@ -434,7 +458,7 @@ where
 impl<K, V> KVPersist for HashMap<K, V>
 where
     K: MapKey + Default + Hash,
-    V: KVPersist,
+    V: KVPersist + Default,
 {
     // "/{key}" + sub-key length
     const MAX_KEY_LEN: usize = 1 + K::MAX_KEY_DISPLAY_LEN + V::MAX_KEY_LEN;
@@ -624,7 +648,7 @@ mod tests {
 
         let mut patches = HashMap::new();
         patches.insert("a".to_string(), Patch::Set(42u32));
-        let delta = HashMapDelta(Some(patches));
+        let delta = DeltaHashMap(Some(patches));
 
         map.apply_delta(&delta);
         assert_eq!(map.get("a"), Some(&42));
@@ -637,7 +661,7 @@ mod tests {
 
         let mut patches = HashMap::new();
         patches.insert("a".to_string(), Patch::<u32>::Unset);
-        let delta = HashMapDelta(Some(patches));
+        let delta = DeltaHashMap(Some(patches));
 
         map.apply_delta(&delta);
         assert!(map.get("a").is_none());
@@ -648,7 +672,7 @@ mod tests {
         let mut map: HashMap<String, u32> = HashMap::new();
         map.insert("a".to_string(), 42);
 
-        let delta = HashMapDelta::<String, u32>(None);
+        let delta = DeltaHashMap::<String, u32>(None);
         map.apply_delta(&delta);
         assert_eq!(map.get("a"), Some(&42));
     }
@@ -708,7 +732,7 @@ mod tests {
             let mut patches = HashMap::new();
             patches.insert("b".to_string(), Patch::Set(2u32));
             patches.insert("a".to_string(), Patch::<u32>::Unset);
-            let delta = HashMapDelta(Some(patches));
+            let delta = DeltaHashMap(Some(patches));
 
             let mut key_buf = heapless::String::<128>::new();
             let _ = key_buf.push_str("test");

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -266,6 +266,29 @@ pub trait ReportedUnionFields: Serialize {
     fn serialize_into_map<S: serde::ser::SerializeMap>(&self, map: &mut S) -> Result<(), S::Error>;
 }
 
+/// Trait for diffing Reported types in-place.
+///
+/// Nulls out fields that haven't changed compared to `old`, leaving only the
+/// delta to report. This enables efficient partial updates — only changed fields
+/// are serialized and sent to the cloud.
+///
+/// ## Usage
+///
+/// ```ignore
+/// let mut reported = ShadowNode::into_reported(&new_state);
+/// reported.diff(&old_reported);
+/// shadow.update_reported(reported).await?;
+/// ```
+///
+/// ## Return Value
+///
+/// Returns `true` if any changes remain after diffing, `false` if the reported
+/// value is now empty (all fields `None`).
+pub trait ReportedDiff {
+    /// Retain only changed fields compared to `old`.
+    fn diff(&mut self, old: &Self) -> bool;
+}
+
 /// Helper to serialize null values for inactive variant fields.
 ///
 /// When serializing an adjacently-tagged enum's Reported type, inactive variants'
@@ -352,7 +375,7 @@ impl VariantResolver for NullResolver {
 ///
 /// This ensures that changes to nested types propagate to parent hashes.
 /// Only the top-level `ShadowRoot::SCHEMA_HASH` is actually stored.
-pub trait ShadowNode: Default + Clone + Sized {
+pub trait ShadowNode: Clone + Sized {
     /// Delta type for partial updates (fields wrapped in Option).
     ///
     /// ## Trait Bounds
@@ -385,7 +408,7 @@ pub trait ShadowNode: Default + Clone + Sized {
     ///     Sio(DeltaSioConfig),
     /// }
     /// ```
-    type Delta: Default + Serialize;
+    type Delta: Serialize;
 
     /// Reported type for serialization to cloud.
     ///

--- a/src/shadows/store/file.rs
+++ b/src/shadows/store/file.rs
@@ -237,7 +237,7 @@ impl KVStore for FileKVStore {
 // StateStore Implementation (state-level operations)
 // =============================================================================
 
-impl<St: KVPersist> StateStore<St> for FileKVStore {
+impl<St: KVPersist + Default> StateStore<St> for FileKVStore {
     type Error = FileKVStoreError;
 
     async fn get_state(&self, prefix: &str) -> Result<St, Self::Error> {

--- a/src/shadows/store/in_memory.rs
+++ b/src/shadows/store/in_memory.rs
@@ -63,7 +63,7 @@ impl<S: Default> Default for InMemory<S> {
     }
 }
 
-impl<S: ShadowNode> StateStore<S> for InMemory<S> {
+impl<S: ShadowNode + Default> StateStore<S> for InMemory<S> {
     type Error = core::convert::Infallible;
 
     async fn get_state(&self, _prefix: &str) -> Result<S, Self::Error> {

--- a/src/shadows/store/sequential.rs
+++ b/src/shadows/store/sequential.rs
@@ -255,7 +255,7 @@ impl<
 // =============================================================================
 
 impl<
-        St: KVPersist,
+        St: KVPersist + Default,
         S: NorFlash + MultiwriteNorFlash,
         M: RawMutex,
         C: KeyCacheImpl<String<MAX_KEY_LEN>>,


### PR DESCRIPTION
## Summary

- **Remove `Default` from `ShadowNode` supertrait** — moved to map impls and state stores where actually needed, enabling types like `core::net::Ipv4Addr` to implement `ShadowNode`
- **Add `core::net` types** — `IpAddr`, `Ipv4Addr`, `Ipv6Addr`, `SocketAddr`, `SocketAddrV4`, `SocketAddrV6` via `impl_opaque\!` with explicit postcard buffer sizes
- **Unify `impl_opaque\!` macro** — single macro with optional explicit size (`impl_opaque\!(T)` infers from `MaxSize`, `impl_opaque\!(T => N)` uses literal)
- **Rename map wrapper types** to match derive convention: `HashMapDelta` → `DeltaHashMap`, `HashMapReported` → `ReportedHashMap` (same for LinearMap)
- **Add `ReportedDiff` trait** — diffs Reported values in-place, nulling unchanged fields for efficient partial updates. Generated for all derived Reported structs/enums with recursive map support. Opaque fields use `PartialEq` directly.