### PR TITLE
fix: Greengrass IPC stability and flatten KV paths

### DIFF
--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -815,7 +815,13 @@ pub(crate) fn generate_struct_code(
 
             let serde_name =
                 get_serde_rename(&field.attrs).unwrap_or_else(|| field_name.to_string());
-            let field_path = format!("/{}", serde_name);
+            // Flatten fields have no key component in KV — their entries are
+            // persisted at the parent's path (same as JSON flattening).
+            let field_path = if attrs.is_flatten() {
+                String::new()
+            } else {
+                format!("/{}", serde_name)
+            };
             let field_path_len = field_path.len();
 
             let has_migration = !attrs.migrate_from().is_empty();

--- a/src/mqtt/greengrass.rs
+++ b/src/mqtt/greengrass.rs
@@ -1,17 +1,44 @@
 //! Implementation of MQTT traits for AWS Greengrass IPC.
 //!
 //! This module provides an std/tokio-based MQTT client using `greengrass-ipc-rust`.
-//! Greengrass IPC natively supports single-topic subscriptions; multi-topic
-//! subscriptions are implemented by polling individual streams.
+//!
+//! ## Subscription pooling
+//!
+//! The Greengrass IPC protocol has a quirk: when the client terminates a
+//! subscription stream (`TERMINATE_STREAM`), the Greengrass core unsubscribes
+//! from the underlying MQTT topic at the cloud broker. If the client then
+//! immediately resubscribes to the same topic, there is a window where the
+//! topic is unsubscribed cloud-side, and any response published during that
+//! window is lost. Unlike normal MQTT, `TERMINATE_STREAM` has no protocol
+//! acknowledgment, so the client cannot wait for the unsubscribe to complete.
+//!
+//! To avoid this race, we pool IPC subscription streams per topic inside
+//! [`GreengrassClient`]. A single long-lived stream per topic is kept open,
+//! and a lightweight channel is swapped on each logical subscribe / unsubscribe
+//! from rustot's core. The IPC stream is never terminated during normal
+//! operation, so the MQTT subscription at the Greengrass core stays alive and
+//! no messages are lost between rustot subscribe cycles.
 
+use std::collections::HashMap;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, RwLock};
 use std::task::Poll;
 
 use bytes::Bytes;
-use futures::Stream;
+use tokio::sync::mpsc;
 
 use crate::mqtt::{MqttMessage, MqttSubscription, PublishOptions, QoS, ToPayload};
+
+type TopicChannel = mpsc::UnboundedSender<greengrass_ipc_rust::MqttMessage>;
+
+/// Per-topic pooled state. Shared between the forwarding task and every
+/// logical subscriber.
+struct PooledSlot {
+    /// Sender for the currently active logical subscriber. `None` when the
+    /// topic was previously subscribed and has since been unsubscribed.
+    /// Accessed synchronously (short critical sections only).
+    sender: Mutex<Option<TopicChannel>>,
+}
 
 /// Wrapper around greengrass-ipc-rust client.
 ///
