### PR TITLE
Remove extra_status parameter from OtaJobContext::new_from

### DIFF
--- a/src/ota/encoding/mod.rs
+++ b/src/ota/encoding/mod.rs
@@ -75,11 +75,7 @@ pub struct OtaJobContext<'a, E: StatusDetailsExt = ()> {
 }
 
 impl<'a, E: StatusDetailsExt> OtaJobContext<'a, E> {
-    pub fn new_from(
-        job_data: JobEventData<'a>,
-        file_idx: usize,
-        mut extra_status: E,
-    ) -> Result<Self, OtaError> {
+    pub fn new_from(job_data: JobEventData<'a>, file_idx: usize) -> Result<Self, OtaError> {
         let file_desc = job_data
             .ota_document
             .files
@@ -90,6 +86,7 @@ impl<'a, E: StatusDetailsExt> OtaJobContext<'a, E> {
             return Err(OtaError::ZeroFileSize);
         }
 
+        let mut extra_status = E::default();
         let mut status = OtaStatusDetails::new();
         if let Some(ref details) = job_data.status_details {
             for (&key, &value) in details.iter() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,7 +28,6 @@ pub enum OtaJobs<'a> {
 #[allow(dead_code)]
 pub fn ota_context_from_execution<'a, E: StatusDetailsExt>(
     execution: JobExecution<'a, OtaJobs<'a>>,
-    extra_status: E,
 ) -> Result<OtaJobContext<'a, E>, OtaError> {
     let ota_doc = match execution.job_document {
         Some(OtaJobs::Ota(doc)) => doc,
@@ -42,6 +41,5 @@ pub fn ota_context_from_execution<'a, E: StatusDetailsExt>(
             status_details: execution.status_details,
         },
         0,
-        extra_status,
     )
 }

--- a/tests/ota_http.rs
+++ b/tests/ota_http.rs
@@ -98,10 +98,8 @@ async fn run_ota_http() -> Result<(), ota::error::OtaError> {
     let execution = parse_job_message::<common::OtaJobs>(&mut message)
         .expect("Failed to parse OTA job document — check logs for details");
 
-    let job_ctx = common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(
-        execution,
-        Default::default(),
-    )?;
+    let job_ctx =
+        common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(execution)?;
 
     log::info!(
         "OTA job received! Protocols: {:?}, update_data_url present: {}",

--- a/tests/ota_mqtt.rs
+++ b/tests/ota_mqtt.rs
@@ -108,7 +108,6 @@ async fn run_ota_happy_path() -> Result<(), ota::error::OtaError> {
 
         let job_ctx = common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(
             execution,
-            Default::default(),
         )?;
 
         let ota_config = ota::config::Config {
@@ -315,7 +314,6 @@ async fn run_ota_cancel(
 
         let job_ctx = common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(
             execution,
-            Default::default(),
         )?;
 
         // Use small block_size + max_blocks_per_request=1 to slow down the
@@ -551,7 +549,6 @@ async fn run_ota_signature_failure() -> Result<(), ota::error::OtaError> {
 
         let job_ctx = common::ota_context_from_execution::<common::file_handler::TestStatusDetails>(
             execution,
-            Default::default(),
         )?;
 
         let ota_config = ota::config::Config {


### PR DESCRIPTION
## Summary

- Remove the `extra_status: E` parameter from `OtaJobContext::new_from`, making the extra status populated exclusively by deserializing incoming `status_details` via `E::default()` + `accept_entry`.
- `OtaJobContext` should represent cloud state 1:1 — extra status details should not be injectable at construction time.