### PR TITLE
fix: Make wait_delta cancellation-safe and align sync_shadow with it

### DIFF
--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -2,6 +2,7 @@
 
 use core::ops::DerefMut;
 
+use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
 use serde::Serialize;
 
 use crate::mqtt::{
@@ -19,6 +20,45 @@ use crate::shadows::{
 };
 
 use super::Shadow;
+
+/// Drop-guard that clears `Shadow::subscription` unless explicitly disarmed.
+///
+/// `wait_delta`'s first-call path installs the delta-topic subscription before
+/// the initial get + apply + ack has finished. If the future is cancelled in
+/// that window (e.g. by a `tokio::select!` branch firing), the subscription
+/// would be left in place and every subsequent call would silently wait for a
+/// delta message on the subscription topic — a permanent hang, because the
+/// cloud only publishes deltas when `desired` changes.
+///
+/// This guard restores the invariant `subscription == Some <=> initial sync
+/// has fully completed` by taking the subscription back on any early exit.
+/// `disarm()` is called on the happy path to keep the subscription cached.
+struct ResetSubscriptionOnDrop<'s, M: RawMutex, T> {
+    subscription: &'s Mutex<M, Option<T>>,
+    armed: bool,
+}
+
+impl<M: RawMutex, T> ResetSubscriptionOnDrop<'_, M, T> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl<M: RawMutex, T> Drop for ResetSubscriptionOnDrop<'_, M, T> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // `try_lock` is synchronous; Drop cannot await. In practice the lock
+        // is free here: any holder would have been on the cancelled future's
+        // stack and its guard is dropped before ours. If the lock is somehow
+        // contended, skipping the reset is safe — we'd merely miss the
+        // cleanup for this one cancellation, which is better than blocking.
+        if let Ok(mut guard) = self.subscription.try_lock() {
+            guard.take();
+        }
+    }
+}
 
 /// Overhead for partial request JSON formatting.
 const PARTIAL_REQUEST_OVERHEAD: usize = 64;
@@ -341,6 +381,20 @@ where
             "[{:?}] wait_delta: entry",
             S::NAME.unwrap_or(CLASSIC_SHADOW)
         );
+
+        // If this is a first call, arm a drop-guard that clears the
+        // subscription on any early exit (cancellation, error, panic). This
+        // preserves the invariant that `subscription == Some` implies the
+        // initial sync completed: without it, cancellation between
+        // `handle_delta` installing the subscription and `update_shadow`
+        // finishing the ack leaves the next caller to wait forever on a
+        // delta topic that only fires when `desired` changes cloud-side.
+        let is_first_call = self.subscription.lock().await.is_none();
+        let mut reset_guard = ResetSubscriptionOnDrop {
+            subscription: &self.subscription,
+            armed: is_first_call,
+        };
+
         let delta = self.handle_delta().await?;
 
         let state = if let Some(ref delta) = delta {
@@ -364,6 +418,7 @@ where
                 // survives MQTT reconnection (clean_start=false) and the delta
                 // is never re-delivered, causing permanent desync.
                 self.subscription.lock().await.take();
+                reset_guard.disarm();
                 return Err(e);
             }
 
@@ -375,6 +430,9 @@ where
                 .await
                 .map_err(|_| Error::DaoWrite)?
         };
