### PR TITLE
Fix fire-and-forget subscription cleanup causing stale MQTT unsubscribes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,23 @@ minicbor = { version = "0.25", optional = true }
 minicbor-serde = { version = "0.3.2", optional = true }
 
 # Shadow storage dependencies
-postcard = { git = "https://github.com/jamesmunns/postcard", rev = "f8a4064", default-features = false, features = ["experimental-derive", "heapless-v0_9"] }
+postcard = { git = "https://github.com/jamesmunns/postcard", rev = "f8a4064", default-features = false, features = [
+    "experimental-derive",
+    "heapless-v0_9",
+] }
 
 # KV-based shadow storage (optional, enabled by shadows_kv_persist feature)
-sequential-storage = { version = "7.0", features = ["heapless-09"], optional = true }
+sequential-storage = { version = "7.0", features = [
+    "heapless-09",
+], optional = true }
 
 serde-json-core = { version = "0.6" }
 rustot-derive = { path = "rustot_derive", version = "0.2.1" }
-embedded-storage-async = "0.4"
-mqttrust = { git = "https://github.com/FactbirdHQ/mqttrust", rev = "629e3bb", optional = true }
+embedded-storage-async = { version = "0.4", optional = true }
+mqttrust = { git = "https://github.com/FactbirdHQ/mqttrust", rev = "d4d0cd8", optional = true }
 
 embassy-time = { version = "0.5.0" }
-embassy-sync = "0.7.2"
+embassy-sync = "0.8"
 embassy-futures = "0.1.2"
 
 log = { version = "0.4", default-features = false, optional = true }
