### PR TITLE
fix: Serialize adjacently-tagged Delta content as inner value

### DIFF
--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -399,10 +399,13 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
         // No variants with data - don't generate the config enum
         TokenStream::new()
     } else {
-        // No Deserialize - inner delta types don't have it, we use parse_delta instead
+        // No Deserialize - inner delta types don't have it, we use parse_delta instead.
+        // Untagged: the active variant is indicated by the outer `mode` field in the
+        // adjacently-tagged layout, so the content must serialize as just the inner
+        // value (not wrapped under the variant name).
         quote! {
             #[derive(Clone, ::serde::Serialize)]
-            #rename_all_attr
+            #[serde(untagged)]
             #vis enum #delta_config_name {
                 #(#delta_config_variants)*
             }

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -1179,11 +1179,8 @@ mod adjacently_tagged {
         };
 
         let json = serde_json::to_string(&delta).unwrap();
-        // Should have "mode" and "config" keys (renamed from fields)
-        assert!(json.contains("\"mode\""));
-        assert!(json.contains("\"config\""));
-        assert!(json.contains("\"sio\"")); // lowercase due to rename_all
-        assert!(json.contains("\"polarity\""));
+        // Adjacently-tagged: config holds the inner data directly, not wrapped in {"sio": ...}
+        assert_eq!(json, r#"{"mode":"sio","config":{"polarity":true}}"#);
 
         // Test deserialization using parse_delta
         use crate::shadows::{NullResolver, ShadowNode};


### PR DESCRIPTION
## Summary

- `create_shadow` now serializes `state.into_delta()` via the generated Delta's derived `Serialize`. For adjacently-tagged enums this produced `{\"mode\":\"sio\",\"config\":{\"sio\":{...}}}` because the generated `Delta*Config` enum used the default externally-tagged layout — AWS expects adjacently-tagged `{\"mode\":\"sio\",\"config\":{...}}`.
- Fix: mark the generated `Delta*Config` enum `#[serde(untagged)]` so its content serializes as just the inner delta value; the variant is already conveyed by the adjacent `mode` field.
- Tightened `test_adjacently_tagged_delta_serialization` to assert the exact JSON — the prior `contains` checks silently passed for both the broken and correct output.