### PR TITLE
Add #[shadow_attr(flatten)] for inlining map entries into parent JSON

### DIFF
--- a/rustot_derive/src/attr/field_attr.rs
+++ b/rustot_derive/src/attr/field_attr.rs
@@ -35,6 +35,10 @@ pub struct FieldAttrs {
     #[cfg(feature = "kv_persist")]
     #[darling(default, rename = "default")]
     pub default_value: Option<DefaultValue>,
+    /// Field is flattened — its entries are inlined into the parent JSON object.
+    /// Only valid for map types (e.g., HashMap<String, V>). Requires `std` feature.
+    #[darling(default)]
+    pub flatten: bool,
 }
 
 /// Report-only field specification
@@ -143,6 +147,11 @@ impl FieldAttrs {
     #[cfg_attr(not(feature = "kv_persist"), allow(dead_code))]
     pub fn opaque_max_size(&self) -> Option<usize> {
         self.opaque.as_ref().and_then(|o| o.max_size)
+    }
+
+    /// Check if this field is marked as flatten
+    pub fn is_flatten(&self) -> bool {
+        self.flatten
     }
 
     /// Get all migration source keys
@@ -380,6 +389,21 @@ mod tests {
         let field_attrs = FieldAttrs::from_attrs(&attrs);
         assert!(!field_attrs.is_report_only());
         assert!(!field_attrs.is_report_only_persist());
+    }
+
+    // Test flatten attribute parsing
+    #[test]
+    fn test_flatten() {
+        let attrs: Vec<Attribute> = vec![parse_quote!(#[shadow_attr(flatten)])];
+        let field_attrs = FieldAttrs::from_attrs(&attrs);
+        assert!(field_attrs.is_flatten());
+    }
+
+    #[test]
+    fn test_not_flatten() {
+        let attrs: Vec<Attribute> = vec![parse_quote!(#[shadow_attr(opaque)])];
+        let field_attrs = FieldAttrs::from_attrs(&attrs);
+        assert!(!field_attrs.is_flatten());
     }
 
     // Test heck integration for rename_all

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -102,6 +102,11 @@ struct FieldCodegen {
 
     /// ReportedDiff::diff() arm for this field
     reported_diff_arm: TokenStream,
+
+    /// Whether this field is flattened
+    is_flatten: bool,
+    /// parse_delta() match arm body for ObjectScanner-based parsing (None if report_only or flatten)
+    parse_delta_match_arm: Option<TokenStream>,
 }
 
 /// Process a single struct field and generate all code fragments.
@@ -115,7 +120,7 @@ struct FieldCodegen {
 /// Leaf fields are serialized directly as their type. Nested fields delegate
 /// to their inner ShadowNode implementation for Delta/Reported types and
 /// KV operations.
-fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
+fn process_field(field: &syn::Field, krate: &TokenStream) -> syn::Result<FieldCodegen> {
     let field_name = field.ident.as_ref().unwrap();
     let field_ty = &field.ty;
     let attrs = FieldAttrs::from_attrs(&field.attrs);
@@ -123,11 +128,28 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
     let serde_name = get_serde_rename(&field.attrs).unwrap_or_else(|| field_name.to_string());
     let _field_path = format!("/{}", serde_name);
 
+    // Validate flatten constraints
+    #[cfg(not(feature = "std"))]
+    if attrs.is_flatten() {
+        return Err(syn::Error::new_spanned(
+            field,
+            "#[shadow_attr(flatten)] requires the `std` feature to be enabled",
+        ));
+    }
+
+    if attrs.is_flatten() && attrs.is_opaque() {
+        return Err(syn::Error::new_spanned(
+            field,
+            "#[shadow_attr(flatten)] and #[shadow_attr(opaque)] are mutually exclusive",
+        ));
+    }
+
     // A field is a "leaf" (direct KV storage) if it's opaque OR has migrations.
     // Fields with migrations must be leaves because migration logic operates on
     // the serialized value directly.
     let has_migration = !attrs.migrate_from().is_empty();
     let is_leaf = attrs.is_opaque() || has_migration;
+    let is_flatten = attrs.is_flatten();
 
     // Filter out shadow_attr from forwarded attributes
     let filtered_attrs: Vec<_> = field
@@ -147,9 +169,14 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
         })
     } else {
         let delta_field_ty = quote! { <#field_ty as #krate::shadows::ShadowNode>::Delta };
+        let serde_attr = if is_flatten {
+            quote! { #[serde(flatten, skip_serializing_if = "Option::is_none")] }
+        } else {
+            quote! { #[serde(skip_serializing_if = "Option::is_none")] }
+        };
         Some(quote! {
             #(#filtered_attrs)*
-            #[serde(skip_serializing_if = "Option::is_none")]
+            #serde_attr
             pub #field_name: Option<#delta_field_ty>,
         })
     };
@@ -163,9 +190,14 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
         }
     } else {
         let reported_field_ty = quote! { <#field_ty as #krate::shadows::ShadowNode>::Reported };
+        let serde_attr = if is_flatten {
+            quote! { #[serde(flatten, skip_serializing_if = "Option::is_none")] }
+        } else {
+            quote! { #[serde(skip_serializing_if = "Option::is_none")] }
+        };
         quote! {
             #(#filtered_attrs)*
-            #[serde(skip_serializing_if = "Option::is_none")]
+            #serde_attr
             pub #field_name: Option<#reported_field_ty>,
         }
     };
@@ -232,9 +264,17 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
     };
 
     // --- reported serialize arm ---
-    let reported_serialize_arm = quote! {
-        if let Some(ref val) = self.#field_name {
-            map.serialize_entry(#serde_name, val)?;
+    let reported_serialize_arm = if is_flatten {
+        quote! {
+            if let Some(ref val) = self.#field_name {
+                #krate::shadows::ReportedUnionFields::serialize_into_map(val, map)?;
+            }
+        }
+    } else {
+        quote! {
+            if let Some(ref val) = self.#field_name {
+                map.serialize_entry(#serde_name, val)?;
+            }
         }
     };
 
@@ -313,8 +353,8 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
         })
     };
 
-    // --- variant_at_path arm (only for non-report_only nested fields) ---
-    let variant_at_path_arm = if attrs.is_report_only() || is_leaf {
+    // --- variant_at_path arm (only for non-report_only, non-flatten nested fields) ---
+    let variant_at_path_arm = if attrs.is_report_only() || is_leaf || is_flatten {
         None
     } else {
         let field_prefix = format!("{}/", serde_name);
@@ -391,7 +431,38 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
         }
     };
 
-    FieldCodegen {
+    // --- parse_delta match arm for ObjectScanner-based parsing (used when struct has flatten) ---
+    let parse_delta_match_arm = if attrs.is_report_only() || is_flatten {
+        None
+    } else if is_leaf {
+        Some(quote! {
+            delta.#field_name = Some(
+                #krate::__macro_support::serde_json_core::from_slice(__value_bytes)
+                    .map(|(v, _)| v)
+                    .map_err(|_| #krate::shadows::ParseError::Deserialize)?
+            );
+        })
+    } else {
+        Some(quote! {
+            {
+                let mut nested_path: #krate::__macro_support::heapless::String<64> = #krate::__macro_support::heapless::String::new();
+                let _ = nested_path.push_str(path);
+                if !path.is_empty() {
+                    let _ = nested_path.push('/');
+                }
+                let _ = nested_path.push_str(#serde_name);
+                delta.#field_name = Some(
+                    <#field_ty as #krate::shadows::ShadowNode>::parse_delta(
+                        __value_bytes,
+                        &nested_path,
+                        resolver
+                    ).await?
+                );
+            }
+        })
+    };
+
+    Ok(FieldCodegen {
         serde_name,
         delta_field,
         reported_field,
@@ -410,7 +481,9 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
         reported_builder_param,
         reported_builder_assign,
         reported_diff_arm,
-    }
+        is_flatten,
+        parse_delta_match_arm,
+    })
 }
 
 /// Generate code for a struct type
@@ -442,11 +515,22 @@ pub(crate) fn generate_struct_code(
     let field_codegens: Vec<FieldCodegen> = named_fields
         .iter()
         .map(|field| process_field(field, krate))
-        .collect();
+        .collect::<syn::Result<Vec<_>>>()?;
+
+    // Validate: at most one flatten field per struct
+    let flatten_count = field_codegens.iter().filter(|f| f.is_flatten).count();
+    if flatten_count > 1 {
+        return Err(syn::Error::new_spanned(
+            input,
+            "at most one #[shadow_attr(flatten)] field is allowed per struct",
+        ));
+    }
 
     // Extract vectors from FieldCodegen structs
+    // Exclude flattened fields from FIELD_NAMES (their keys are dynamic)
     let field_names: Vec<_> = field_codegens
         .iter()
+        .filter(|f| !f.is_flatten)
         .map(|f| f.serde_name.clone())
         .collect();
     let delta_fields: Vec<_> = field_codegens
@@ -537,15 +621,93 @@ pub(crate) fn generate_struct_code(
         }
     };
 
-    // Generate parse_delta body - always use FieldScanner
-    let field_name_strs: Vec<_> = parse_delta_field_names.iter().map(|s| s.as_str()).collect();
-    let parse_delta_body = quote! {
-        let scanner = #krate::shadows::tag_scanner::FieldScanner::scan(json, &[#(#field_name_strs),*])
-            .map_err(#krate::shadows::ParseError::Scan)?;
+    // Check if any non-report_only field is flattened (requires ObjectScanner-based parse_delta)
+    let has_flatten_delta = field_codegens
+        .iter()
+        .any(|f| f.is_flatten && f.delta_field.is_some());
 
-        let mut delta = Self::Delta::default();
-        #(#parse_delta_arms)*
-        Ok(delta)
+    // Generate parse_delta body
+    let parse_delta_body = if has_flatten_delta {
+        // ObjectScanner-based parse_delta: iterate all JSON entries, dispatch known
+        // fields by name, collect remaining entries for the flattened field.
+        let mut match_arms = Vec::new();
+        let mut flatten_field_name = None;
+        let mut flatten_field_ty = None;
+
+        for (field, codegen) in named_fields.iter().zip(field_codegens.iter()) {
+            if codegen.is_flatten && codegen.delta_field.is_some() {
+                flatten_field_name = Some(field.ident.as_ref().unwrap());
+                flatten_field_ty = Some(&field.ty);
+            } else if let (Some(ref arm), Some(ref name)) = (
+                &codegen.parse_delta_match_arm,
+                &codegen.parse_delta_field_name,
+            ) {
+                match_arms.push(quote! { #name => { #arm } });
+            }
+        }
+
+        let flatten_field_name = flatten_field_name.unwrap();
+        let flatten_field_ty = flatten_field_ty.unwrap();
+
+        quote! {
+            if #krate::shadows::tag_scanner::ObjectScanner::is_null_or_empty(json) {
+                return Ok(Self::Delta::default());
+            }
+
+            let mut __scanner = #krate::shadows::tag_scanner::ObjectScanner::new(json)
+                .map_err(#krate::shadows::ParseError::Scan)?;
+            let mut delta = Self::Delta::default();
+            let mut __flatten_entries: Vec<(&[u8], &[u8])> = Vec::new();
+
+            while let Some((__key_bytes, __value_bytes)) = __scanner.next_entry()
+                .map_err(#krate::shadows::ParseError::Scan)?
+            {
+                let __key_str = core::str::from_utf8(&__key_bytes[1..__key_bytes.len()-1])
+                    .map_err(|_| #krate::shadows::ParseError::Deserialize)?;
+
+                match __key_str {
+                    #(#match_arms)*
+                    _ => {
+                        __flatten_entries.push((__key_bytes, __value_bytes));
+                    }
+                }
+            }
+
+            if !__flatten_entries.is_empty() {
+                let mut __fj: Vec<u8> = Vec::with_capacity(
+                    __flatten_entries.iter().map(|(k, v)| k.len() + v.len() + 2).sum::<usize>() + 2
+                );
+                __fj.push(b'{');
+                for (__i, (__k, __v)) in __flatten_entries.iter().enumerate() {
+                    if __i > 0 { __fj.push(b','); }
+                    __fj.extend_from_slice(__k);
+                    __fj.push(b':');
+                    __fj.extend_from_slice(__v);
+                }
+                __fj.push(b'}');
+
+                delta.#flatten_field_name = Some(
+                    <#flatten_field_ty as #krate::shadows::ShadowNode>::parse_delta(
+                        &__fj,
+                        path,
+                        resolver
+                    ).await?
+                );
+            }
+
+            Ok(delta)
+        }
+    } else {
+        // FieldScanner-based parse_delta (no flatten field)
+        let field_name_strs: Vec<_> = parse_delta_field_names.iter().map(|s| s.as_str()).collect();
+        quote! {
+            let scanner = #krate::shadows::tag_scanner::FieldScanner::scan(json, &[#(#field_name_strs),*])
+                .map_err(#krate::shadows::ParseError::Scan)?;
+
+            let mut delta = Self::Delta::default();
+            #(#parse_delta_arms)*
+            Ok(delta)
+        }
     };
 
     // Generate ShadowNode impl (always generated)

--- a/rustot_derive/src/lib.rs
+++ b/rustot_derive/src/lib.rs
@@ -48,6 +48,7 @@ use codegen::generate_shadow_node;
 /// - `#[shadow_attr(migrate(from = "old_key"))]` - Migration from old key
 /// - `#[shadow_attr(migrate(from = "old_key", convert = fn))]` - Migration with conversion
 /// - `#[shadow_attr(default = value)]` - Custom default value
+/// - `#[shadow_attr(flatten)]` - Flatten map entries into parent object (requires `std`)
 ///
 /// # Example
 ///
@@ -83,6 +84,7 @@ pub fn shadow_root(
 /// - `#[shadow_attr(report_only)]` - Field only appears in Reported type
 /// - `#[shadow_attr(migrate(from = "old_key"))]` - Migration from old key
 /// - `#[shadow_attr(default = value)]` - Custom default value
+/// - `#[shadow_attr(flatten)]` - Flatten map entries into parent object (requires `std`)
 ///
 /// # Supported Types
 ///

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -300,10 +300,12 @@ where
 /// `None` means "no changes to the map" (the map field itself was absent
 /// from the delta). `Some(map)` contains per-entry patches.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 pub struct DeltaHashMap<K: Eq + Hash, D>(pub Option<HashMap<K, Patch<D>>>);
 
 /// Reported type for `HashMap`-based shadow fields.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+#[serde(transparent)]
 pub struct ReportedHashMap<K: Eq + Hash, R>(pub HashMap<K, R>);
 
 impl<K: Eq + Hash + serde::Serialize, R: serde::Serialize> ReportedUnionFields
@@ -311,7 +313,10 @@ impl<K: Eq + Hash + serde::Serialize, R: serde::Serialize> ReportedUnionFields
 {
     const FIELD_NAMES: &'static [&'static str] = &[];
 
-    fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
+    fn serialize_into_map<S: SerializeMap>(&self, map: &mut S) -> Result<(), S::Error> {
+        for (key, value) in self.0.iter() {
+            map.serialize_entry(key, value)?;
+        }
         Ok(())
     }
 }
@@ -772,5 +777,195 @@ mod tests {
             assert!(loaded.get("a").is_none());
             assert_eq!(loaded.get("b"), Some(&2));
         }
+    }
+}
+
+// =============================================================================
+// Flatten Tests
+// =============================================================================
+
+#[cfg(test)]
+mod flatten_tests {
+    use crate::shadows::{NullResolver, ShadowNode};
+    use rustot_derive::{shadow_node, shadow_root};
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
+
+    #[shadow_node]
+    #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+    struct ConnectorConfig {
+        pub enabled: bool,
+    }
+
+    #[shadow_root(name = "displays")]
+    #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+    struct DisplaysShadow {
+        pub brightness: u8,
+        #[shadow_attr(flatten)]
+        pub connectors: HashMap<String, ConnectorConfig>,
+    }
+
+    #[tokio::test]
+    async fn test_flatten_parse_delta_mixed_fields() {
+        let json =
+            br#"{"brightness": 50, "HDMI-A-1": {"enabled": true}, "DP-1": {"enabled": false}}"#;
+        let delta = DisplaysShadow::parse_delta(json, "", &NullResolver)
+            .await
+            .unwrap();
+
+        // Normal field parsed
+        assert_eq!(delta.brightness, Some(50));
+
+        // Flattened entries collected into connectors delta
+        let patches = delta.connectors.as_ref().unwrap().0.as_ref().unwrap();
+        assert_eq!(patches.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_flatten_parse_delta_only_normal() {
+        let json = br#"{"brightness": 80}"#;
+        let delta = DisplaysShadow::parse_delta(json, "", &NullResolver)
+            .await
+            .unwrap();
+
+        assert_eq!(delta.brightness, Some(80));
+        // No remaining keys → connectors delta is None
+        assert!(delta.connectors.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_flatten_parse_delta_only_flattened() {
+        let json = br#"{"HDMI-A-1": {"enabled": true}}"#;
+        let delta = DisplaysShadow::parse_delta(json, "", &NullResolver)
+            .await
+            .unwrap();
+
+        assert!(delta.brightness.is_none());
+        let patches = delta.connectors.as_ref().unwrap().0.as_ref().unwrap();
+        assert_eq!(patches.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_flatten_parse_delta_null() {
+        let json = b"null";
+        let delta = DisplaysShadow::parse_delta(json, "", &NullResolver)
+            .await
+            .unwrap();
+
+        assert!(delta.brightness.is_none());
+        assert!(delta.connectors.is_none());
+    }
+
+    #[test]
+    fn test_flatten_apply_delta() {
+        let mut state = DisplaysShadow {
+            brightness: 50,
+            connectors: HashMap::new(),
+        };
+
+        // Build a delta with both normal and flattened updates
+        let mut patches = HashMap::new();
+        patches.insert(
+            "HDMI-A-1".to_string(),
+            crate::shadows::data_types::Patch::Set(DeltaConnectorConfig {
+                enabled: Some(true),
+            }),
+        );
+        let delta = DeltaDisplaysShadow {
+            brightness: Some(80),
+            connectors: Some(super::DeltaHashMap(Some(patches))),
+        };
+
+        state.apply_delta(&delta);
+        assert_eq!(state.brightness, 80);
+        assert_eq!(
+            state.connectors.get("HDMI-A-1"),
+            Some(&ConnectorConfig { enabled: true })
+        );
+    }
+
+    #[test]
+    fn test_flatten_into_reported() {
+        let state = DisplaysShadow {
+            brightness: 50,
+            connectors: {
+                let mut m = HashMap::new();
+                m.insert("HDMI-A-1".to_string(), ConnectorConfig { enabled: true });
+                m
+            },
+        };
+
+        let reported = state.into_reported();
+        assert_eq!(reported.brightness, Some(50));
+        let connector_reported = &reported.connectors.as_ref().unwrap().0["HDMI-A-1"];
+        assert_eq!(connector_reported.enabled, Some(true));
+    }
+
+    #[test]
+    fn test_flatten_reported_serializes_flat() {
+        let state = DisplaysShadow {
+            brightness: 50,
+            connectors: {
+                let mut m = HashMap::new();
+                m.insert("HDMI-A-1".to_string(), ConnectorConfig { enabled: true });
+                m
+            },
+        };
+
+        let reported = state.into_reported();
+        let json = serde_json::to_string(&reported).unwrap();
+
+        // Should NOT contain "connectors" as a nested key
+        assert!(!json.contains("\"connectors\""));
+        // Should contain flat entries
+        assert!(json.contains("\"brightness\""));
+        assert!(json.contains("\"HDMI-A-1\""));
+        assert!(json.contains("\"enabled\""));
+    }
+
+    #[test]
+    fn test_flatten_delta_serializes_flat() {
+        let mut patches = HashMap::new();
+        patches.insert(
+            "DP-1".to_string(),
+            crate::shadows::data_types::Patch::Set(DeltaConnectorConfig {
+                enabled: Some(false),
+            }),
+        );
+
+        let delta = DeltaDisplaysShadow {
+            brightness: Some(60),
+            connectors: Some(super::DeltaHashMap(Some(patches))),
+        };
+
+        let json = serde_json::to_string(&delta).unwrap();
+        // Should NOT contain "connectors" as a nested key
+        assert!(!json.contains("\"connectors\""));
+        // Should contain flat entries
+        assert!(json.contains("\"brightness\""));
+        assert!(json.contains("\"DP-1\""));
+    }
+
+    #[test]
+    fn test_flatten_into_partial_reported() {
+        let state = DisplaysShadow {
+            brightness: 50,
+            connectors: {
+                let mut m = HashMap::new();
+                m.insert("HDMI-A-1".to_string(), ConnectorConfig { enabled: true });
+                m.insert("DP-1".to_string(), ConnectorConfig { enabled: false });
+                m
+            },
+        };
+
+        // Delta only changes brightness — connectors should be None in partial reported
+        let delta = DeltaDisplaysShadow {
+            brightness: Some(80),
+            connectors: None,
+        };
+
+        let partial = state.into_partial_reported(&delta);
+        assert_eq!(partial.brightness, Some(50));
+        assert!(partial.connectors.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Adds `#[shadow_attr(flatten)]` attribute that inlines a map field's entries into the parent JSON object, similar to serde's `#[serde(flatten)]`
- Gated behind the `std` feature (requires `Vec` allocation for JSON reconstruction during `parse_delta`)
- When a struct has a flatten field, `parse_delta` switches from `FieldScanner` to `ObjectScanner`, dispatching known fields by name and collecting remaining entries for the flattened field
- Adds `#[serde(transparent)]` to `DeltaHashMap` and `ReportedHashMap` so serde's `FlatMapSerializer` works correctly
- Fixes `ReportedHashMap::serialize_into_map` to actually serialize entries (was a no-op)

**Constraints enforced at compile time:**
- `flatten` + `opaque` is a compile error (contradictory semantics)
- `flatten` without `std` feature is a compile error
- At most one `flatten` field per struct

**Example:**
```rust
#[shadow_root(name = "displays")]
struct DisplaysShadow {
    pub brightness: u8,
    #[shadow_attr(flatten)]
    pub connectors: HashMap<String, ConnectorConfig>,
}
// Serializes as {"brightness": 50, "HDMI-A-1": {"enabled": true}}
// instead of   {"brightness": 50, "connectors": {"HDMI-A-1": {...}}}
```