@@ -58,10 +63,14 @@ rumqttc = { version = "0.24", optional = true }
 greengrass-ipc-rust = { git = "https://github.com/FactbirdHQ/greengrass-ipc-rust", rev = "bcc6df9", optional = true }
 bytes = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+], optional = true }
 
 # Multi-shadow manager dependencies (optional, feature-gated)
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"], optional = true }
+aws-config = { version = "1.1.7", features = [
+    "behavior-version-latest",
+], optional = true }
 aws-sdk-iotdataplane = { version = "1.72.0", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 
@@ -100,11 +109,19 @@ uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 serial_test = "3"
 rumqttc = { version = "0.24", features = ["use-native-tls"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+] }
 
 
 [features]
-default = ["transfer_mqtt", "metric_cbor", "provision_cbor", "shadows_kv_persist", "mqtt_mqttrust"]
+default = [
+    "transfer_mqtt",
+    "metric_cbor",
+    "provision_cbor",
+    "shadows_kv_persist",
+    "mqtt_mqttrust",
+]
 
 metric_cbor = ["dep:minicbor", "dep:minicbor-serde"]
 
@@ -115,13 +132,27 @@ transfer_mqtt = ["dep:minicbor", "dep:minicbor-serde"]
 transfer_http = []
 transfer_http_reqwest = ["transfer_http", "std", "dep:reqwest"]
 
-std = ["serde/std", "minicbor-serde?/std", "dep:tokio", "dep:serde_json", "dep:base64", "postcard/alloc", "rustot-derive/std", "embassy-time/std", "embassy-time/generic-queue-8"]
+std = [
+    "serde/std",
+    "minicbor-serde?/std",
+    "dep:tokio",
+    "dep:serde_json",
+    "dep:base64",
+    "postcard/alloc",
+    "rustot-derive/std",
+    "embassy-time/std",
+    "embassy-time/generic-queue-8",
+]
 
 # Field-level KV shadow persistence traits (KVStore, KVPersist, FileKVStore with std)
 shadows_kv_persist = ["rustot-derive/kv_persist", "postcard/heapless"]
 
 # Flash-based KV store using sequential-storage (requires shadows_kv_persist)
-sequential_storage = ["shadows_kv_persist", "dep:sequential-storage"]
+sequential_storage = [
+    "shadows_kv_persist",
+    "dep:sequential-storage",
+    "dep:embedded-storage-async",
+]
 
 # Generates bon-based builder methods (desired(), reported()) on shadow structs.
 # Downstream crates must also add `bon` as a direct dependency.
@@ -132,7 +163,14 @@ log = ["dep:log"]
 
 # Multi-shadow manager (runtime-named shadows with wildcard subscriptions)
 # Requires std for tokio, AWS SDK, etc.
-shadows_multi = ["std", "dep:aws-config", "dep:aws-sdk-iotdataplane", "dep:uuid", "tokio/time", "rustot-derive/multi"]
+shadows_multi = [
+    "std",
+    "dep:aws-config",
+    "dep:aws-sdk-iotdataplane",
+    "dep:uuid",
+    "tokio/time",
+    "rustot-derive/multi",
+]
 
 # MQTT client implementations (all optional, feature-gated)
 mqtt_mqttrust = ["dep:mqttrust"]

--- a/src/defender_metrics/mod.rs
+++ b/src/defender_metrics/mod.rs
@@ -62,7 +62,9 @@ impl<'m, C: MqttClient> MetricHandler<'m, C> {
             .await
             .map_err(|_| MetricError::PublishSubscribe)?;
 
-        self.await_metric_response(&mut subscription).await
+        let result = self.await_metric_response(&mut subscription).await;
+        let _ = subscription.unsubscribe().await;
+        result
     }
 
     async fn await_metric_response(

--- a/src/jobs/stream.rs
+++ b/src/jobs/stream.rs
@@ -205,7 +205,7 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
             .await
             .map_err(|_| JobError::Mqtt)?;
 
-        loop {
+        let result = loop {
             let message = match embassy_time::with_timeout(
                 embassy_time::Duration::from_secs(5),
                 sub.next_message(),
@@ -213,16 +213,19 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
             .await
             {
                 Ok(Some(msg)) => msg,
-                Ok(None) => return Err(JobError::Mqtt),
-                Err(_) => return Err(JobError::Timeout),
+                Ok(None) => break Err(JobError::Mqtt),
+                Err(_) => break Err(JobError::Timeout),
             };
 
             match Topic::from_str(message.topic_name()) {
-                Some(Topic::UpdateAccepted(_)) => return Ok(()),
-                Some(Topic::UpdateRejected(_)) => return Err(JobError::Mqtt),
+                Some(Topic::UpdateAccepted(_)) => break Ok(()),
+                Some(Topic::UpdateRejected(_)) => break Err(JobError::Mqtt),
                 _ => continue,
             }
-        }
+        };
+
+        let _ = sub.unsubscribe().await;
+        result
     }
 }
 

--- a/src/mqtt/greengrass.rs
+++ b/src/mqtt/greengrass.rs
@@ -2,13 +2,14 @@
 //!
 //! This module provides an std/tokio-based MQTT client using `greengrass-ipc-rust`.
 //! Greengrass IPC natively supports single-topic subscriptions; multi-topic
-//! subscriptions are implemented by merging individual streams via `SelectAll`.
+//! subscriptions are implemented by polling individual streams.
 
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Poll;
 
 use bytes::Bytes;
-use futures::stream::SelectAll;
-use futures::StreamExt;
+use futures::Stream;
 
 use crate::mqtt::{MqttMessage, MqttSubscription, PublishOptions, QoS, ToPayload};
 
@@ -115,7 +116,7 @@ impl crate::mqtt::MqttClient for GreengrassClient {
         let client = self.client.clone();
         let topics_owned: [(&str, QoS); N] = *topics;
         async move {
-            let mut merged = SelectAll::new();
+            let mut streams = Vec::with_capacity(N);
             for (topic, qos) in &topics_owned {
                 let stream = client
                     .subscribe_to_iot_core(greengrass_ipc_rust::SubscribeToIoTCoreRequest {
@@ -123,17 +124,39 @@ impl crate::mqtt::MqttClient for GreengrassClient {
                         qos: to_gg_qos(*qos),
                     })
                     .await?;
-                merged.push(stream);
+                streams.push(stream);
             }
 
-            Ok(GreengrassSubscription { merged })
+            Ok(GreengrassSubscription { streams })
         }
     }
 }
 
 /// Subscription wrapper for Greengrass.
+///
+/// Holds the underlying IPC stream operations. Call [`close()`](Self::close)
+/// to deterministically terminate all streams before dropping. If `close()` is
+/// not called, `Drop` on each [`StreamOperation`] performs best-effort cleanup
+/// via fire-and-forget async tasks.
 pub struct GreengrassSubscription {
-    merged: SelectAll<greengrass_ipc_rust::StreamOperation<greengrass_ipc_rust::IoTCoreMessage>>,
+    streams: Vec<greengrass_ipc_rust::StreamOperation<greengrass_ipc_rust::IoTCoreMessage>>,
+}
+
+impl GreengrassSubscription {
+    /// Explicitly close all underlying IPC streams, awaiting each termination.
+    ///
+    /// Mirrors [`StreamOperation::close()`] — each stream sends
+    /// `TERMINATE_STREAM` and unregisters its handler synchronously (awaited).
+    /// Because the handler is removed before `Drop` runs, the `Drop` impl on
+    /// each `StreamOperation` becomes a no-op (it cannot find the stream in
+    /// the map).
+    pub async fn close(self) -> Result<(), greengrass_ipc_rust::Error> {
+        for stream in self.streams {
+            // Errors are non-fatal: the stream may already be closed server-side.
+            let _ = stream.close().await;
+        }
+        Ok(())
+    }
 }
 
 impl MqttSubscription for GreengrassSubscription {
@@ -144,14 +167,30 @@ impl MqttSubscription for GreengrassSubscription {
     type Error = greengrass_ipc_rust::Error;
 
     async fn next_message(&mut self) -> Option<Self::Message<'_>> {
-        self.merged.next().await.map(|iot_msg| GreengrassMessage {
-            inner: iot_msg.message,
+        futures::future::poll_fn(|cx| {
+            let mut all_done = true;
+            for stream in self.streams.iter_mut() {
+                match Pin::new(stream).poll_next(cx) {
+                    Poll::Ready(Some(msg)) => {
+                        return Poll::Ready(Some(GreengrassMessage { inner: msg.message }));
+                    }
+                    Poll::Ready(None) => continue,
+                    Poll::Pending => {
+                        all_done = false;
+                    }
+                }
+            }
+            if all_done {
+                Poll::Ready(None)
+            } else {
+                Poll::Pending
+            }
         })
+        .await
     }
 
     async fn unsubscribe(self) -> Result<(), Self::Error> {
-        drop(self.merged);
-        Ok(())
+        self.close().await
     }
 }
 

--- a/src/shadows/multi/manager.rs
+++ b/src/shadows/multi/manager.rs
@@ -364,7 +364,9 @@ where
             .await
             .map_err(|e| MultiShadowError::Mqtt(format!("{:?}", e)))?;
 
-        let delta_state = self.wait_for_response(&shadow_name, &mut sub, None).await?;
+        let result = self.wait_for_response(&shadow_name, &mut sub, None).await;
+        let _ = sub.unsubscribe().await;
+        let delta_state = result?;
 
         let prefix = Self::shadow_name(id);
         let mut state: T =
@@ -529,6 +531,8 @@ where
         })
         .await;
 
+        let _ = sub.unsubscribe().await;
+
         match result {
             Ok(Ok(())) | Err(_) => {
                 let prefix = Self::shadow_name(id);
@@ -645,8 +649,11 @@ where
             .await
             .map_err(|e| MultiShadowError::Mqtt(format!("{:?}", e)))?;
 
-        self.wait_for_response(shadow_name, &mut sub, client_token)
-            .await
+        let result = self
+            .wait_for_response(shadow_name, &mut sub, client_token)
+            .await;
+        let _ = sub.unsubscribe().await;
+        result
     }
 
     /// Wait for accepted/rejected response on a merged subscription.

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -155,7 +155,7 @@ where
         //*** WAIT RESPONSE ***/
         debug!("Wait for Accepted or Rejected");
 
-        loop {
+        let result = loop {
             let message = sub.next_message().await.ok_or(Error::InvalidPayload)?;
 
             match Topic::from_str(S::PREFIX, message.topic_name()) {
@@ -169,7 +169,7 @@ where
                         continue;
                     }
 
-                    return Ok(response.state);
+                    break Ok(response.state);
                 }
                 Some((Topic::UpdateRejected, _, _)) => {
                     let mut buf = [0u8; 64];
@@ -183,16 +183,19 @@ where
                         continue;
                     }
 
-                    return Err(Error::ShadowError(
+                    break Err(Error::ShadowError(
                         error_response.try_into().unwrap_or(ShadowError::NotFound),
                     ));
                 }
                 _ => {
                     error!("Expected Topic name GetRejected or GetAccepted but got something else");
-                    return Err(Error::WrongShadowName);
+                    break Err(Error::WrongShadowName);
                 }
             }
-        }
+        };
+
+        let _ = sub.unsubscribe().await;
+        result
     }
 
     /// Fetch the shadow state from the cloud.
