### PR TITLE
fix: Handle new HashMap keys in into_partial_reported

### DIFF
--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -459,10 +459,16 @@ where
             for (key, patch) in patches.iter() {
                 match patch {
                     Patch::Set(inner_delta) => {
-                        // Include the entry's partial reported (after apply_delta)
                         if let Some(v) = self.get(key) {
                             let _ =
                                 reported.insert(key.clone(), v.into_partial_reported(inner_delta));
+                        } else {
+                            // New key not yet in state — use default with delta
+                            // applied, mirroring the apply_delta pattern.
+                            let mut new_val = V::default();
+                            new_val.apply_delta(inner_delta);
+                            let _ = reported
+                                .insert(key.clone(), new_val.into_partial_reported(inner_delta));
                         }
                     }
                     Patch::Unset => {

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -433,9 +433,15 @@ where
             for (key, patch) in patches.iter() {
                 match patch {
                     Patch::Set(inner_delta) => {
-                        // Include the entry's partial reported (after apply_delta)
                         if let Some(v) = self.get(key) {
                             reported.insert(key.clone(), v.into_partial_reported(inner_delta));
+                        } else {
+                            // New key not yet in state — use default with delta
+                            // applied, mirroring the apply_delta pattern.
+                            let mut new_val = V::default();
+                            new_val.apply_delta(inner_delta);
+                            reported
+                                .insert(key.clone(), new_val.into_partial_reported(inner_delta));
                         }
                     }
                     Patch::Unset => {


### PR DESCRIPTION
## Summary

- `into_partial_reported` for `HashMap`/`LinearMap` silently skipped entries where the key existed in the delta but not yet in `self`. This caused `update_desired` to omit the reported section for newly discovered map entries (e.g. a display connector appearing for the first time), leaving the cloud with a desired-only partial that creates a spurious delta.
- Mirror the `apply_delta` pattern: when the key is missing, create a `V::default()`, apply the delta, then derive its partial reported.