### PR TITLE
feat: Add From impls for enum and collection Reported/Delta types

### DIFF
--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -110,6 +110,8 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
     let mut reported_variants = Vec::new(); // For ReportedPortMode
     let mut variant_names = Vec::new(); // Serde names for all variants
     let mut variant_idents = Vec::new(); // Rust idents for all variants
+    let mut reported_from_impls: Vec<TokenStream> = Vec::new();
+    let mut delta_from_impls: Vec<TokenStream> = Vec::new();
 
     // For apply_delta - mode switching
     let mut mode_switch_arms = Vec::new();
@@ -217,6 +219,22 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 delta_config_variants.push(quote! { #variant_ident(#delta_inner_ty), });
                 reported_variants.push(quote! { #variant_ident(#reported_inner_ty), });
                 desired_variants.push(quote! { #variant_ident(#delta_inner_ty), });
+
+                // From impls for #[builder(into)] support
+                reported_from_impls.push(quote! {
+                    impl From<#reported_inner_ty> for #reported_name {
+                        fn from(inner: #reported_inner_ty) -> Self {
+                            Self::#variant_ident(inner)
+                        }
+                    }
+                });
+                delta_from_impls.push(quote! {
+                    impl From<#delta_inner_ty> for #delta_config_name {
+                        fn from(inner: #delta_inner_ty) -> Self {
+                            Self::#variant_ident(inner)
+                        }
+                    }
+                });
                 from_desired_arms.push(quote! {
                     #desired_name::#variant_ident(config) => #delta_name {
                         mode: #krate::shadows::DeltaMode::Known(#variant_enum_name::#variant_ident),
@@ -598,6 +616,9 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 map.end()
             }
         }
+
+        #(#reported_from_impls)*
+        #(#delta_from_impls)*
     };
 
     // =========================================================================

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -129,6 +129,8 @@ pub(crate) fn generate_simple_enum_code(
     let mut into_partial_reported_arms = Vec::new();
     let mut schema_hash_code = Vec::new();
     let mut reported_diff_arms = Vec::new();
+    let mut reported_from_impls: Vec<TokenStream> = Vec::new();
+    let mut delta_from_impls: Vec<TokenStream> = Vec::new();
 
     for variant in variants {
         let variant_ident = &variant.ident;
@@ -208,6 +210,22 @@ pub(crate) fn generate_simple_enum_code(
 
                 delta_variants.push(quote! { #variant_ident(#delta_inner_ty), });
                 reported_variants.push(quote! { #variant_ident(#reported_inner_ty), });
+
+                // From impls for #[builder(into)] support
+                reported_from_impls.push(quote! {
+                    impl From<#reported_inner_ty> for #reported_name {
+                        fn from(inner: #reported_inner_ty) -> Self {
+                            Self::#variant_ident(inner)
+                        }
+                    }
+                });
+                delta_from_impls.push(quote! {
+                    impl From<#delta_inner_ty> for #delta_name {
+                        fn from(inner: #delta_inner_ty) -> Self {
+                            Self::#variant_ident(inner)
+                        }
+                    }
+                });
 
                 // apply_delta: set variant and delegate to inner
                 apply_delta_arms.push(quote! {
@@ -430,6 +448,9 @@ pub(crate) fn generate_simple_enum_code(
         }
 
         #reported_default_impl
+
+        #(#reported_from_impls)*
+        #(#delta_from_impls)*
     };
 
     // Generate variant_at_path match arms

--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -326,6 +326,20 @@ pub struct DeltaLinearMap<K: Eq, D, const N: usize>(
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 pub struct ReportedLinearMap<K: Eq, R, const N: usize>(pub heapless::LinearMap<K, R, N>);
 
+impl<K: Eq, R, const N: usize> From<heapless::LinearMap<K, R, N>> for ReportedLinearMap<K, R, N> {
+    fn from(map: heapless::LinearMap<K, R, N>) -> Self {
+        Self(map)
+    }
+}
+
+impl<K: Eq, D, const N: usize> From<heapless::LinearMap<K, Patch<D>, N>>
+    for DeltaLinearMap<K, D, N>
+{
+    fn from(map: heapless::LinearMap<K, Patch<D>, N>) -> Self {
+        Self(Some(map))
+    }
+}
+
 impl<K: Eq + serde::Serialize, R: serde::Serialize, const N: usize> ReportedFields
     for ReportedLinearMap<K, R, N>
 {

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -308,6 +308,18 @@ pub struct DeltaHashMap<K: Eq + Hash, D>(pub Option<HashMap<K, Patch<D>>>);
 #[serde(transparent)]
 pub struct ReportedHashMap<K: Eq + Hash, R>(pub HashMap<K, R>);
 
+impl<K: Eq + Hash, R> From<HashMap<K, R>> for ReportedHashMap<K, R> {
+    fn from(map: HashMap<K, R>) -> Self {
+        Self(map)
+    }
+}
+
+impl<K: Eq + Hash, D> From<HashMap<K, Patch<D>>> for DeltaHashMap<K, D> {
+    fn from(map: HashMap<K, Patch<D>>) -> Self {
+        Self(Some(map))
+    }
+}
+
 impl<K: Eq + Hash + serde::Serialize, R: serde::Serialize> ReportedFields
     for ReportedHashMap<K, R>
 {


### PR DESCRIPTION
## Summary

- Generate `From<ReportedInnerType> for ReportedEnumType` and `From<DeltaInnerType> for DeltaEnumType` for each newtype enum variant (both simple and adjacently-tagged enums)
- Add `From<LinearMap<K, R, N>> for ReportedLinearMap<K, R, N>` and `From<LinearMap<K, Patch<D>, N>> for DeltaLinearMap<K, D, N>`
- Add equivalent `From<HashMap>` impls for std types

### Motivation

Parent struct builders use `#[builder(into)]` on nested ShadowNode fields. Without `From` impls, users must manually wrap values in enum variants or collection newtypes:

```rust
// Before — manual wrapping required:
PinConfig::reported()
    .s1(ReportedPortMode::IoLink(
        IoLinkConfig::reported().device_id(42).build(),
    ))
    .build();

// After — #[builder(into)] just works:
PinConfig::reported()
    .s1(IoLinkConfig::reported().device_id(42).build())
    .build();
```

Same for collections:
```rust
// Before:
WifiConfig::reported()
    .known_networks(ReportedLinearMap(map))
    .build();

// After:
WifiConfig::reported()
    .known_networks(map)
    .build();
```

### Caveat

`From` impls are generated for all newtype variants. If two variants wrap the same inner type, this would produce conflicting impls. Currently no shadow types in the codebase have this pattern, but it should be documented or guarded against in the future.