### PR TITLE
feat: Add report_only(persist) attribute for shadow fields

### DIFF
--- a/rustot_derive/src/shadow/generation/modifier.rs
+++ b/rustot_derive/src/shadow/generation/modifier.rs
@@ -3,6 +3,7 @@ use syn::{parse_quote, punctuated::Punctuated, Data, DeriveInput, Field, Ident, 
 
 use super::variant_or_field_visitor::{
     borrow_fields, borrow_fields_mut, extract_type_from_option, has_shadow_arg,
+    is_report_only_persist, is_report_only_stripped,
 };
 
 pub trait Modifier {
@@ -64,16 +65,40 @@ impl Modifier for WithDerivesModifier {
     }
 }
 
-/// Filter all fields annotated with `#[shadow_attr(report_only)]` from the
+/// Filter fields annotated with `#[shadow_attr(report_only)]` from the
 /// `output` AST.
-pub struct ReportOnlyModifier;
+///
+/// - `strip_persist: false` — only strip plain `report_only` fields (keep
+///   `report_only(persist)` in the struct). Used for the original struct
+///   and the Reported `From` impl.
+/// - `strip_persist: true` — strip ALL `report_only` variants including
+///   `report_only(persist)`. Used for the Delta struct.
+pub struct ReportOnlyModifier {
+    pub strip_persist: bool,
+}
 
 impl ReportOnlyModifier {
-    fn filter_report_only(field: &Field) -> bool {
-        if has_shadow_arg(&field.attrs, "report_only") {
-            return false;
+    fn should_keep(&self, field: &Field) -> bool {
+        let is_any_report_only = has_shadow_arg(&field.attrs, "report_only");
+
+        if is_any_report_only {
+            if self.strip_persist {
+                // Delta mode: strip all report_only variants
+                return false;
+            }
+            // Struct mode: only strip plain report_only, keep persist
+            if is_report_only_stripped(&field.attrs) {
+                return false;
+            }
+            // report_only(persist): keep in struct, but validate no bare Option
+            if is_report_only_persist(&field.attrs) && extract_type_from_option(&field.ty).is_some()
+            {
+                panic!("Optionals are only allowed in plain `report_only` fields, not `report_only(persist)`");
+            }
+            return true;
         }
 
+        // Normal field: Option types are not allowed
         if extract_type_from_option(&field.ty).is_some() {
             panic!("Optionals are only allowed in `report_only` fields");
         }
@@ -94,7 +119,7 @@ impl Modifier for ReportOnlyModifier {
                     .iter()
                     .zip(new_fields.iter_mut())
                     .filter_map(|(old_field, new_field)| {
-                        Self::filter_report_only(old_field).then_some(new_field.clone())
+                        self.should_keep(old_field).then_some(new_field.clone())
                     })
                     .collect::<Punctuated<Field, Token![,]>>();
             }

--- a/rustot_derive/src/shadow/generation/variant_or_field_visitor.rs
+++ b/rustot_derive/src/shadow/generation/variant_or_field_visitor.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use syn::{
     parse_quote, punctuated::Punctuated, spanned::Spanned, Attribute, DataStruct, Field, Fields,
-    Ident, Token, Type, Visibility,
+    Ident, Meta, Token, Type, Visibility,
 };
 
 use crate::shadow::{DEFAULT_ATTRIBUTE, SHADOW_ATTRIBUTE};
@@ -158,14 +158,47 @@ pub fn get_attr(attrs: &Vec<Attribute>, attr: &str) -> Option<Attribute> {
 
 pub fn has_shadow_arg(attrs: &Vec<Attribute>, arg: &str) -> bool {
     if let Some(a) = get_attr(&attrs, SHADOW_ATTRIBUTE) {
-        let shadow_args = a
-            .parse_args_with(Punctuated::<Ident, Token![,]>::parse_terminated)
-            .unwrap_or_default();
-
-        return shadow_args.iter().any(|i| i.to_string() == arg);
+        // Parse as Meta to support both bare idents (e.g. `leaf`) and
+        // function-call syntax (e.g. `report_only(persist)`)
+        if let Ok(metas) = a.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) {
+            return metas.iter().any(|meta| meta.path().is_ident(arg));
+        }
     }
 
     false
+}
+
+/// Check for a specific option within a shadow arg.
+/// e.g. `has_shadow_arg_option(attrs, "report_only", "persist")` matches
+/// `#[shadow_attr(report_only(persist))]`
+pub fn has_shadow_arg_option(attrs: &Vec<Attribute>, arg: &str, option: &str) -> bool {
+    if let Some(a) = get_attr(attrs, SHADOW_ATTRIBUTE) {
+        if let Ok(metas) = a.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) {
+            return metas.iter().any(|meta| {
+                if let Meta::List(list) = meta {
+                    if list.path.is_ident(arg) {
+                        if let Ok(inner) =
+                            list.parse_args_with(Punctuated::<Ident, Token![,]>::parse_terminated)
+                        {
+                            return inner.iter().any(|i| i == option);
+                        }
+                    }
+                }
+                false
+            });
+        }
+    }
+    false
+}
+
+/// True for plain `report_only` (field is stripped from struct, not persisted)
+pub fn is_report_only_stripped(attrs: &Vec<Attribute>) -> bool {
+    has_shadow_arg(attrs, "report_only") && !has_shadow_arg_option(attrs, "report_only", "persist")
+}
+
+/// True for `report_only(persist)` (field kept in struct, persisted, but excluded from Delta)
+pub fn is_report_only_persist(attrs: &Vec<Attribute>) -> bool {
+    has_shadow_arg_option(attrs, "report_only", "persist")
 }
 
 pub fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {

--- a/rustot_derive/src/shadow/shadow_patch.rs
+++ b/rustot_derive/src/shadow/shadow_patch.rs
@@ -74,7 +74,9 @@ pub fn shadow_patch(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     let desired_tokens = {
         ShadowGenerator::new(full_input.clone())
-            .modifier(&mut ReportOnlyModifier)
+            .modifier(&mut ReportOnlyModifier {
+                strip_persist: false,
+            })
             .modifier(&mut RenameModifier(original_ident.clone()))
             .modifier(&mut WithDerivesModifier(
                 macro_params.auto_derive.unwrap_or(true),
@@ -93,7 +95,9 @@ pub fn shadow_patch(attr: TokenStream, input: TokenStream) -> TokenStream {
             GenerateShadowPatchImplVisitor::new(Path::from(reported_ident.clone()));
 
         ShadowGenerator::new(full_input.clone())
-            .modifier(&mut ReportOnlyModifier)
+            .modifier(&mut ReportOnlyModifier {
+                strip_persist: true,
+            })
             .variant_or_field_visitor(&mut SetNewVisibilityVisitor(true))
             .variant_or_field_visitor(&mut SetNewTypeVisitor(delta.clone()))
             .variant_or_field_visitor(&mut shadowpatch_impl_generator)
@@ -127,7 +131,9 @@ pub fn shadow_patch(attr: TokenStream, input: TokenStream) -> TokenStream {
             .generator(&mut DefaultGenerator(false))
             .variant_or_field_visitor(&mut RemoveShadowAttributesVisitor)
             .generator(&mut NewGenerator)
-            .modifier(&mut ReportOnlyModifier)
+            .modifier(&mut ReportOnlyModifier {
+                strip_persist: false,
+            })
             .generator(&mut GenerateFromImpl)
             .finalize()
     };

--- a/rustot_derive/tests/shadow.rs
+++ b/rustot_derive/tests/shadow.rs
@@ -379,3 +379,105 @@ fn enum_leaf() {
 //         a: A,
 //     }
 // }
+
+#[test]
+fn report_only_persist() {
+    #[shadow(name = "persist_test")]
+    #[derive(Debug, PartialEq)]
+    struct Config {
+        pub mode: u8,
+
+        pub inner: Inner,
+
+        /// This field is kept in the struct and persisted, but NOT in Delta
+        #[shadow_attr(report_only(persist), leaf)]
+        pub verified: bool,
+
+        #[shadow_attr(report_only, leaf)]
+        pub status: u8,
+    }
+
+    #[shadow_patch]
+    #[derive(Debug, PartialEq)]
+    struct Inner {
+        hello: u16,
+    }
+
+    // 1. Field exists on the runtime struct
+    let config = Config {
+        mode: 1,
+        inner: Inner { hello: 42 },
+        verified: true,
+    };
+    assert!(config.verified);
+
+    // 2. report_only(persist) field does NOT exist on Delta
+    //    (if it did, this wouldn't compile because we'd need to set it)
+    let delta = DeltaConfig {
+        mode: Some(2),
+        inner: None,
+    };
+
+    // 3. report_only(persist) field exists on Reported with actual value
+    let reported = ReportedConfig::from(config.clone());
+    assert_eq!(reported.verified, Some(true)); // persist: gets Some(v.verified)
+    assert_eq!(reported.status, None); // plain report_only: gets None
+    assert_eq!(reported.mode, Some(1));
+    assert_eq!(reported.inner, Some(ReportedInner { hello: Some(42) }));
+
+    // 4. apply_patch does not touch report_only(persist) fields
+    let mut config2 = Config {
+        mode: 1,
+        inner: Inner { hello: 10 },
+        verified: true,
+    };
+    config2.apply_patch(delta);
+    assert_eq!(config2.mode, 2); // changed by delta
+    assert!(config2.verified); // unchanged -- not in delta
+
+    // 5. Reported struct can set report_only(persist) fields
+    let reported_manual = ReportedConfig {
+        mode: None,
+        inner: None,
+        verified: Some(false),
+        status: Some(42),
+    };
+    assert_eq!(reported_manual.verified, Some(false));
+}
+
+#[test]
+fn report_only_persist_with_nested() {
+    /// Test that report_only(persist) works alongside other field types
+    #[shadow(name = "mixed")]
+    #[derive(Debug, PartialEq)]
+    struct Mixed {
+        pub normal: u32,
+
+        #[shadow_attr(report_only(persist), leaf)]
+        pub local_flag: bool,
+
+        #[shadow_attr(report_only)]
+        pub ephemeral: u16,
+    }
+
+    // Struct has normal + persist fields, not ephemeral
+    let m = Mixed {
+        normal: 10,
+        local_flag: false,
+    };
+
+    // Delta only has normal field
+    let delta = DeltaMixed { normal: Some(20) };
+
+    // Reported has all fields
+    let reported = ReportedMixed::from(m.clone());
+    assert_eq!(reported.normal, Some(10));
+    assert_eq!(reported.local_flag, Some(false));
+    assert_eq!(reported.ephemeral, None);
+
+    // apply_patch only affects normal fields
+    let mut m2 = m;
+    m2.apply_patch(delta);
+    assert_eq!(m2.normal, 20);
+    assert!(!m2.local_flag); // unchanged
+}

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -69,7 +69,11 @@ impl<'a, M: RawMutex, S: ShadowState> ShadowHandler<'a, '_, M, S> {
                                 .topics(&[SubscribeTopic::builder()
                                     .topic_path(
                                         topics::Topic::UpdateDelta
-                                            .format::<64>(S::PREFIX, self.mqtt.client_id(), S::NAME)?
+                                            .format::<64>(
+                                                S::PREFIX,
+                                                self.mqtt.client_id(),
+                                                S::NAME,
+                                            )?
                                             .as_str(),
                                     )
                                     .build()])
@@ -490,6 +494,39 @@ where
         if let Some(delta) = response.delta {
             state.apply_patch(delta.clone());
 
+            self.dao.lock().await.write(&state).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Update shadow state with persistence and cloud reporting.
+    ///
+    /// Unlike [`update`](Self::update), this gives mutable access to the
+    /// state, saves it to the DAO, then reports to the cloud. Use this for
+    /// fields marked `#[shadow_attr(report_only(persist))]` that need local
+    /// persistence but are excluded from the Delta type.
+    ///
+    /// The closure receives `(&mut S, &mut S::Reported)`:
+    /// - Modify `S` directly for fields that need persistence
+    /// - Set fields on `Reported` for cloud reporting
+    pub async fn update_with_state<F: FnOnce(&mut S, &mut S::Reported)>(
+        &self,
+        f: F,
+    ) -> Result<(), Error> {
+        let mut update = S::Reported::default();
+        let mut state = self.dao.lock().await.read().await?;
+        f(&mut state, &mut update);
+
+        // Persist state (including report_only(persist) fields)
+        self.dao.lock().await.write(&state).await?;
+
+        // Report to cloud
+        let response = self.handler.update_shadow(None, Some(update)).await?;
+
+        // Handle delta from cloud (won't include report_only(persist) fields)
+        if let Some(delta) = response.delta {
+            state.apply_patch(delta.clone());
             self.dao.lock().await.write(&state).await?;
         }
 


### PR DESCRIPTION
## Summary

- Adds `#[shadow_attr(report_only(persist))]` attribute variant for shadow fields that need to be excluded from the Delta type (cloud cannot write them) while being kept in the runtime struct and persisted via ShadowDAO
- Adds `PersistedShadow::update_with_state()` method that gives mutable access to the state, saves to DAO, then reports to cloud — needed for persisting `report_only(persist)` field changes
- Extends the `has_shadow_arg` parser to support `Meta::List` syntax (e.g. `report_only(persist)`) alongside bare idents

## Motivation

Fields like `wifi_verified` in the firmware need to be:
- **Persisted** across reboots (via ShadowDAO)
- **Used in business logic** (e.g. fallback decisions)
- **Reported** to the cloud
- **NOT writable** from the cloud (excluded from desired/delta state)

Previously this was impossible: `report_only` strips the field from the struct entirely, while a normal field appears in the desired state.

## Behavior matrix

| Aspect | Normal field | `report_only` | `report_only(persist)` |
|--------|-------------|---------------|------------------------|
| In runtime struct | Yes | No | **Yes** |
| In Delta type | Yes | No | **No** |
| In Reported type | Yes | Yes | Yes |
| Persisted via DAO | Yes | No | **Yes** |
| Cloud can write | Yes | No | No |

## Test plan

- [x] Existing 7 shadow derive tests continue to pass
- [x] New `report_only_persist` test: verifies field exists on struct, excluded from Delta, included in Reported with `Some(value)`, and `apply_patch` doesn't touch it
- [x] New `report_only_persist_with_nested` test: verifies alongside normal and plain report_only fields
- [x] `cargo check --lib` passes
- [x] `cargo fmt` clean