### PR TITLE
Add ShadowNode::into_delta and fix create_shadow to populate full cloud state

### DIFF
--- a/rustot_derive/src/attr/field_attr.rs
+++ b/rustot_derive/src/attr/field_attr.rs
@@ -131,7 +131,7 @@ impl FieldAttrs {
 
     /// Check if this field is report_only with KV persistence
     pub fn is_report_only_persist(&self) -> bool {
-        self.report_only.as_ref().map_or(false, |spec| spec.persist)
+        self.report_only.as_ref().is_some_and(|spec| spec.persist)
     }
 
     /// Check if this field is marked as opaque

--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -120,6 +120,9 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
     // For into_reported - full conversion
     let mut into_reported_arms = Vec::new();
 
+    // For into_delta - full delta conversion
+    let mut into_delta_arms: Vec<TokenStream> = Vec::new();
+
     // For into_partial_reported - match on self and construct Reported directly
     let mut into_partial_reported_arms = Vec::new();
 
@@ -174,6 +177,14 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 // into_reported: unit variant
                 into_reported_arms.push(quote! {
                     Self::#variant_ident => Self::Reported::#variant_ident,
+                });
+
+                // into_delta: unit variant — mode only, no config
+                into_delta_arms.push(quote! {
+                    Self::#variant_ident => #delta_name {
+                        mode: #krate::shadows::DeltaMode::Known(#variant_enum_name::#variant_ident),
+                        config: #krate::shadows::DeltaContent::Absent,
+                    },
                 });
 
                 // into_partial_reported: unit variant has no inner state
@@ -233,6 +244,16 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                     Self::#variant_ident(ref inner) => {
                         Self::Reported::#variant_ident(#krate::shadows::ShadowNode::into_reported(inner))
                     }
+                });
+
+                // into_delta: delegate to inner's into_delta
+                into_delta_arms.push(quote! {
+                    Self::#variant_ident(ref inner) => #delta_name {
+                        mode: #krate::shadows::DeltaMode::Known(#variant_enum_name::#variant_ident),
+                        config: #krate::shadows::DeltaContent::Value(
+                            #delta_config_name::#variant_ident(#krate::shadows::ShadowNode::into_delta(inner))
+                        ),
+                    },
                 });
 
                 // into_partial_reported: get inner delta from config if matching, else use default
