### PR TITLE
Fix defmt compilation errors for types missing Format impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 bitmaps = { version = "3.1", default-features = false }
-heapless = { version = "0.9", features = ["serde"] }
+heapless = { version = "0.9.2", features = ["serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 minicbor = { version = "0.25", optional = true }
@@ -158,7 +158,7 @@ sequential_storage = [
 # Downstream crates must also add `bon` as a direct dependency.
 shadows_builders = ["rustot-derive/builders"]
 
-defmt = ["dep:defmt", "sequential-storage?/defmt"]
+defmt = ["dep:defmt", "heapless/defmt", "sequential-storage?/defmt"]
 log = ["dep:log"]
 
 # Multi-shadow manager (runtime-named shadows with wildcard subscriptions)

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -533,8 +533,8 @@ impl Transfer {
                     block.block_payload,
                 )
                 .await
-                .map_err(|e| {
-                    error!("Block write failed: {:?}", e);
+                .map_err(|_| {
+                    error!("Block write failed");
                     error::TransferError::WriteFailed
                 })?;
 


### PR DESCRIPTION
## Summary

- Drop `BlockWriter::Error` interpolation from `error\!` macro in `ingest_data_block` — the error type is only bounded by `Debug`, not `defmt::Format`
- Enable `heapless/defmt` feature gate so `Vec<Protocol>` satisfies `Format` in `error\!` call sites