+
+        // Initial sync succeeded — keep the cached subscription for the loop.
+        reset_guard.disarm();
 
         info!(
             "[{:?}] wait_delta: return has_delta={}",
@@ -485,7 +543,14 @@ where
     pub async fn sync_shadow(&self) -> Result<S, Error> {
         let delta_state = self.get_shadow_from_cloud().await?;
 
-        let state = if let Some(delta) = delta_state.delta {
+        // Prefer `desired` over `delta` to match `wait_delta`. The cloud's
+        // `delta` is a diff against its current `reported`, which may be
+        // stale or missing entirely on first boot — applying only the diff
+        // leaves local fields in an inconsistent state (e.g. a URL updated
+        // while its parent variant discriminator is unchanged), and the
+        // subsequent reported ack writes those inconsistent defaults back
+        // to the cloud. The full `desired` converges reliably in all cases.
+        let state = if let Some(delta) = delta_state.desired.or(delta_state.delta) {
             let state = self
                 .apply_and_save(&delta)
                 .await

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -1880,3 +1880,56 @@ async fn test_commit_preserves_map_entries_and_removes_orphans() {
     // Orphan removed
     assert!(!kv_has_key(&kv, "dev/old_field").await);
 }
+
+// =========================================================================
+// Cancellation safety
+// =========================================================================
+
+/// Regression test for a cancellation-safety hang in `wait_delta`.
+///
+/// The first call to `wait_delta` walks a multi-step sequence:
+///   1. subscribe to the delta topic
+///   2. cache the subscription in `Shadow::subscription`
+///   3. publish `get` and await `get/accepted`
+///   4. apply the delta locally and acknowledge via `update`
+///
+/// Previously, step 2 happened before step 3 completed. If the future was
+/// cancelled between subscribe and ack (e.g. because a sibling branch of a
+/// `tokio::select!` fired first), the subscription stayed installed but no
+/// initial sync had run. Every subsequent `wait_delta` call would then see
+/// the cached subscription and take the fast-path branch, blocking forever
+/// on a delta topic that only fires when cloud `desired` changes —
+/// permanent desync without any error signal.
+///
+/// Invariant asserted here: after a cancelled `wait_delta`, the cached
+/// subscription must be cleared so the next caller re-runs initial sync.
+#[tokio::test]
+async fn test_wait_delta_cancellation_clears_cached_subscription() {
+    use core::time::Duration;
+
+    let kv = InMemory::<SimpleConfig>::new();
+    let mqtt = MockMqttClient::new("test-client");
+    let shadow = Shadow::<SimpleConfig, _, _>::new(&kv, &mqtt);
+    shadow.load().await.unwrap();
+
+    // Sanity check: fresh shadow has no cached subscription.
+    assert!(shadow.subscription.lock().await.is_none());
+
+    // `MockSubscription::next_message` pends forever, so `wait_delta` hangs
+    // inside `get_shadow_from_cloud` after caching the subscription. Time
+    // out to simulate an outer `select!` cancelling the future.
+    let result = tokio::time::timeout(Duration::from_millis(20), shadow.wait_delta()).await;
+    assert!(
+        result.is_err(),
+        "wait_delta should have been cancelled by the timeout"
+    );
+
+    // Without the drop-guard this assertion fails: the subscription was
+    // cached by step 2 and never cleared on cancellation.
+    assert!(
+        shadow.subscription.lock().await.is_none(),
+        "subscription must be cleared after cancellation so the next \
+         wait_delta call redoes the full initial sync instead of \
+         blocking on the delta topic",
+    );
+}


### PR DESCRIPTION
## Summary

Two related correctness bugs in `Shadow`'s cloud client, surfaced by a real-world hang in a downstream `tokio::select!` loop.

### 1. \`wait_delta\` is not cancellation-safe on its first call

\`handle_delta\` installs the delta-topic subscription into \`Shadow::subscription\` *before* \`get_shadow_from_cloud\` + \`apply_and_save\` + \`update_shadow\` have run:

\`\`\`rust
let sub = self.mqtt.subscribe(&[...]).await?;
let _ = sub_ref.insert(sub);                           //  ← sticky write
let delta_state = self.get_shadow_from_cloud().await?; //  ← may yield
\`\`\`

If the future is cancelled in that window (e.g. by a sibling branch of a \`tokio::select!\` firing — the caller I traced had an \`interval.tick()\` that was immediately ready at t=0), the subscription stays cached but no initial sync happened. Every subsequent \`wait_delta\` call then sees \`sub_ref.is_some()\`, takes the fast-path branch, and blocks forever on a delta topic that only fires when \`desired\` changes cloud-side — a permanent desync with no error signal.

**Observed symptom downstream:** device processes startup, enters its event loop, logs a single \`get/accepted\` from the initial sync, then silence forever. Race-dependent: occasionally the cancellation hits *before* \`sub_ref.insert(sub)\`, the retry fires, and the same binary starts cleanly. Same code, same input, different outcome.

**Fix:** a drop-guard that clears the cached subscription on any early exit (cancel/error/panic) when this is a first call, and is disarmed once the full sequence has succeeded. Restores the invariant \`subscription == Some <=> initial sync has completed\`.

### 2. \`sync_shadow\` diverges from \`wait_delta\` on what to apply

\`sync_shadow\` applied \`delta_state.delta\` (the partial diff the cloud computes against its current \`reported\`) rather than \`desired.or(delta)\`. When local state is at defaults (first boot) and cloud \`reported\` is stale, the delta may miss fields whose parent variant discriminator hasn't changed — e.g. cloud desired is \`{mode: custom, config: {url: \"…\"}}\`, cloud reported is \`{mode: custom, config: {url: \"old\"}}\`, delta is \`{config: {url: \"…\"}}\` only. Applying it to a local state with \`mode = splash\` (default) leaves \`mode\` unchanged; the subsequent reported ack then writes \`mode: splash\` back to the cloud, corrupting the shadow.

\`wait_delta\` already does \`desired.or(delta)\` at \`cloud.rs:79\`. This aligns \`sync_shadow\` so the two entry points converge reliably.

## Regression test

\`test_wait_delta_cancellation_clears_cached_subscription\` forces \`wait_delta\` to pend inside \`get_shadow_from_cloud\` via the mock MQTT client (whose subscription \`next_message\` is \`future::pending\`), cancels it with \`tokio::time::timeout\`, and asserts \`Shadow::subscription\` is \`None\` afterwards.

Verified the test fails without the drop-guard armed (sanity-checked by temporarily forcing \`armed: false\` — the assertion fires).

All existing tests pass: 157 lib tests, including all 121 \`shadows::*\` tests.