@@ -784,6 +805,12 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
             fn into_reported(&self) -> Self::Reported {
                 match self {
                     #(#into_reported_arms)*
+                }
+            }
+
+            fn into_delta(&self) -> Self::Delta {
+                match self {
+                    #(#into_delta_arms)*
                 }
             }
 

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -125,6 +125,7 @@ pub(crate) fn generate_simple_enum_code(
     let mut variant_names = Vec::new();
     let mut apply_delta_arms = Vec::new();
     let mut into_reported_arms = Vec::new();
+    let mut into_delta_arms: Vec<TokenStream> = Vec::new();
     let mut into_partial_reported_arms = Vec::new();
     let mut schema_hash_code = Vec::new();
     let mut reported_diff_arms = Vec::new();
@@ -159,6 +160,11 @@ pub(crate) fn generate_simple_enum_code(
                 // into_reported: for unit variants, return the reported variant
                 into_reported_arms.push(quote! {
                     Self::#variant_ident => Self::Reported::#variant_ident,
+                });
+
+                // into_delta: for unit variants, return the delta variant
+                into_delta_arms.push(quote! {
+                    Self::#variant_ident => Self::Delta::#variant_ident,
                 });
 
                 // into_partial_reported: for unit variants, return the reported variant
@@ -219,6 +225,13 @@ pub(crate) fn generate_simple_enum_code(
                 into_reported_arms.push(quote! {
                     Self::#variant_ident(ref inner) => {
                         Self::Reported::#variant_ident(#krate::shadows::ShadowNode::into_reported(inner))
+                    }
+                });
+
+                // into_delta: delegate to inner's into_delta
+                into_delta_arms.push(quote! {
+                    Self::#variant_ident(ref inner) => {
+                        Self::Delta::#variant_ident(#krate::shadows::ShadowNode::into_delta(inner))
                     }
                 });
 
@@ -525,6 +538,12 @@ pub(crate) fn generate_simple_enum_code(
             fn into_reported(&self) -> Self::Reported {
                 match self {
                     #(#into_reported_arms)*
+                }
+            }
+
+            fn into_delta(&self) -> Self::Delta {
+                match self {
+                    #(#into_delta_arms)*
                 }
             }
 

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -85,6 +85,9 @@ struct FieldCodegen {
     /// into_reported() field assignment (for ShadowNode impl)
     into_reported_arm: TokenStream,
 
+    /// into_delta() field assignment (None for report_only fields)
+    into_delta_arm: Option<TokenStream>,
+
     /// desired_cleanup() delegation arm (None for leaf and report_only fields)
     desired_cleanup_arm: Option<TokenStream>,
 
@@ -285,6 +288,17 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
         quote! { #field_name: Some(#krate::shadows::ShadowNode::into_reported(&self.#field_name)), }
     };
 
+    // --- into_delta arm (report_only fields are not in Delta, so no arm needed) ---
+    let into_delta_arm = if attrs.report_only {
+        None
+    } else if is_leaf {
+        Some(quote! { #field_name: Some(self.#field_name.clone()), })
+    } else {
+        Some(
+            quote! { #field_name: Some(#krate::shadows::ShadowNode::into_delta(&self.#field_name)), },
+        )
+    };
+
     // --- desired_cleanup arm (only for non-report_only nested fields) ---
     let desired_cleanup_arm = if attrs.is_report_only() || is_leaf {
         None
@@ -389,6 +403,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
         parse_delta_field_name,
         parse_delta_arm,
         into_reported_arm,
+        into_delta_arm,
         desired_cleanup_arm,
         desired_builder_param,
         desired_builder_assign,
@@ -473,6 +488,10 @@ pub(crate) fn generate_struct_code(
     let into_reported_arms: Vec<_> = field_codegens
         .iter()
         .map(|f| f.into_reported_arm.clone())
+        .collect();
+    let into_delta_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.into_delta_arm.clone())
         .collect();
     let desired_cleanup_arms: Vec<_> = field_codegens
         .iter()
@@ -559,6 +578,12 @@ pub(crate) fn generate_struct_code(
             fn into_reported(&self) -> Self::Reported {
                 #reported_name {
                     #(#into_reported_arms)*
+                }
+            }
+
+            fn into_delta(&self) -> Self::Delta {
+                #delta_name {
+                    #(#into_delta_arms)*
                 }
             }
 

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -289,7 +289,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> FieldCodegen {
     };
 
     // --- into_delta arm (report_only fields are not in Delta, so no arm needed) ---
-    let into_delta_arm = if attrs.report_only {
+    let into_delta_arm = if attrs.is_report_only() {
         None
     } else if is_leaf {
         Some(quote! { #field_name: Some(self.#field_name.clone()), })

--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -46,6 +46,10 @@ impl<const N: usize> ShadowNode for heapless::String<N> {
         self.clone()
     }
 
+    fn into_delta(&self) -> Self::Delta {
+        self.clone()
+    }
+
     fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
         self.clone()
     }
@@ -173,6 +177,10 @@ where
     }
 
     fn into_reported(&self) -> Self::Reported {
+        self.clone()
+    }
+
+    fn into_delta(&self) -> Self::Delta {
         self.clone()
     }
 
@@ -435,6 +443,14 @@ where
             let _ = reported.insert(key.clone(), value.into_reported());
         }
         ReportedLinearMap(reported)
+    }
+
+    fn into_delta(&self) -> Self::Delta {
+        let mut map = heapless::LinearMap::new();
+        for (key, value) in self.iter() {
+            let _ = map.insert(key.clone(), Patch::Set(value.into_delta()));
+        }
+        DeltaLinearMap(Some(map))
     }
 
     fn into_partial_reported(&self, delta: &Self::Delta) -> Self::Reported {
@@ -800,6 +816,10 @@ macro_rules! impl_array_shadow_node {
             }
 
             fn into_reported(&self) -> Self::Reported {
+                self.clone()
+            }
+
+            fn into_delta(&self) -> Self::Delta {
                 self.clone()
             }
 

--- a/src/shadows/impls/opaque.rs
+++ b/src/shadows/impls/opaque.rs
@@ -69,6 +69,10 @@ macro_rules! impl_opaque {
                 self.clone()
             }
 
+            fn into_delta(&self) -> Self::Delta {
+                self.clone()
+            }
+
             fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
                 self.clone()
             }

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -44,6 +44,10 @@ impl ShadowNode for String {
         self.clone()
     }
 
+    fn into_delta(&self) -> Self::Delta {
+        self.clone()
+    }
+
     fn into_partial_reported(&self, _delta: &Self::Delta) -> Self::Reported {
         self.clone()
     }
@@ -167,6 +171,10 @@ where
     }
 
     fn into_reported(&self) -> Self::Reported {
+        self.clone()
+    }
+
+    fn into_delta(&self) -> Self::Delta {
         self.clone()
     }
 
@@ -404,6 +412,14 @@ where
             reported.insert(key.clone(), value.into_reported());
         }
         ReportedHashMap(reported)
+    }
+
+    fn into_delta(&self) -> Self::Delta {
+        let mut map = HashMap::new();
+        for (key, value) in self.iter() {
+            map.insert(key.clone(), Patch::Set(value.into_delta()));
+        }
+        DeltaHashMap(Some(map))
     }
 
     fn into_partial_reported(&self, delta: &Self::Delta) -> Self::Reported {

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -481,6 +481,15 @@ pub trait ShadowNode: Clone + Sized {
     #[allow(clippy::wrong_self_convention)]
     fn into_reported(&self) -> Self::Reported;
 
+    /// Convert to a fully populated delta (all fields `Some`).
+    ///
+    /// Used when creating a shadow to populate the desired state in the cloud.
+    /// Unlike `into_reported`, this excludes `report_only` fields (which are
+    /// not part of the Delta type) — giving the cloud a complete picture of
+    /// all modifiable keys.
+    #[allow(clippy::wrong_self_convention)]
+    fn into_delta(&self) -> Self::Delta;
+
     /// Convert to reported representation containing only fields present in delta.
     ///
     /// Used for efficient acknowledgment - reports only changed fields.

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -130,7 +130,7 @@ where
         reported: Option<S::Reported>,
     ) -> Result<DeltaState<S::Delta, S::Delta>, Error> {
         debug!(
-            "[{:?}] Updating reported shadow value.",
+            "[{:?}] Updating shadow value.",
             S::NAME.unwrap_or(CLASSIC_SHADOW),
         );
 

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -34,7 +34,7 @@ impl<'a, 'm, S, C, K> Shadow<'a, 'm, S, C, K>
 where
     S: ShadowRoot + Clone,
     S::Delta: Serialize,
-    S::Reported: Serialize + Default,
+    S::Reported: Serialize,
     C: MqttClient,
     K: StateStore<S>,
     [(); max_topic_len(S::PREFIX, S::NAME)]:,
@@ -124,9 +124,9 @@ where
     }
 
     /// Publish an update request to the cloud and wait for response.
-    async fn update_shadow(
+    async fn update_shadow<D: Serialize>(
         &self,
-        desired: Option<S::Delta>,
+        desired: Option<D>,
         reported: Option<S::Reported>,
     ) -> Result<DeltaState<S::Delta, S::Delta>, Error> {
         debug!(
@@ -134,7 +134,7 @@ where
             S::NAME.unwrap_or(CLASSIC_SHADOW),
         );
 
-        let request: Request<'_, S::Delta, S::Reported> = Request {
+        let request: Request<'_, D, S::Reported> = Request {
             state: RequestState { desired, reported },
             client_token: Some(self.mqtt.client_id()),
             version: None,
@@ -408,7 +408,7 @@ where
     pub async fn update_reported(&self, reported: impl Into<S::Reported>) -> Result<(), Error> {
         let reported: S::Reported = reported.into();
 
-        let response = self.update_shadow(None, Some(reported)).await?;
+        let response = self.update_shadow::<S::Delta>(None, Some(reported)).await?;
 
         if let Some(delta) = response.delta {
             self.apply_and_save(&delta)
@@ -490,10 +490,13 @@ where
         Ok(state)
     }
 
-    /// Create a new shadow in the cloud with default reported state.
+    /// Create a new shadow in the cloud with the current device state.
     ///
-    /// Publishes an update request with `S::Reported::default()` and returns
-    /// the resulting delta state from the cloud.
+    /// Reads the actual state from the KV store and publishes it to the cloud
+    /// with both `desired` (fully populated delta — all modifiable keys) and
+    /// `reported` (full reported state including report_only fields). This
+    /// ensures the cloud has a complete picture of the device's state from
+    /// the start.
     ///
     /// ## Example
     ///
@@ -506,7 +509,16 @@ where
             S::NAME.unwrap_or(CLASSIC_SHADOW),
         );
 
-        self.update_shadow(None, Some(S::Reported::default())).await
+        let state: S = self
+            .store
+            .get_state(Self::prefix())
+            .await
+            .map_err(|_| Error::DaoWrite)?;
+
+        let desired = state.into_delta();
+        let reported = state.into_reported();
+
+        self.update_shadow(Some(desired), Some(reported)).await
     }
 
     /// Delete the shadow from the cloud and remove all persisted state.

--- a/tests/shadows.rs
+++ b/tests/shadows.rs
@@ -286,6 +286,49 @@ async fn test_shadow_end_to_end() {
         assert_eq!(state.tagged, TaggedEnum::None);
         assert_eq!(state.adjacent, Adjacent::Off);
 
+        // Verify cloud document has both desired and reported fully populated
+        let doc = cloud_get_shadow(&client, thing_name)
+            .await
+            .expect("Failed to get shadow after create");
+        log::info!("Cloud doc after create: {}", doc["state"]);
+
+        let desired = &doc["state"]["desired"];
+        let reported = &doc["state"]["reported"];
+
+        // desired should have all modifiable fields
+        assert!(
+            !desired.is_null(),
+            "desired should be populated after create"
+        );
+        assert!(desired["count"].is_number(), "desired should have count");
+        assert!(!desired["active"].is_null(), "desired should have active");
+        assert!(!desired["inner"].is_null(), "desired should have inner");
+        assert!(!desired["tagged"].is_null(), "desired should have tagged");
+        assert!(
+            !desired["adjacent"].is_null(),
+            "desired should have adjacent"
+        );
+
+        // desired should NOT have report_only fields
+        assert!(
+            desired.get("version").is_none() || desired["version"].is_null(),
+            "desired should not have report_only field 'version'"
+        );
+
+        // reported should have all fields including report_only
+        assert!(
+            !reported.is_null(),
+            "reported should be populated after create"
+        );
+        assert!(reported["count"].is_number(), "reported should have count");
+
+        // There should be no delta (desired == reported for non-report-only fields)
+        assert!(
+            doc["state"]["delta"].is_null(),
+            "delta should be null when desired matches reported"
+        );
+        log::info!("Cloud state verified: desired and reported fully populated, no delta");
+
         // =====================================================================
         // Test 1: Primitive fields (count, active)
         // =====================================================================


### PR DESCRIPTION
## Summary

- Adds `ShadowNode::into_delta(&self) -> Self::Delta` — converts state to a fully populated delta (all `Some`), excluding `report_only` fields. This gives the cloud visibility into all modifiable keys.
- Fixes `create_shadow` to read the actual device state from the KV store and publish both `desired` (via `into_delta`) and `reported` (via `into_reported`), instead of only sending `Reported::default()` with no desired.
- Makes `update_shadow` generic over the desired type (`D: Serialize`) so `create_shadow` can send `S::Delta` as desired while other callers continue sending `S::Delta` or `Option<S::Delta>` unchanged.
- Drops the now-unnecessary `S::Reported: Default` bound from the cloud impl block.