@@ -21,6 +48,9 @@ pub struct GreengrassClient {
     client: Arc<greengrass_ipc_rust::GreengrassCoreIPCClient>,
     /// Greengrass doesn't expose client_id directly - use thing name from env.
     client_id: String,
+    /// Pool of active IPC subscription streams keyed by topic.
+    /// Uses std RwLock — no lock is held across await points.
+    pool: Arc<RwLock<HashMap<String, Arc<PooledSlot>>>>,
 }
 
 impl GreengrassClient {
@@ -29,13 +59,9 @@ impl GreengrassClient {
     /// The client ID is retrieved from the `AWS_IOT_THING_NAME` environment variable.
     pub async fn connect() -> Result<Self, greengrass_ipc_rust::Error> {
         let client = greengrass_ipc_rust::GreengrassCoreIPCClient::connect().await?;
-        // Thing name from Greengrass environment variable
         let client_id =
             std::env::var("AWS_IOT_THING_NAME").unwrap_or_else(|_| "unknown".to_string());
-        Ok(Self {
-            client: Arc::new(client),
-            client_id,
-        })
+        Ok(Self::new(Arc::new(client), client_id))
     }
 
     /// Create a client from an existing IPC client.
@@ -44,7 +70,7 @@ impl GreengrassClient {
     pub fn from_ipc(client: Arc<greengrass_ipc_rust::GreengrassCoreIPCClient>) -> Self {
         let client_id =
             std::env::var("AWS_IOT_THING_NAME").unwrap_or_else(|_| "unknown".to_string());
-        Self { client, client_id }
+        Self::new(client, client_id)
     }
 
     /// Create a new client with a custom client ID.
@@ -52,10 +78,76 @@ impl GreengrassClient {
         client_id: impl Into<String>,
     ) -> Result<Self, greengrass_ipc_rust::Error> {
         let client = greengrass_ipc_rust::GreengrassCoreIPCClient::connect().await?;
-        Ok(Self {
-            client: Arc::new(client),
-            client_id: client_id.into(),
-        })
+        Ok(Self::new(Arc::new(client), client_id.into()))
+    }
+
+    fn new(client: Arc<greengrass_ipc_rust::GreengrassCoreIPCClient>, client_id: String) -> Self {
+        Self {
+            client,
+            client_id,
+            pool: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Ensure a long-lived IPC subscription exists for `topic` and return its
+    /// pooled slot. Spawns a forwarding task on first subscribe.
+    ///
+    /// The pool lock is never held across an await point.
+    async fn ensure_slot(
+        &self,
+        topic: &str,
+        qos: QoS,
+    ) -> Result<Arc<PooledSlot>, greengrass_ipc_rust::Error> {
+        // Fast path: already pooled.
+        if let Some(slot) = self.pool.read().unwrap().get(topic).cloned() {
+            return Ok(slot);
+        }
+
+        // Slow path: subscribe without holding the pool lock.
+        let stream = self
+            .client
+            .subscribe_to_iot_core(greengrass_ipc_rust::SubscribeToIoTCoreRequest {
+                topic_name: topic.to_string(),
+                qos: to_gg_qos(qos),
+            })
+            .await?;
+
+        let slot = Arc::new(PooledSlot {
+            sender: Mutex::new(None),
+        });
+
+        // Insert into pool. Recheck in case of race — another task might
+        // have subscribed to the same topic while we were awaiting.
+        {
+            let mut pool = self.pool.write().unwrap();
+            if let Some(existing) = pool.get(topic).cloned() {
+                drop(stream);
+                return Ok(existing);
+            }
+            pool.insert(topic.to_string(), slot.clone());
+        }
+
+        // Spawn the forwarder. It reads from the IPC stream forever and
+        // forwards each message to whichever subscriber's sender is
+        // currently installed in the slot. When the stream closes (e.g.
+        // IPC connection lost) the task removes the entry so a subsequent
+        // subscribe reopens the stream.
+        let slot_for_task = slot.clone();
+        let pool_for_task = self.pool.clone();
+        let topic_for_task = topic.to_string();
+        tokio::spawn(async move {
+            use futures::StreamExt;
+            let mut stream = stream;
+            while let Some(msg) = stream.next().await {
+                let sender = { slot_for_task.sender.lock().unwrap().clone() };
+                if let Some(tx) = sender {
+                    let _ = tx.send(msg.message);
+                }
+            }
+            pool_for_task.write().unwrap().remove(&topic_for_task);
+        });
+
+        Ok(slot)
     }
 }
 
@@ -96,7 +188,6 @@ impl crate::mqtt::MqttClient for GreengrassClient {
                 topic_name: topic,
                 qos: to_gg_qos(options.qos),
                 payload: Bytes::from(buf),
-                // MQTTv5 properties (could be extended)
                 user_properties: None,
                 message_expiry_interval_seconds: None,
                 correlation_data: None,
@@ -113,48 +204,48 @@ impl crate::mqtt::MqttClient for GreengrassClient {
         &self,
         topics: &[(&str, QoS); N],
     ) -> impl core::future::Future<Output = Result<Self::Subscription<'_, N>, Self::Error>> {
-        let client = self.client.clone();
-        let topics_owned: [(&str, QoS); N] = *topics;
+        let topics_owned: [(String, QoS); N] = topics.map(|(t, q)| (t.to_string(), q));
         async move {
-            let mut streams = Vec::with_capacity(N);
+            let mut receivers = Vec::with_capacity(N);
             for (topic, qos) in &topics_owned {
-                let stream = client
-                    .subscribe_to_iot_core(greengrass_ipc_rust::SubscribeToIoTCoreRequest {
-                        topic_name: topic.to_string(),
-                        qos: to_gg_qos(*qos),
-                    })
-                    .await?;
-                streams.push(stream);
+                let slot = self.ensure_slot(topic, *qos).await?;
+                let (tx, rx) = mpsc::unbounded_channel();
+                // Swap in the new sender. Any previous sender is dropped —
+                // its receiver (held by the previous subscriber) sees the
+                // channel close but keeps whatever is still buffered.
+                *slot.sender.lock().unwrap() = Some(tx.clone());
+                receivers.push(SubscriptionReceiver { slot, tx, rx });
             }
-
-            Ok(GreengrassSubscription { streams })
+            Ok(GreengrassSubscription { receivers })
         }
     }
 }
 
+/// One logical-subscriber handle: a reference to the pooled slot plus the
+/// receiver half of the channel currently installed in that slot. Holds a
+/// clone of its own sender for identity checks on teardown.
+struct SubscriptionReceiver {
+    slot: Arc<PooledSlot>,
+    tx: TopicChannel,
+    rx: mpsc::UnboundedReceiver<greengrass_ipc_rust::MqttMessage>,
+}
+
 /// Subscription wrapper for Greengrass.
 ///
-/// Holds the underlying IPC stream operations. Call [`close()`](Self::close)
-/// to deterministically terminate all streams before dropping. If `close()` is
-/// not called, `Drop` on each [`StreamOperation`] performs best-effort cleanup
-/// via fire-and-forget async tasks.
+/// Holds one receiver per subscribed topic. On drop or explicit
+/// [`close()`](Self::close) / [`unsubscribe()`](MqttSubscription::unsubscribe),
+/// the receivers are dropped and the pooled slots' senders are cleared.
+/// The underlying IPC streams stay open and reusable for future subscribes.
 pub struct GreengrassSubscription {
-    streams: Vec<greengrass_ipc_rust::StreamOperation<greengrass_ipc_rust::IoTCoreMessage>>,
+    receivers: Vec<SubscriptionReceiver>,
 }
 
 impl GreengrassSubscription {
-    /// Explicitly close all underlying IPC streams, awaiting each termination.
-    ///
-    /// Mirrors [`StreamOperation::close()`] — each stream sends
-    /// `TERMINATE_STREAM` and unregisters its handler synchronously (awaited).
-    /// Because the handler is removed before `Drop` runs, the `Drop` impl on
-    /// each `StreamOperation` becomes a no-op (it cannot find the stream in
-    /// the map).
+    /// Release this subscription. Clears the pooled slots' senders so that
+    /// future messages are discarded until someone subscribes again. Does
+    /// NOT terminate the underlying IPC streams — they stay in the pool.
     pub async fn close(self) -> Result<(), greengrass_ipc_rust::Error> {
-        for stream in self.streams {
-            // Errors are non-fatal: the stream may already be closed server-side.
-            let _ = stream.close().await;
-        }
+        // Delegated to Drop.
         Ok(())
     }
 }
@@ -169,10 +260,10 @@ impl MqttSubscription for GreengrassSubscription {
     async fn next_message(&mut self) -> Option<Self::Message<'_>> {
         futures::future::poll_fn(|cx| {
             let mut all_done = true;
-            for stream in self.streams.iter_mut() {
-                match Pin::new(stream).poll_next(cx) {
+            for recv in self.receivers.iter_mut() {
+                match Pin::new(&mut recv.rx).poll_recv(cx) {
                     Poll::Ready(Some(msg)) => {
-                        return Poll::Ready(Some(GreengrassMessage { inner: msg.message }));
+                        return Poll::Ready(Some(GreengrassMessage { inner: msg }));
                     }
                     Poll::Ready(None) => continue,
                     Poll::Pending => {
@@ -191,6 +282,23 @@ impl MqttSubscription for GreengrassSubscription {
 
     async fn unsubscribe(self) -> Result<(), Self::Error> {
         self.close().await
+    }
+}
+
+impl Drop for GreengrassSubscription {
+    fn drop(&mut self) {
+        // Only clear the slot if it still holds OUR sender. If someone
+        // else has already resubscribed to the same topic, they installed
+        // a new sender and we must not clobber it. `same_channel` tells us
+        // whether two senders reference the same underlying channel.
+        for receiver in &self.receivers {
+            let mut guard = receiver.slot.sender.lock().unwrap();
+            if let Some(ref current) = *guard
+                && current.same_channel(&receiver.tx)
+            {
+                *guard = None;
+            }
+        }
     }
 }
 
@@ -236,22 +344,19 @@ impl MqttMessage for GreengrassMessage {
     }
 
     fn payload_mut(&mut self) -> &mut [u8] {
-        // Bytes requires conversion to owned Vec for mutation
-        // For now, we use make_mut which clones if shared
         self.inner.payload.to_vec().leak()
     }
 
     fn qos(&self) -> QoS {
-        // Greengrass doesn't expose QoS on received messages
-        QoS::AtLeastOnce // Default assumption
+        QoS::AtLeastOnce
     }
 
     fn dup(&self) -> bool {
-        false // Not exposed by Greengrass
+        false
     }
 
     fn retain(&self) -> bool {
-        false // Not exposed by Greengrass
+        false
     }
 }
 
@@ -259,7 +364,6 @@ impl MqttMessage for GreengrassMessage {
 fn to_gg_qos(qos: QoS) -> greengrass_ipc_rust::QoS {
     match qos {
         QoS::AtMostOnce => greengrass_ipc_rust::QoS::AtMostOnce,
-        // Greengrass only supports QoS 0 and 1
         QoS::AtLeastOnce | QoS::ExactlyOnce => greengrass_ipc_rust::QoS::AtLeastOnce,
     }
 }

--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -412,11 +412,14 @@ where
             let patch = if trimmed == "\"unset\"" || trimmed == "null" {
                 Patch::Unset
             } else {
-                // Build nested path for resolver
+                // Build nested path for resolver. Avoid leading `/` when the
+                // parent path is empty — the KV store keys don't have leading
+                // slashes, so a mismatch breaks variant resolution.
                 let mut nested_path = heapless::String::<128>::new();
                 let _ = nested_path.push_str(path);
-                let _ = nested_path.push_str("/");
-                // Use core::fmt::Write for key display
+                if !path.is_empty() {
+                    let _ = nested_path.push_str("/");
+                }
                 use core::fmt::Write;
                 let _ = write!(nested_path, "{}", &key);
 

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -389,8 +389,14 @@ where
             let patch = if trimmed == "\"unset\"" || trimmed == "null" {
                 Patch::Unset
             } else {
-                // Build nested path for resolver
-                let nested_path = format!("{}/{}", path, key);
+                // Build nested path for resolver. Avoid leading `/` when the
+                // parent path is empty — the KV store keys don't have leading
+                // slashes, so a mismatch breaks variant resolution.
+                let nested_path = if path.is_empty() {
+                    format!("{}", key)
+                } else {
+                    format!("{}/{}", path, key)
+                };
 
                 let delta = V::parse_delta(value_bytes, &nested_path, resolver).await?;
                 Patch::Set(delta)


### PR DESCRIPTION
## Summary

Three interrelated fixes uncovered while building a shadow-driven application on Greengrass with nested adjacently-tagged enums inside a flattened \`HashMap\` field.

### Subscription pooling in \`GreengrassClient\` (\`src/mqtt/greengrass.rs\`)

The Greengrass IPC protocol has a quirk: when the client sends \`TERMINATE_STREAM\`, the Greengrass core unsubscribes the underlying MQTT topic at the cloud. A subsequent resubscribe races with this — the cloud may publish a response while the topic is briefly unsubscribed, and that response is lost. Unlike normal MQTT, \`TERMINATE_STREAM\` has no acknowledgment, so the client can't wait for the unsubscribe to complete.

Fix: pool IPC subscription streams per topic inside \`GreengrassClient\`. A single long-lived stream per topic stays open; a channel is swapped on each logical subscribe/unsubscribe. The IPC stream is never terminated during normal operation, so the MQTT subscription at the core stays alive and no messages are lost.

### Flatten fields and KV paths (\`rustot_derive/src/codegen/struct_codegen.rs\`)

\`#[shadow_attr(flatten)]\` inlines a field's entries into the parent's JSON object. \`parse_delta\` already handled this, but \`persist_to_kv\` still appended \`/fieldname\` to the KV path, so the stored \`_variant\` key and the resolver's lookup path disagreed. Variant resolution silently failed, \`apply_delta\` did nothing, and partial updates on adjacently-tagged enums inside flattened maps became no-ops.

Fix: skip the field_path component for flatten fields in KV codegen.

### HashMap nested_path (\`src/shadows/impls/{std,heapless}_impls.rs\`)

\`HashMap::parse_delta\` was building \`format\!(\"{}/{}\", path, key)\`, which produces \`/DP-1\` when the parent path is empty. KV keys have no leading slash, so the resolver key mismatched and variant resolution silently failed.

Fix: use just \`key\` when parent path is empty.