### PR TITLE
feat: Rename ReportedUnionFields to ReportedFields, add persist_report_only

### DIFF
--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -274,7 +274,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                     },
                 });
 
-                // For flat union serialize - use ReportedUnionFields
+                // For flat union serialize - use ReportedFields
                 inactive_variant_field_nulls.push((variant_ident.clone(), inner_ty.clone()));
 
                 // Schema hash for newtype variant
@@ -497,7 +497,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 .map(|(_, inner_ty)| {
                     quote! {
                         #krate::shadows::serialize_null_fields(
-                            <<#inner_ty as #krate::shadows::ShadowNode>::Reported as #krate::shadows::ReportedUnionFields>::FIELD_NAMES,
+                            <<#inner_ty as #krate::shadows::ShadowNode>::Reported as #krate::shadows::ReportedFields>::FIELD_NAMES,
                             &mut content_map
                         )?;
                     }
@@ -516,7 +516,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                         map.serialize_entry(#tag_key, #serde_name)?;
                         // Create nested content map using a helper that implements Serialize
                         struct ContentWrapper<'a, C>(&'a C, core::marker::PhantomData<fn() -> ()>);
-                        impl<'a, C: #krate::shadows::ReportedUnionFields + ::serde::Serialize> ::serde::Serialize for ContentWrapper<'a, C> {
+                        impl<'a, C: #krate::shadows::ReportedFields + ::serde::Serialize> ::serde::Serialize for ContentWrapper<'a, C> {
                             fn serialize<SS>(&self, serializer: SS) -> Result<SS::Ok, SS::Error>
                             where
                                 SS: ::serde::Serializer,
@@ -588,7 +588,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 S: ::serde::Serializer,
             {
                 use ::serde::ser::SerializeMap;
-                use #krate::shadows::ReportedUnionFields;
+                use #krate::shadows::ReportedFields;
 
                 const TOTAL_FIELDS: usize = #total_fields_expr;
                 let mut map = serializer.serialize_map(Some(TOTAL_FIELDS))?;
@@ -663,7 +663,7 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                     .filter(|(other_ident, _)| other_ident != variant_ident)
                     .map(|(_, inner_ty)| {
                         quote! {
-                            <<#inner_ty as #krate::shadows::ShadowNode>::Reported as #krate::shadows::ReportedUnionFields>::FIELD_NAMES
+                            <<#inner_ty as #krate::shadows::ShadowNode>::Reported as #krate::shadows::ReportedFields>::FIELD_NAMES
                         }
                     })
                     .collect();
@@ -1042,10 +1042,10 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
     };
 
     // =========================================================================
-    // 6. Generate ReportedUnionFields Implementation
+    // 6. Generate ReportedFields Implementation
     // =========================================================================
     let reported_union_fields_impl = quote! {
-        impl #krate::shadows::ReportedUnionFields for #reported_name {
+        impl #krate::shadows::ReportedFields for #reported_name {
             const FIELD_NAMES: &'static [&'static str] = &[#tag_key];
 
             fn serialize_into_map<S: ::serde::ser::SerializeMap>(

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -758,10 +758,10 @@ pub(crate) fn generate_simple_enum_code(
         #kv_persist_impl
     };
 
-    // Generate ReportedUnionFields impl for enum
+    // Generate ReportedFields impl for enum
     // For enums, we need to serialize the discriminant
     let reported_union_fields_impl = quote! {
-        impl #krate::shadows::ReportedUnionFields for #reported_name {
+        impl #krate::shadows::ReportedFields for #reported_name {
             const FIELD_NAMES: &'static [&'static str] = &[];
 
             fn serialize_into_map<S: ::serde::ser::SerializeMap>(

--- a/rustot_derive/src/codegen/mod.rs
+++ b/rustot_derive/src/codegen/mod.rs
@@ -5,7 +5,7 @@
 //! - Reported type with skip_serializing_if
 //! - ShadowNode trait implementation
 //! - ShadowRoot trait implementation (for root types)
-//! - ReportedUnionFields implementation
+//! - ReportedFields implementation
 
 mod adjacently_tagged;
 mod enum_codegen;
@@ -33,7 +33,7 @@ pub(crate) struct CodegenOutput {
     pub reported_type: TokenStream,
     /// The `ShadowNode` trait implementation (includes `KVPersist` when feature-enabled)
     pub shadow_node_impl: TokenStream,
-    /// The `ReportedUnionFields` trait implementation
+    /// The `ReportedFields` trait implementation
     pub reported_union_fields_impl: TokenStream,
     /// Builder impl block for `desired()` / `reported()` associated functions
     pub builder_impl: TokenStream,

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -72,7 +72,7 @@ struct FieldCodegen {
     into_partial_reported_arm: TokenStream,
     /// SCHEMA_HASH computation code
     schema_hash_code: TokenStream,
-    /// ReportedUnionFields::serialize_into_map arm
+    /// ReportedFields::serialize_into_map arm
     reported_serialize_arm: TokenStream,
     /// variant_at_path() delegation arm (None for leaf fields)
     variant_at_path_arm: Option<TokenStream>,
@@ -102,6 +102,9 @@ struct FieldCodegen {
 
     /// ReportedDiff::diff() arm for this field
     reported_diff_arm: TokenStream,
+
+    /// persist_report_only() arm for report_only(persist) fields (None otherwise)
+    persist_report_only_arm: Option<TokenStream>,
 
     /// Whether this field is flattened
     is_flatten: bool,
@@ -267,7 +270,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> syn::Result<FieldCo
     let reported_serialize_arm = if is_flatten {
         quote! {
             if let Some(ref val) = self.#field_name {
-                #krate::shadows::ReportedUnionFields::serialize_into_map(val, map)?;
+                #krate::shadows::ReportedFields::serialize_into_map(val, map)?;
             }
         }
     } else {
@@ -462,6 +465,24 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> syn::Result<FieldCo
         })
     };
 
+    // --- persist_report_only arm (only for report_only(persist) leaf fields) ---
+    let persist_report_only_arm = if attrs.is_report_only_persist() {
+        let field_kv_path = format!("/{}", serde_name);
+        Some(quote! {
+            if let Some(ref val) = self.#field_name {
+                let __saved_len = __key_buf.len();
+                let _ = __key_buf.push_str(#field_kv_path);
+                let mut __buf = [0u8; <#field_ty as #krate::__macro_support::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE];
+                let bytes = #krate::__macro_support::postcard::to_slice(val, &mut __buf)
+                    .map_err(|_| #krate::shadows::KvError::Serialization)?;
+                __kv.store(__key_buf.as_str(), bytes).await.map_err(#krate::shadows::KvError::Kv)?;
+                __key_buf.truncate(__saved_len);
+            }
+        })
+    } else {
+        None
+    };
+
     Ok(FieldCodegen {
         serde_name,
         delta_field,
@@ -481,6 +502,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> syn::Result<FieldCo
         reported_builder_param,
         reported_builder_assign,
         reported_diff_arm,
+        persist_report_only_arm,
         is_flatten,
         parse_delta_match_arm,
     })
@@ -584,6 +606,10 @@ pub(crate) fn generate_struct_code(
     let reported_diff_arms: Vec<_> = field_codegens
         .iter()
         .map(|f| f.reported_diff_arm.clone())
+        .collect();
+    let persist_report_only_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.persist_report_only_arm.clone())
         .collect();
 
     // Generate Delta type - always use FieldScanner, no Deserialize needed
@@ -1065,9 +1091,32 @@ pub(crate) fn generate_struct_code(
         #kv_persist_impl
     };
 
-    // Generate ReportedUnionFields impl
+    // Generate persist_report_only override if there are report_only(persist) fields
+    #[cfg(not(feature = "kv_persist"))]
+    let persist_report_only_method = quote! {};
+    #[cfg(feature = "kv_persist")]
+    let persist_report_only_method = if persist_report_only_arms.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            fn persist_report_only<__K: #krate::shadows::KVStore>(
+                &self,
+                __prefix: &str,
+                __kv: &__K,
+            ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<__K::Error>>> {
+                async move {
+                    let mut __key_buf = #krate::__macro_support::heapless::String::<64>::new();
+                    let _ = __key_buf.push_str(__prefix);
+                    #(#persist_report_only_arms)*
+                    Ok(())
+                }
+            }
+        }
+    };
+
+    // Generate ReportedFields impl
     let reported_union_fields_impl = quote! {
-        impl #krate::shadows::ReportedUnionFields for #reported_name {
+        impl #krate::shadows::ReportedFields for #reported_name {
             const FIELD_NAMES: &'static [&'static str] = &[#(#field_names),*];
 
             fn serialize_into_map<S: ::serde::ser::SerializeMap>(
@@ -1077,6 +1126,8 @@ pub(crate) fn generate_struct_code(
                 #(#reported_serialize_arms)*
                 Ok(())
             }
+
+            #persist_report_only_method
         }
 
         impl #krate::shadows::ReportedDiff for #reported_name {

--- a/rustot_derive/src/lib.rs
+++ b/rustot_derive/src/lib.rs
@@ -22,7 +22,7 @@ use codegen::generate_shadow_node;
 /// - `ShadowNode` trait implementation (persistence support)
 /// - `Delta{Name}` struct for applying partial updates
 /// - `Reported{Name}` struct with serde skip_serializing_if
-/// - `ReportedUnionFields` implementation
+/// - `ReportedFields` implementation
 /// - `desired()` / `reported()` builder methods (requires `shadows_builders` feature)
 ///
 /// # Builder Methods
@@ -76,7 +76,7 @@ pub fn shadow_root(
 /// - `ShadowNode` trait implementation (persistence support)
 /// - `Delta{Name}` struct/enum for applying partial updates
 /// - `Reported{Name}` struct/enum with serde skip_serializing_if
-/// - `ReportedUnionFields` implementation
+/// - `ReportedFields` implementation
 ///
 /// # Field Attributes
 ///
@@ -126,7 +126,7 @@ pub fn shadow_node(
 /// - `ShadowNode` trait implementation (persistence support)
 /// - `Delta{Name}` struct for applying partial updates
 /// - `Reported{Name}` struct with serde skip_serializing_if
-/// - `ReportedUnionFields` implementation
+/// - `ReportedFields` implementation
 /// - `desired()` / `reported()` builder methods (requires `shadows_builders` feature)
 ///
 /// # Attributes

--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -6,7 +6,7 @@
 //!
 //! All implementations are strictly no_std / no_alloc.
 
-use crate::shadows::{ParseError, ReportedUnionFields, ShadowNode, VariantResolver, fnv1a_hash};
+use crate::shadows::{ParseError, ReportedFields, ShadowNode, VariantResolver, fnv1a_hash};
 use serde::ser::SerializeMap;
 
 #[cfg(feature = "shadows_kv_persist")]
@@ -55,7 +55,7 @@ impl<const N: usize> ShadowNode for heapless::String<N> {
     }
 }
 
-impl<const N: usize> ReportedUnionFields for heapless::String<N> {
+impl<const N: usize> ReportedFields for heapless::String<N> {
     const FIELD_NAMES: &'static [&'static str] = &[];
 
     fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
@@ -189,7 +189,7 @@ where
     }
 }
 
-impl<T, const N: usize> ReportedUnionFields for heapless::Vec<T, N>
+impl<T, const N: usize> ReportedFields for heapless::Vec<T, N>
 where
     T: Clone + Default + serde::Serialize + serde::de::DeserializeOwned,
 {
@@ -326,7 +326,7 @@ pub struct DeltaLinearMap<K: Eq, D, const N: usize>(
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub struct ReportedLinearMap<K: Eq, R, const N: usize>(pub heapless::LinearMap<K, R, N>);
 
-impl<K: Eq + serde::Serialize, R: serde::Serialize, const N: usize> ReportedUnionFields
+impl<K: Eq + serde::Serialize, R: serde::Serialize, const N: usize> ReportedFields
     for ReportedLinearMap<K, R, N>
 {
     const FIELD_NAMES: &'static [&'static str] = &[];
@@ -828,7 +828,7 @@ macro_rules! impl_array_shadow_node {
             }
         }
 
-        impl<T> ReportedUnionFields for [T; $n]
+        impl<T> ReportedFields for [T; $n]
         where
             T: Clone + Default + serde::Serialize + serde::de::DeserializeOwned,
         {

--- a/src/shadows/impls/opaque.rs
+++ b/src/shadows/impls/opaque.rs
@@ -13,7 +13,7 @@
 //! it works transparently for both primitives and nested `ShadowNode` types,
 //! eliminating the need for `is_primitive()` checks in the derive macro.
 
-/// Implement `ShadowNode`, `ReportedUnionFields`, and (with `shadows_kv_persist`)
+/// Implement `ShadowNode`, `ReportedFields`, and (with `shadows_kv_persist`)
 /// `KVPersist` for opaque/leaf types.
 ///
 /// # Forms
@@ -78,7 +78,7 @@ macro_rules! impl_opaque {
             }
         }
 
-        impl $crate::shadows::ReportedUnionFields for $ty {
+        impl $crate::shadows::ReportedFields for $ty {
             const FIELD_NAMES: &'static [&'static str] = &[];
 
             fn serialize_into_map<S: ::serde::ser::SerializeMap>(

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -4,7 +4,7 @@
 //! - `Vec<T>` — opaque leaf type
 //! - `HashMap<K, V>` — map collection with per-entry Patch deltas
 
-use crate::shadows::{ParseError, ReportedUnionFields, ShadowNode, VariantResolver, fnv1a_hash};
+use crate::shadows::{ParseError, ReportedFields, ShadowNode, VariantResolver, fnv1a_hash};
 use serde::ser::SerializeMap;
 use std::collections::HashMap;
 use std::string::String;
@@ -53,7 +53,7 @@ impl ShadowNode for String {
     }
 }
 
-impl ReportedUnionFields for String {
+impl ReportedFields for String {
     const FIELD_NAMES: &'static [&'static str] = &[];
 
     fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
@@ -183,7 +183,7 @@ where
     }
 }
 
-impl<T> ReportedUnionFields for Vec<T>
+impl<T> ReportedFields for Vec<T>
 where
     T: Clone + Default + serde::Serialize + serde::de::DeserializeOwned,
 {
@@ -308,7 +308,7 @@ pub struct DeltaHashMap<K: Eq + Hash, D>(pub Option<HashMap<K, Patch<D>>>);
 #[serde(transparent)]
 pub struct ReportedHashMap<K: Eq + Hash, R>(pub HashMap<K, R>);
 
-impl<K: Eq + Hash + serde::Serialize, R: serde::Serialize> ReportedUnionFields
+impl<K: Eq + Hash + serde::Serialize, R: serde::Serialize> ReportedFields
     for ReportedHashMap<K, R>
 {
     const FIELD_NAMES: &'static [&'static str] = &[];

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -102,7 +102,7 @@ pub enum DeltaContent<T> {
     Value(T),
     /// Null cleanup — serializes as `{field1: null, field2: null, ...}`.
     ///
-    /// Each inner slice is a `FIELD_NAMES` from a `ReportedUnionFields` impl,
+    /// Each inner slice is a `FIELD_NAMES` from a `ReportedFields` impl,
     /// allowing multiple variants' fields to be combined.
     NullFields(&'static [&'static [&'static str]]),
 }
@@ -243,16 +243,16 @@ pub fn delta_mode_is_absent<T>(dm: &DeltaMode<T>) -> bool {
 ///
 /// ## Why Universal Implementation?
 ///
-/// All `#[shadow_node]` types generate `ReportedUnionFields` for their Reported type,
+/// All `#[shadow_node]` types generate `ReportedFields` for their Reported type,
 /// even if they're not used inside an adjacently-tagged enum. This is because at
 /// macro expansion time, we don't know if a type will later be used as an inner
 /// type of an adjacently-tagged enum.
 ///
 /// ## Supertrait: `Serialize`
 ///
-/// `ReportedUnionFields` requires `Serialize` as a supertrait. This means the
-/// `ShadowNode::Reported` bound of `ReportedUnionFields` implies `Serialize`.
-pub trait ReportedUnionFields: Serialize {
+/// `ReportedFields` requires `Serialize` as a supertrait. This means the
+/// `ShadowNode::Reported` bound of `ReportedFields` implies `Serialize`.
+pub trait ReportedFields: Serialize {
     /// Names of all fields this type contributes to the flat union.
     ///
     /// Used to null out inactive variant fields during serialization.
@@ -264,6 +264,22 @@ pub trait ReportedUnionFields: Serialize {
     /// adds fields to an existing `SerializeMap`. This enables flat union serialization
     /// where multiple types' fields are combined into a single JSON object.
     fn serialize_into_map<S: serde::ser::SerializeMap>(&self, map: &mut S) -> Result<(), S::Error>;
+
+    /// Persist `report_only(persist)` fields from this Reported struct to KV storage.
+    ///
+    /// For each `report_only(persist)` field that is `Some`, writes the value to
+    /// its KV key. Fields that are `None` are not touched.
+    ///
+    /// Default implementation is a no-op — types without `report_only(persist)`
+    /// fields don't need to persist anything.
+    #[cfg(feature = "shadows_kv_persist")]
+    fn persist_report_only<K: KVStore>(
+        &self,
+        _prefix: &str,
+        _kv: &K,
+    ) -> impl core::future::Future<Output = Result<(), KvError<K::Error>>> {
+        core::future::ready(Ok(()))
+    }
 }
 
 /// Trait for diffing Reported types in-place.
@@ -416,12 +432,12 @@ pub trait ShadowNode: Clone + Sized {
     /// Fields marked `report_only` are excluded from the state struct and only
     /// appear in this Reported type. They are `None` in partial reported.
     ///
-    /// ## Trait Bound: `ReportedUnionFields`
+    /// ## Trait Bound: `ReportedFields`
     ///
-    /// All `Reported` types must implement `ReportedUnionFields`, which provides:
+    /// All `Reported` types must implement `ReportedFields`, which provides:
     /// - `Serialize` (as a supertrait)
     /// - `serialize_into_map()` for flat union serialization
-    type Reported: ReportedUnionFields;
+    type Reported: ReportedFields;
 
     /// Compile-time hash of this type's schema structure.
     ///

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -410,6 +410,12 @@ where
     pub async fn update_reported(&self, reported: impl Into<S::Reported>) -> Result<(), Error> {
         let reported: S::Reported = reported.into();
 
+        // Persist any report_only(persist) fields to KV before sending to cloud.
+        self.store
+            .persist_reported(Self::prefix(), &reported)
+            .await
+            .map_err(|_| Error::DaoWrite)?;
+
         let response = self.update_shadow::<S::Delta>(None, Some(reported)).await?;
 
         if let Some(delta) = response.delta {

--- a/src/shadows/store/mod.rs
+++ b/src/shadows/store/mod.rs
@@ -128,6 +128,18 @@ pub trait StateStore<S: ShadowNode> {
     /// - KV stores: Returns a resolver that fetches `_variant` keys from storage
     fn resolver<'a>(&'a self, prefix: &'a str) -> impl VariantResolver + 'a;
 
+    /// Persist `report_only(persist)` fields from a Reported struct to storage.
+    ///
+    /// Called by `Shadow::update_reported()` before sending to MQTT.
+    /// Default implementation is a no-op. KV-backed stores override this.
+    async fn persist_reported(
+        &self,
+        _prefix: &str,
+        _reported: &S::Reported,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     /// Parse JSON delta, resolve variants, apply, and return the typed delta.
     ///
     /// This method:

--- a/src/shadows/store/sequential.rs
+++ b/src/shadows/store/sequential.rs
@@ -12,6 +12,7 @@ use sequential_storage::cache::{KeyCacheImpl, NoCache};
 use sequential_storage::map::{MapConfig, MapStorage};
 
 use super::{ApplyJsonError, KVStore, StateStore};
+use crate::shadows::ReportedFields;
 use crate::shadows::commit::CommitStats;
 use crate::shadows::error::KvError;
 use crate::shadows::migration::LoadResult;
@@ -458,6 +459,20 @@ impl<
             orphans_removed,
             schema_hash_updated: true,
         })
+    }
+
+    async fn persist_reported(
+        &self,
+        prefix: &str,
+        reported: &St::Reported,
+    ) -> Result<(), Self::Error> {
+        reported
+            .persist_report_only(prefix, self)
+            .await
+            .map_err(|e| match e {
+                KvError::Kv(kv_err) => kv_err,
+                _ => SequentialKVStoreError::KeyTooLong,
+            })
     }
 
     fn resolver<'a>(&'a self, prefix: &'a str) -> impl VariantResolver + 'a {


### PR DESCRIPTION
## Summary

- Rename `ReportedUnionFields` to `ReportedFields` — the trait now covers both flat union serialization and KV persistence of `report_only(persist)` fields
- Add `persist_report_only` method to `ReportedFields` trait with default no-op. The macro generates a non-default impl for types with `report_only(persist)` fields that writes `Some` values to KV
- Add `persist_reported` method to `StateStore` trait with default no-op. `SequentialKVStore` overrides it to delegate to `persist_report_only`
- `Shadow::update_reported` now calls `persist_reported` before sending to MQTT, ensuring `report_only(persist)` fields are persisted when reported

### Use case

When the firmware sets `wifi_verified = false` and reports it via `update_reported`, the value is now automatically persisted to KV storage. Previously, `report_only(persist)` fields could only be persisted through `set_state` (full state write), with no way to persist individual field updates through the reporting path.