@@ -202,46 +205,56 @@ where
 
         let mut sub = self.publish_and_subscribe(Topic::Get, b"").await?;
 
-        let get_message = sub.next_message().await.ok_or(Error::InvalidPayload)?;
+        // Scope the message so it's dropped before we unsubscribe.
+        // Returns Ok(Some(state)) on success, Ok(None) on 404 (needs create),
+        // or Err on other failures.
+        let result = {
+            let get_message = sub.next_message().await.ok_or(Error::InvalidPayload)?;
 
-        // Check if topic is GetAccepted
-        // Deserialize message
-        // Persist shadow and return new shadow
-        match Topic::from_str(S::PREFIX, get_message.topic_name()) {
-            Some((Topic::GetAccepted, _, _)) => {
-                let resolver = self.store.resolver(Self::prefix());
-                let response = AcceptedResponse::parse::<S, _>(get_message.payload(), &resolver)
-                    .await
-                    .map_err(|_| Error::InvalidPayload)?;
+            match Topic::from_str(S::PREFIX, get_message.topic_name()) {
+                Some((Topic::GetAccepted, _, _)) => {
+                    let resolver = self.store.resolver(Self::prefix());
+                    let response =
+                        AcceptedResponse::parse::<S, _>(get_message.payload(), &resolver)
+                            .await
+                            .map_err(|_| Error::InvalidPayload)?;
 
-                Ok(response.state)
-            }
-            Some((Topic::GetRejected, _, _)) => {
-                let mut buf = [0u8; 64];
-                let (error_response, _) = serde_json_core::from_slice_escaped::<ErrorResponse>(
-                    get_message.payload(),
-                    &mut buf,
-                )
-                .map_err(|_| Error::ShadowError(ShadowError::NotFound))?;
-
-                if error_response.code == 404 {
-                    debug!(
-                        "[{:?}] Thing has no shadow document. Creating with defaults...",
-                        S::NAME.unwrap_or(CLASSIC_SHADOW)
-                    );
-                    return self.create_shadow().await;
+                    Ok(Some(response.state))
                 }
+                Some((Topic::GetRejected, _, _)) => {
+                    let mut buf = [0u8; 64];
+                    let (error_response, _) = serde_json_core::from_slice_escaped::<ErrorResponse>(
+                        get_message.payload(),
+                        &mut buf,
+                    )
+                    .map_err(|_| Error::ShadowError(ShadowError::NotFound))?;
 
-                Err(Error::ShadowError(
-                    error_response.try_into().unwrap_or(ShadowError::NotFound),
-                ))
+                    if error_response.code == 404 {
+                        debug!(
+                            "[{:?}] Thing has no shadow document. Creating with defaults...",
+                            S::NAME.unwrap_or(CLASSIC_SHADOW)
+                        );
+                        Ok(None)
+                    } else {
+                        Err(Error::ShadowError(
+                            error_response.try_into().unwrap_or(ShadowError::NotFound),
+                        ))
+                    }
+                }
+                _ => {
+                    error!(
+                        "Expected topic name to be GetRejected or GetAccepted but got something else"
+                    );
+                    Err(Error::WrongShadowName)
+                }
             }
-            _ => {
-                error!(
-                    "Expected topic name to be GetRejected or GetAccepted but got something else"
-                );
-                Err(Error::WrongShadowName)
-            }
+        };
+
+        let _ = sub.unsubscribe().await;
+
+        match result? {
+            Some(state) => Ok(state),
+            None => self.create_shadow().await,
         }
     }
 
@@ -511,29 +524,34 @@ where
 
         let mut sub = self.publish_and_subscribe(Topic::Delete, b"").await?;
 
-        let message = sub.next_message().await.ok_or(Error::InvalidPayload)?;
+        let result = {
+            let message = sub.next_message().await.ok_or(Error::InvalidPayload)?;
 
-        match Topic::from_str(S::PREFIX, message.topic_name()) {
-            Some((Topic::DeleteAccepted, _, _)) => {}
-            Some((Topic::DeleteRejected, _, _)) => {
-                let mut buf = [0u8; 64];
-                let (error_response, _) = serde_json_core::from_slice_escaped::<ErrorResponse>(
-                    message.payload(),
-                    &mut buf,
-                )
-                .map_err(|_| Error::ShadowError(ShadowError::NotFound))?;
+            match Topic::from_str(S::PREFIX, message.topic_name()) {
+                Some((Topic::DeleteAccepted, _, _)) => Ok(()),
+                Some((Topic::DeleteRejected, _, _)) => {
+                    let mut buf = [0u8; 64];
+                    let (error_response, _) = serde_json_core::from_slice_escaped::<ErrorResponse>(
+                        message.payload(),
+                        &mut buf,
+                    )
+                    .map_err(|_| Error::ShadowError(ShadowError::NotFound))?;
 
-                return Err(Error::ShadowError(
-                    error_response.try_into().unwrap_or(ShadowError::NotFound),
-                ));
+                    Err(Error::ShadowError(
+                        error_response.try_into().unwrap_or(ShadowError::NotFound),
+                    ))
+                }
+                _ => {
+                    error!(
+                        "Expected Topic name DeleteRejected or DeleteAccepted but got something else"
+                    );
+                    Err(Error::WrongShadowName)
+                }
             }
-            _ => {
-                error!(
-                    "Expected Topic name DeleteRejected or DeleteAccepted but got something else"
-                );
-                return Err(Error::WrongShadowName);
-            }
-        }
+        };
+
+        let _ = sub.unsubscribe().await;
+        result?;
 
         self.store
             .delete_state(Self::prefix())

--- a/src/transfer/control_interface/mqtt.rs
+++ b/src/transfer/control_interface/mqtt.rs
@@ -71,7 +71,7 @@ impl<C: MqttClient> ControlInterface for Mqtt<&'_ C> {
         // For QoS 1 updates, subscribe to accepted/rejected before publishing
         // so we can verify the cloud processed the update. Critical for the
         // final Succeeded update before reboot.
-        let mut sub = if qos == QoS::AtLeastOnce {
+        let sub = if qos == QoS::AtLeastOnce {
             let accepted_topic =
                 JobTopic::UpdateAccepted(job_name)
                     .format::<{ MAX_THING_NAME_LEN + MAX_JOB_ID_LEN + 25 }>(self.0.client_id())?;
@@ -110,8 +110,8 @@ impl<C: MqttClient> ControlInterface for Mqtt<&'_ C> {
             .map_err(|_| TransferError::Mqtt)?;
 
         // For QoS 1: wait for accepted/rejected response
-        if let Some(ref mut sub) = sub {
-            loop {
+        if let Some(mut sub) = sub {
+            let result = loop {
                 let message = match embassy_time::with_timeout(
                     embassy_time::Duration::from_secs(5),
                     sub.next_message(),
@@ -119,16 +119,16 @@ impl<C: MqttClient> ControlInterface for Mqtt<&'_ C> {
                 .await
                 {
                     Ok(Some(msg)) => msg,
-                    Ok(None) => return Err(TransferError::Mqtt),
+                    Ok(None) => break Err(TransferError::Mqtt),
                     Err(_) => {
                         warn!("Timeout waiting for job update accepted/rejected");
-                        return Err(TransferError::Timeout);
+                        break Err(TransferError::Timeout);
                     }
                 };
 
                 match jobs::Topic::from_str(message.topic_name()) {
                     Some(jobs::Topic::UpdateAccepted(_)) => {
-                        return Ok(());
+                        break Ok(());
                     }
                     Some(jobs::Topic::UpdateRejected(_)) => {
                         let (error_response, _) =
@@ -136,14 +136,17 @@ impl<C: MqttClient> ControlInterface for Mqtt<&'_ C> {
                                 .map_err(|_| TransferError::Mqtt)?;
 
                         error!("Job update rejected: {:?}", error_response.message);
-                        return Err(TransferError::UpdateRejected(error_response.code));
+                        break Err(TransferError::UpdateRejected(error_response.code));
                     }
                     _ => {
                         // Not our topic, keep waiting
                         continue;
                     }
                 }
-            }
+            };
+
+            let _ = sub.unsubscribe().await;
+            return result;
         }
 
         Ok(())

--- a/src/transfer/data_interface/mod.rs
+++ b/src/transfer/data_interface/mod.rs
@@ -81,6 +81,16 @@ pub trait BlockTransfer {
     /// Passes the updated progress so the transfer can request more blocks
     /// when a batch is exhausted (MQTT) or advance its internal cursor (HTTP).
     async fn on_block_written(&mut self, progress: &BlockProgress) -> Result<(), TransferError>;
+
+    /// Explicitly close the transfer session, releasing any subscriptions.
+    ///
+    /// If not called, cleanup is best-effort via `Drop`.
+    async fn close(self) -> Result<(), TransferError>
+    where
+        Self: Sized,
+    {
+        Ok(())
+    }
 }
 
 pub trait DataInterface {

--- a/src/transfer/data_interface/mqtt.rs
+++ b/src/transfer/data_interface/mqtt.rs
@@ -344,6 +344,13 @@ impl<'t, S: MqttSubscription, C: MqttClient> BlockTransfer for MqttTransfer<'t, 
         }
         Ok(())
     }
+
+    async fn close(self) -> Result<(), TransferError> {
+        self.sub
+            .unsubscribe()
+            .await
+            .map_err(|_| TransferError::Mqtt)
+    }
 }
 
 impl<C: MqttClient> DataInterface for Mqtt<&'_ C> {

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -345,14 +345,6 @@ impl Transfer {
                             }
                             Ok(None) => {
                                 warn!("Data stream ended (clean session/disconnect). Re-establishing and resuming...");
-
-                                let blocks_remaining = {
-                                    let progress = progress_state.lock().await;
-                                    progress.blocks_remaining
-                                };
-
-                                info!("Resuming transfer: {} blocks remaining", blocks_remaining);
-
                                 // Break inner loop to trigger re-establishment
                                 break;
                             }
@@ -371,6 +363,15 @@ impl Transfer {
                         transfer.on_block_written(&bp).await?;
                     }
                 }
+
+                // Stream disconnected — close the transfer before re-establishing
+                let _ = transfer.close().await;
+
+                let blocks_remaining = {
+                    let progress = progress_state.lock().await;
+                    progress.blocks_remaining
+                };
+                info!("Resuming transfer: {} blocks remaining", blocks_remaining);
             }
         };
 

--- a/src/transfer/pal.rs
+++ b/src/transfer/pal.rs
@@ -159,6 +159,7 @@ pub trait BlockWriter {
 }
 
 /// Blanket implementation: any [`NorFlash`] is a [`BlockWriter`].
+#[cfg(feature = "sequential_storage")]
 impl<T: embedded_storage_async::nor_flash::NorFlash> BlockWriter for T {
     type Error = T::Error;
 


### PR DESCRIPTION
## Summary

- `GreengrassSubscription` previously used `SelectAll<StreamOperation>` to merge multi-topic subscriptions. When dropped, each `StreamOperation::Drop` spawns a fire-and-forget `tokio::spawn` to send `TERMINATE_STREAM`. These async tasks race with the next subscribe call for the same topics, causing duplicate MQTT unsubscribes on the broker (observed: 2 subscribes, 3 unsubscribes for a single shadow update).
- Replace `SelectAll` with `Vec<StreamOperation>` and add an explicit `close()` method that awaits each `StreamOperation::close()` deterministically. `Drop` remains as best-effort cleanup if `close()` is not called.
- Update all request-response subscription sites across shadows, jobs, defender metrics, and transfer modules to call `unsubscribe()` (which delegates to `close()`) before dropping the subscription.
- Add `close()` to `BlockTransfer` trait with a default no-op, implemented on `MqttTransfer` to unsubscribe the data/notify-next topics on re-establishment.
- Make `embedded-storage-async` optional, gated behind `sequential_storage` feature (only relevant for microcontroller targets).