### PR TITLE
feat: AWS IoT Commands module + README overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,9 @@ rumqttc = { version = "0.24", features = ["use-native-tls"] }
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
+aws-sdk-iotjobsdataplane = "1"
+minicbor = "0.25"
+minicbor-serde = "0.3"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ default = [
     "transfer_mqtt",
     "metric_cbor",
     "provision_cbor",
+    "commands_cbor",
     "shadows_kv_persist",
     "mqtt_mqttrust",
 ]
@@ -126,6 +127,8 @@ default = [
 metric_cbor = ["dep:minicbor", "dep:minicbor-serde"]
 
 provision_cbor = ["dep:minicbor", "dep:minicbor-serde"]
+
+commands_cbor = ["dep:minicbor", "dep:minicbor-serde"]
 
 transfer_mqtt = ["dep:minicbor", "dep:minicbor-serde"]
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,140 @@
 # Rust of Things (rustot)
 
-> A `no_std`, `no_alloc` crate for interacting with AWS IoT services on embedded devices.
+> A `no_std`, `no_alloc` crate for talking to AWS IoT services from embedded devices.
 
-This crate aims to provide a pure-Rust implementation of essential AWS IoT features for embedded systems, inspired by the Amazon FreeRTOS AWS IoT Device SDK.
+`rustot` is a pure-Rust, async-first implementation of the device-side AWS IoT
+service protocols. It is designed for resource-constrained MCUs (think
+embassy + ESP32 / nRF / STM32) but also runs unchanged on `std` targets via
+`tokio` for testing.
 
-## Features
+The crate aims for parity with the equivalent surface area of the [Amazon
+FreeRTOS AWS IoT Device SDK], spelt in idiomatic Rust.
 
-- **File Transfer & OTA Updates:** ([`transfer`] module)
-  - Download files from AWS IoT Jobs over MQTT or HTTP.
-  - Generic file transfers via `Transfer::perform`.
-  - OTA firmware updates via `Transfer::perform_ota` with self-test and image state management.
-- **Device Shadow:** ([`shadows`] module)
-  - Synchronize device state with the cloud using AWS IoT Device Shadow service.
-  - Get, update, and delete device shadows.
-- **Jobs:** ([`jobs`] module)
-  - Receive and execute jobs remotely on your devices.
-  - Track job status and report progress to AWS IoT.
-- **Device Defender:** ([`defender_metrics`] module)
-  - Implement security best practices and detect anomalies on your devices.
-- **Fleet Provisioning:** ([`provisioning`] module)
-  - Securely provision and connect devices to AWS IoT at scale.
-- **Lightweight and `no_std`:** Designed specifically for resource-constrained embedded devices.
+[Amazon FreeRTOS AWS IoT Device SDK]: https://github.com/aws/aws-iot-device-sdk-embedded-C
+
+## Supported services
+
+| Module | AWS service | Description |
+|---|---|---|
+| [`jobs`](src/jobs) | [Jobs] | Receive remote operations, report progress, drive a job state machine. |
+| [`commands`](src/commands) | [Commands] | One-shot, cloud-to-device instructions with optional progress reporting and ack handshake. |
+| [`shadows`](src/shadows) | [Device Shadow] | Synchronise reported / desired state with the cloud. Supports classic and named shadows, plus a multi-shadow manager. |
+| [`provisioning`](src/provisioning) | [Fleet Provisioning] | Provisioning by claim — exchange a bootstrap certificate for a per-device certificate. |
+| [`defender_metrics`](src/defender_metrics) | [Device Defender] | Publish device-side security metrics. |
+| [`transfer`](src/transfer) | OTA on top of Jobs | Generic file transfer (`Transfer::perform`) and OTA firmware updates (`Transfer::perform_ota`) with self-test / image-state hooks, over MQTT or HTTP. The OTA path is wire-compatible with the Amazon FreeRTOS [`afr_ota`][afr] job-document format produced by the [`CreateOTAUpdate`][create-ota] control-plane API. |
+
+[Jobs]: https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html
+[Commands]: https://docs.aws.amazon.com/iot/latest/developerguide/iot-remote-command.html
+[Device Shadow]: https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html
+[Fleet Provisioning]: https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html
+[Device Defender]: https://docs.aws.amazon.com/iot/latest/developerguide/device-defender.html
+[afr]: https://docs.aws.amazon.com/freertos/latest/userguide/ota-mqtt-protocol.html
+[create-ota]: https://docs.aws.amazon.com/iot/latest/apireference/API_CreateOTAUpdate.html
+
+## Design
+
+- **`no_std`, `no_alloc`** — every API uses `heapless`, borrowed `&str`, and
+  caller-provided buffers. No dynamic allocation in the hot path.
+- **Backend-agnostic MQTT** — service modules are written against the
+  `crate::mqtt::MqttClient` trait. Pick one backend per build:
+  - `mqtt_mqttrust`   — bare-metal / embassy
+  - `mqtt_rumqttc`    — std + tokio (testing, gateways)
+  - `mqtt_greengrass` — AWS Greengrass IPC
+- **Async, with no executor lock-in** — futures + `embassy-time` for
+  timeouts. Works with `embassy-executor`, `tokio`, or any other.
+- **Generic over user types** — services that carry a payload (Jobs job
+  documents, Commands request payloads, Shadow state) are parameterised by a
+  user `Serialize` / `Deserialize` type. Bring your own enum.
+
+## Toolchain
+
+Requires nightly Rust. The crate uses `generic_const_exprs` for compile-time
+topic-length sizing.
+
+```bash
+rustup toolchain install nightly
+rustup override set nightly  # in the project directory
+```
+
+## Cargo features
+
+### Service-level
+
+| Feature | Default | Effect |
+|---|---|---|
+| `transfer_mqtt`    | yes | Enable MQTT-based file transfer / OTA. |
+| `transfer_http`    | no  | Enable HTTP-based file transfer (no client). |
+| `transfer_http_reqwest` | no | HTTP transfer via `reqwest` (`std`-only). |
+| `metric_cbor`      | yes | Defender Metrics: CBOR payloads (else JSON). |
+| `provision_cbor`   | yes | Fleet Provisioning: CBOR payloads (else JSON). |
+| `commands_cbor`    | yes | Commands: CBOR payloads (else JSON). |
+| `shadows_kv_persist`  | yes | Field-level shadow persistence to a KV store. |
+| `sequential_storage`  | no  | Flash-backed KV store via `sequential-storage`. |
+| `shadows_builders`    | no  | Generate `bon` builder methods on shadow structs. |
+| `shadows_multi`       | no  | Runtime-named shadows with wildcard subscriptions (requires `std`). |
+
+### MQTT backend (pick exactly one)
+
+| Feature | When to use |
+|---|---|
+| `mqtt_mqttrust`   | `no_std` embedded device with a `mqttrust` client. **Default.** |
+| `mqtt_rumqttc`    | `std` host (e.g. integration tests, gateways) using `rumqttc`. |
+| `mqtt_greengrass` | Running inside an AWS Greengrass nucleus via IPC. |
+
+### Build / runtime
+
+| Feature | Effect |
+|---|---|
+| `std`     | Enable `std`-only paths (file-backed KV, tokio-based test infra). |
+| `defmt`   | Derive `defmt::Format` on public types and route logs through `defmt`. |
+| `log`     | Route logs through the `log` crate. |
+
+## Per-service usage
+
+Each service module ships its own README with workflow, topic table, and a
+worked example:
+
+- [`commands`](src/commands/README.md)
+- [`jobs`](src/jobs/README.md)
+- [`shadows`](src/shadows/README.md)
+- [`provisioning`](src/provisioning/README.md)
+- [`defender_metrics`](src/defender_metrics/README.md)
+- [`transfer`](src/transfer/README.md)
+
+Integration tests under `tests/` (`ota_mqtt.rs`, `provisioning.rs`,
+`shadows.rs`, …) double as end-to-end usage examples against real AWS IoT.
+
+## Testing
+
+Unit tests run in-tree:
+
+```bash
+cargo test --lib
+```
+
+Integration tests under `tests/` exercise real AWS IoT endpoints. They expect
+a `tests/secrets/identity.pfx` (or `claim_identity.pfx` for provisioning) and
+environment variables (`THING_NAME`, `AWS_HOSTNAME`, …); see each test's
+header for specifics.
 
 ## Contributing
 
-Contributions, suggestions, bug reports, and reviews are highly appreciated!
+Contributions, suggestions, bug reports, and reviews are highly appreciated.
 
 ## License
 
 Licensed under either of
 
 - Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  <http://opensource.org/licenses/MIT>)
 
 at your option.
 
 ### Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -1,0 +1,182 @@
+# AWS IoT Commands
+
+Cloud-to-device, one-shot remote instructions. Unlike Jobs, command executions
+have no queueing or retry semantics — the device receives a single request and
+returns a single terminal response.
+
+See the [AWS IoT Remote Commands documentation][aws-docs] for the full service
+specification.
+
+[aws-docs]: https://docs.aws.amazon.com/iot/latest/developerguide/iot-remote-command.html
+
+## Workflow
+
+1. **Subscribe** to the wildcard request topic
+   `$aws/commands/things/{ThingName}/executions/+/request/{format}`.
+2. On message: **parse** the `executionId` from the topic and deserialize the
+   payload into your own `Deserialize` type.
+3. (optional) Publish `IN_PROGRESS` updates to
+   `.../executions/{executionId}/response/{format}` for long-running work.
+4. Publish a **terminal status** (`SUCCEEDED` / `FAILED` / `REJECTED`) on the
+   same response topic, optionally with `statusReason` and `result`.
+5. (optional) Subscribe to
+   `.../response/{accepted,rejected}/{format}` for cloud confirmation.
+
+The cloud-side default execution timeout is 10 seconds, max 12 hours. Devices
+may publish a terminal status to override a cloud-issued `TIMED_OUT`.
+
+## Topic table
+
+| Direction | Purpose | Topic |
+|---|---|---|
+| Sub  | Incoming commands | `$aws/commands/things/{Thing}/executions/+/request/{format}` |
+| Pub  | Status / result   | `$aws/commands/things/{Thing}/executions/{id}/response/{format}` |
+| Sub  | Cloud accepted    | `$aws/commands/things/{Thing}/executions/{id}/response/accepted/{format}` |
+| Sub  | Cloud rejected    | `$aws/commands/things/{Thing}/executions/{id}/response/rejected/{format}` |
+
+`{format}` is `cbor` when the `commands_cbor` feature is enabled, `json`
+otherwise. The `executionId` is carried in the topic path; the payload need
+not include it.
+
+## Status values
+
+| Value | Terminal? | Notes |
+|---|---|---|
+| `IN_PROGRESS` | no | Optional progress reports during long-running work. |
+| `SUCCEEDED`   | yes | Command finished as requested. |
+| `FAILED`      | yes | Command was understood but execution failed. |
+| `REJECTED`    | yes | Command is invalid or unsupported on this device. |
+| `TIMED_OUT`   | yes (when reported by device) | Device-reported timeout; can override a cloud-issued `TIMED_OUT`. |
+
+`statusReason.reasonCode` must match `[A-Z0-9_-]+` and is at most 64 chars;
+`statusReason.reasonDescription` is at most 1024 chars.
+
+## Example
+
+```rust
+use rustot::commands::{CommandAgent, CommandResultEntry, ResultMap, parse_command_request};
+use rustot::mqtt::{Mqtt, MqttClient, MqttSubscription};
+
+// The on-the-wire payload shape is whatever your command template emits; AWS
+// does not impose one. This example uses an internally-tagged enum keyed on
+// the field name your template uses (`command` is just illustrative).
+#[derive(serde::Deserialize)]
+#[serde(tag = "command", content = "parameters")]
+enum Command<'a> {
+    Reboot,
+    SetMode { mode: &'a str },
+    GetBatteryLevel,
+}
+
+async fn run<C: MqttClient>(mqtt: Mqtt<&C>) {
+    let agent = CommandAgent::new(&mqtt);
+    let mut sub = agent.subscribe().await.unwrap();
+
+    while let Some(mut msg) = sub.next_message().await {
+        let Some(req) = parse_command_request::<Command>(&mut msg) else { continue };
+        let id = req.execution_id.as_str();
+
+        match req.payload {
+            Command::Reboot => {
+                // Long-running: tell the cloud we're working.
+                agent.report_in_progress(id, None).await.ok();
+                // ... do the reboot prep ...
+                agent.succeed::<()>(id, None).await.ok();
+            }
+
+            Command::SetMode { mode } if mode == "comfort" || mode == "eco" => {
+                agent.succeed::<()>(id, None).await.ok();
+            }
+            Command::SetMode { mode } => {
+                agent.reject(id, "UNSUPPORTED_MODE", Some(mode)).await.ok();
+            }
+
+            Command::GetBatteryLevel => {
+                let mut result = ResultMap::new();
+                result.insert("battery", CommandResultEntry::String { s: "85%" }).unwrap();
+                agent.succeed(id, Some(&result)).await.ok();
+            }
+        }
+    }
+}
+```
+
+### What the helpers publish
+
+- `report_in_progress(id, reason)` — QoS 0, fire-and-forget. Use during
+  long-running work to extend the execution past the cloud-side timeout.
+- `succeed(id, result)` / `fail(id, code, desc)` / `reject(id, code, desc)`
+  — QoS 1, publish then await `accepted` / `rejected` from the cloud with a
+  5-second timeout. Returns `CommandError::Rejected(_)` on rejection,
+  `CommandError::Timeout` if no ack arrives.
+
+## `result` field
+
+A command result is a map keyed by name; each entry carries one of:
+
+- `s`   — string
+- `b`   — boolean
+- `bin` — binary (base64 string in JSON; raw bytes in CBOR per AWS)
+
+Use [`ResultMap`] for the common case:
+
+```rust
+use rustot::commands::{CommandResultEntry, ResultMap};
+
+let mut result = ResultMap::new();
+result.insert("status",  CommandResultEntry::String { s: "ok"   }).unwrap();
+result.insert("ok",      CommandResultEntry::Bool   { b: true   }).unwrap();
+result.insert("payload", CommandResultEntry::Bin    { bin: "AAA=" }).unwrap();
+agent.succeed(execution_id, Some(&result)).await?;
+```
+
+For a fixed-shape result, define your own `Serialize` struct and pass `&value`
+to `agent.succeed(...)`.
+
+[`ResultMap`]: https://docs.rs/rustot/latest/rustot/commands/type.ResultMap.html
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `commands_cbor` | yes | Encode payloads as CBOR via `minicbor-serde`; topic suffix becomes `cbor`. Disable for JSON. |
+
+Only one format is active per build, mirroring `provision_cbor` /
+`metric_cbor`.
+
+## Limitations
+
+- **Things only.** The unregistered `$aws/commands/clients/{ClientId}/...` form
+  is not supported.
+- **`CommandResultEntry::Bin` is `&str` in both formats.** AWS encodes `bin`
+  as a base64 string in JSON but as a raw CBOR byte string. JSON callers must
+  base64-encode binary data themselves; CBOR callers who need a true byte
+  string should construct a custom `Serialize` type instead of using
+  `ResultMap`.
+- **No MQTT5 user properties.** Only the `json` and `cbor` AWS-defined topic
+  suffixes are handled; non-JSON / non-CBOR custom payloads with MQTT5
+  `content-type` user properties are out of scope.
+
+## Testing
+
+Unit tests cover topic format/parse, payload-shape regression guards
+(`Update::encode` JSON output for representative status combinations), the
+CBOR encode→decode round-trip, and `parse_command_request` happy path
+plus topic-mismatch:
+
+```bash
+cargo test --lib commands::
+cargo test --lib --no-default-features --features mqtt_mqttrust commands::
+```
+
+A live integration test against AWS IoT is not yet shipped; trigger an
+execution end-to-end with the AWS CLI:
+
+```bash
+aws iot-jobs-data start-command-execution \
+  --target-arn   arn:aws:iot:<region>:<account>:thing/<ThingName> \
+  --command-arn  arn:aws:iot:<region>:<account>:command/<CommandName> \
+  --parameters   'mode={S=comfort}'
+```
+
+and observe the device subscribe → request → response → `accepted` flow.

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -169,14 +169,28 @@ cargo test --lib commands::
 cargo test --lib --no-default-features --features mqtt_mqttrust commands::
 ```
 
-A live integration test against AWS IoT is not yet shipped; trigger an
-execution end-to-end with the AWS CLI:
+An end-to-end integration test (`tests/commands.rs`) creates a fresh Command
+resource in AWS IoT, triggers `StartCommandExecution` against the test thing,
+and asserts the cloud-side execution status reaches `SUCCEEDED`:
+
+```bash
+RUST_LOG=trace \
+  THING_NAME=MyTestThing \
+  AWS_HOSTNAME=xxxxxxxx-ats.iot.eu-west-1.amazonaws.com \
+  cargo test --test commands --features "commands_cbor,log"
+```
+
+`tests/secrets/identity.pfx` must hold a valid AWS IoT identity for the
+thing; `IDENTITY_PASSWORD` may be set if the file is password-protected. AWS
+credentials must be available in the environment with permission to assume
+the cross-account role used by the test harness.
+
+To trigger an execution by hand from outside the test harness:
 
 ```bash
 aws iot-jobs-data start-command-execution \
   --target-arn   arn:aws:iot:<region>:<account>:thing/<ThingName> \
-  --command-arn  arn:aws:iot:<region>:<account>:command/<CommandName> \
-  --parameters   'mode={S=comfort}'
+  --command-arn  arn:aws:iot:<region>:<account>:command/<CommandName>
 ```
 
 and observe the device subscribe → request → response → `accepted` flow.

--- a/src/commands/data_types.rs
+++ b/src/commands/data_types.rs
@@ -1,0 +1,118 @@
+use serde::{Deserialize, Serialize};
+
+/// AWS schema: `reasonCode` matches `[A-Z0-9_-]+` and is at most 64 characters.
+pub const MAX_REASON_CODE_LEN: usize = 64;
+/// AWS schema: `reasonDescription` is at most 1024 characters.
+pub const MAX_REASON_DESCRIPTION_LEN: usize = 1024;
+/// Maximum number of entries in a default `ResultMap`.
+pub const MAX_RESULT_ENTRIES: usize = 8;
+
+/// Status values a device may publish for a command execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CommandStatus {
+    #[serde(rename = "IN_PROGRESS")]
+    InProgress,
+    #[serde(rename = "SUCCEEDED")]
+    Succeeded,
+    #[serde(rename = "FAILED")]
+    Failed,
+    #[serde(rename = "REJECTED")]
+    Rejected,
+    #[serde(rename = "TIMED_OUT")]
+    TimedOut,
+}
+
+impl CommandStatus {
+    /// Whether this status is terminal (cloud will not accept further updates
+    /// once a terminal status is recorded).
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Succeeded | Self::Failed | Self::Rejected | Self::TimedOut
+        )
+    }
+}
+
+/// AWS schema: `{ "reasonCode": "<...>", "reasonDescription": "<...>" }`
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct StatusReason<'a> {
+    #[serde(rename = "reasonCode")]
+    pub reason_code: &'a str,
+    #[serde(rename = "reasonDescription")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason_description: Option<&'a str>,
+}
+
+/// One entry in a command execution `result` map.
+///
+/// AWS encodes the type as the field name itself: `s` (string), `b` (boolean),
+/// or `bin` (binary). With `serde(untagged)` the active variant is selected
+/// from whichever field is present.
+///
+/// **CBOR caveat (v1)**: AWS encodes `bin` as raw bytes in CBOR but as a
+/// base64 string in JSON. This v1 representation uses `&str` in both cases —
+/// for JSON the caller is responsible for base64-encoding binary data. For
+/// CBOR, raw bytes are out of scope; if needed, deserialize the request and
+/// build a custom `Serialize` type that emits a CBOR byte string.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum CommandResultEntry<'a> {
+    String { s: &'a str },
+    Bool { b: bool },
+    Bin { bin: &'a str },
+}
+
+/// Default-sized result map type for ergonomic use.
+pub type ResultMap<'a> = heapless::LinearMap<&'a str, CommandResultEntry<'a>, MAX_RESULT_ENTRIES>;
+
+/// Outbound payload sent to
+/// `$aws/commands/things/{thing}/executions/{id}/response/{format}`.
+#[derive(Debug, PartialEq, Serialize)]
+pub struct UpdateCommandExecutionRequest<'a, R: Serialize = ()> {
+    /// Optional. The execution id is already encoded in the topic; AWS allows
+    /// echoing it in the body.
+    #[serde(rename = "executionId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_id: Option<&'a str>,
+
+    pub status: CommandStatus,
+
+    #[serde(rename = "statusReason")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_reason: Option<StatusReason<'a>>,
+
+    /// Caller-supplied result. Generic so users may provide a `ResultMap<'a>`,
+    /// a custom struct, or any value that matches AWS's `result` schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<&'a R>,
+}
+
+/// A parsed inbound command request.
+///
+/// `execution_id` is owned (`heapless::String`) to release the topic-name
+/// borrow before the payload is decoded — this disambiguates the immutable
+/// borrow of [`MqttMessage::topic_name`] from the mutable borrow of
+/// [`MqttMessage::payload_mut`] used by the JSON deserializer.
+///
+/// [`MqttMessage::topic_name`]: crate::mqtt::MqttMessage::topic_name
+/// [`MqttMessage::payload_mut`]: crate::mqtt::MqttMessage::payload_mut
+#[derive(Debug, PartialEq)]
+pub struct CommandRequest<P> {
+    pub execution_id: heapless::String<{ super::topics::MAX_EXECUTION_ID_LEN }>,
+    pub payload: P,
+}
+
+/// Cloud rejection payload (received on `.../response/rejected/{format}`).
+#[derive(Debug, Deserialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ErrorResponse<'a> {
+    #[serde(rename = "executionId")]
+    pub execution_id: Option<&'a str>,
+    pub status: Option<&'a str>,
+    pub message: Option<&'a str>,
+    pub timestamp: Option<i64>,
+    #[serde(rename = "errorCode")]
+    pub error_code: Option<u16>,
+}

--- a/src/commands/error.rs
+++ b/src/commands/error.rs
@@ -1,0 +1,32 @@
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CommandError {
+    Overflow,
+    InvalidPayload,
+    Mqtt,
+    Timeout,
+    Encoding,
+    DeserializeJson(#[cfg_attr(feature = "defmt", defmt(Debug2Format))] serde_json_core::de::Error),
+    #[cfg(feature = "commands_cbor")]
+    DeserializeCbor,
+    Rejected(u16),
+}
+
+impl From<serde_json_core::ser::Error> for CommandError {
+    fn from(_: serde_json_core::ser::Error) -> Self {
+        Self::Overflow
+    }
+}
+
+impl From<serde_json_core::de::Error> for CommandError {
+    fn from(e: serde_json_core::de::Error) -> Self {
+        Self::DeserializeJson(e)
+    }
+}
+
+#[cfg(feature = "commands_cbor")]
+impl From<minicbor_serde::error::DecodeError> for CommandError {
+    fn from(_: minicbor_serde::error::DecodeError) -> Self {
+        Self::DeserializeCbor
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,65 @@
+//! # AWS IoT Commands (Remote Commands)
+//!
+//! Cloud-to-device, one-shot instruction service. Unlike Jobs, command
+//! executions have no queueing or retry semantics — the device receives a
+//! request and returns a single terminal response.
+//!
+//! See: <https://docs.aws.amazon.com/iot/latest/developerguide/iot-remote-command.html>
+//!
+//! ## Workflow
+//!
+//! 1. Subscribe to `$aws/commands/things/{ThingName}/executions/+/request/{format}`.
+//! 2. On message: parse `executionId` from the topic, deserialize the payload.
+//! 3. Optionally publish `IN_PROGRESS` to `.../executions/{id}/response/{format}`.
+//! 4. Publish a terminal status (`SUCCEEDED` / `FAILED` / `REJECTED`) on the
+//!    same response topic, optionally with `statusReason` and `result`.
+//! 5. Optionally subscribe to `.../response/accepted/{format}` and
+//!    `.../response/rejected/{format}` for cloud confirmation.
+//!
+//! Default cloud-side timeout is 10 seconds, max 12 hours. Devices may publish
+//! a terminal status to override a cloud-issued `TIMED_OUT`.
+//!
+//! ## Payload format
+//!
+//! With the `commands_cbor` feature enabled, payloads use CBOR; otherwise
+//! JSON. This mirrors `provision_cbor` in `crate::provisioning`. Only one
+//! format may be active per build.
+//!
+//! ## Caveats
+//!
+//! - **Binary results in CBOR**: AWS encodes the `bin` result variant as a raw
+//!   CBOR byte string, but [`CommandResultEntry::Bin`] currently exposes
+//!   `&str`. JSON callers should pass base64-encoded strings; CBOR callers who
+//!   need byte-string results should construct a custom `Serialize` type
+//!   instead of using [`ResultMap`].
+//! - The unregistered `$aws/commands/clients/{ClientId}/...` form is not
+//!   supported; this module targets registered Things only.
+
+pub mod data_types;
+pub mod error;
+pub mod stream;
+pub mod topics;
+pub mod update;
+
+pub use data_types::{
+    CommandRequest, CommandResultEntry, CommandStatus, ErrorResponse, MAX_REASON_CODE_LEN,
+    MAX_REASON_DESCRIPTION_LEN, MAX_RESULT_ENTRIES, ResultMap, StatusReason,
+    UpdateCommandExecutionRequest,
+};
+pub use error::CommandError;
+pub use stream::{CommandAgent, parse_command_request};
+pub use topics::{CommandTopic, MAX_COMMAND_TOPIC_LEN, MAX_EXECUTION_ID_LEN, Topic};
+pub use update::Update;
+
+/// AWS IoT thing-name length limit, re-exported from `crate::jobs`.
+pub use crate::jobs::MAX_THING_NAME_LEN;
+
+/// Factory mirroring `crate::jobs::Jobs`.
+pub struct Commands;
+
+impl Commands {
+    /// Start a new `UpdateCommandExecution` builder.
+    pub fn update<'a>(status: CommandStatus) -> Update<'a, ()> {
+        Update::new(status)
+    }
+}

--- a/src/commands/stream.rs
+++ b/src/commands/stream.rs
@@ -1,0 +1,306 @@
+use serde::{Deserialize, Serialize};
+
+use crate::commands::data_types::CommandRequest;
+use crate::commands::{
+    Commands,
+    data_types::CommandStatus,
+    error::CommandError,
+    topics::{CommandTopic, MAX_COMMAND_TOPIC_LEN, Topic},
+    update::Update,
+};
+use crate::mqtt::{Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
+
+/// Helper for the AWS IoT Commands subscribe / response lifecycle.
+///
+/// Mirrors `crate::jobs::stream::JobAgent`. Caller drives the message loop on
+/// the returned subscription via [`parse_command_request`]; this struct
+/// provides convenience helpers for publishing status updates.
+///
+/// # Example
+///
+/// ```ignore
+/// let agent = CommandAgent::new(&mqtt);
+/// let mut sub = agent.subscribe().await?;
+/// while let Some(mut msg) = sub.next_message().await {
+///     let Some(req) = parse_command_request::<MyCommand>(&mut msg) else { continue };
+///     match req.payload {
+///         MyCommand::Reboot => {
+///             agent.report_in_progress(req.execution_id.as_str(), None).await.ok();
+///             // ... do work ...
+///             agent.succeed::<()>(req.execution_id.as_str(), None).await?;
+///         }
+///         MyCommand::Unknown => {
+///             agent.reject(req.execution_id.as_str(), "UNKNOWN", None).await?;
+///         }
+///     }
+/// }
+/// ```
+pub struct CommandAgent<'a, C: MqttClient> {
+    mqtt: &'a Mqtt<&'a C>,
+}
+
+impl<'a, C: MqttClient> CommandAgent<'a, C> {
+    pub fn new(mqtt: &'a Mqtt<&'a C>) -> Self {
+        Self { mqtt }
+    }
+
+    /// Subscribe to `executions/+/request/{format}` (single topic, QoS 0).
+    pub async fn subscribe(&self) -> Result<C::Subscription<'a, 1>, CommandError> {
+        let thing = self.mqtt.0.client_id();
+        let topic = CommandTopic::Subscribe.format::<MAX_COMMAND_TOPIC_LEN>(thing)?;
+        self.mqtt
+            .0
+            .subscribe(&[(topic.as_str(), QoS::AtMostOnce)])
+            .await
+            .map_err(|_| CommandError::Mqtt)
+    }
+
+    /// Fire-and-forget IN_PROGRESS report (QoS 0).
+    pub async fn report_in_progress(
+        &self,
+        execution_id: &str,
+        reason: Option<(&str, Option<&str>)>,
+    ) -> Result<(), CommandError> {
+        let mut upd: Update<'_, ()> =
+            Update::new(CommandStatus::InProgress).execution_id(execution_id);
+        if let Some((code, desc)) = reason {
+            upd = upd.status_reason(code, desc);
+        }
+        let topic = CommandTopic::Response(execution_id)
+            .format::<MAX_COMMAND_TOPIC_LEN>(self.mqtt.0.client_id())?;
+        self.mqtt
+            .0
+            .publish(&topic, upd)
+            .await
+            .map_err(|_| CommandError::Mqtt)
+    }
+
+    /// Publish `SUCCEEDED` and wait for cloud `accepted`/`rejected`.
+    pub async fn succeed<R: Serialize>(
+        &self,
+        execution_id: &str,
+        result: Option<&R>,
+    ) -> Result<(), CommandError> {
+        match result {
+            Some(r) => {
+                let upd = Commands::update(CommandStatus::Succeeded)
+                    .execution_id(execution_id)
+                    .result(r);
+                self.publish_and_wait(execution_id, upd).await
+            }
+            None => {
+                let upd: Update<'_, ()> =
+                    Commands::update(CommandStatus::Succeeded).execution_id(execution_id);
+                self.publish_and_wait(execution_id, upd).await
+            }
+        }
+    }
+
+    /// Publish `FAILED` with a `statusReason` and wait for ack.
+    pub async fn fail(
+        &self,
+        execution_id: &str,
+        reason_code: &str,
+        description: Option<&str>,
+    ) -> Result<(), CommandError> {
+        let upd: Update<'_, ()> = Commands::update(CommandStatus::Failed)
+            .execution_id(execution_id)
+            .status_reason(reason_code, description);
+        self.publish_and_wait(execution_id, upd).await
+    }
+
+    /// Publish `REJECTED` with a `statusReason` and wait for ack.
+    pub async fn reject(
+        &self,
+        execution_id: &str,
+        reason_code: &str,
+        description: Option<&str>,
+    ) -> Result<(), CommandError> {
+        let upd: Update<'_, ()> = Commands::update(CommandStatus::Rejected)
+            .execution_id(execution_id)
+            .status_reason(reason_code, description);
+        self.publish_and_wait(execution_id, upd).await
+    }
+
+    async fn publish_and_wait<R: Serialize>(
+        &self,
+        execution_id: &str,
+        payload: Update<'_, R>,
+    ) -> Result<(), CommandError> {
+        let thing = self.mqtt.0.client_id();
+        let accepted_topic =
+            CommandTopic::ResponseAccepted(execution_id).format::<MAX_COMMAND_TOPIC_LEN>(thing)?;
+        let rejected_topic =
+            CommandTopic::ResponseRejected(execution_id).format::<MAX_COMMAND_TOPIC_LEN>(thing)?;
+
+        let mut sub = self
+            .mqtt
+            .0
+            .subscribe(&[
+                (accepted_topic.as_str(), QoS::AtMostOnce),
+                (rejected_topic.as_str(), QoS::AtMostOnce),
+            ])
+            .await
+            .map_err(|_| CommandError::Mqtt)?;
+
+        let topic = CommandTopic::Response(execution_id).format::<MAX_COMMAND_TOPIC_LEN>(thing)?;
+        self.mqtt
+            .0
+            .publish_with_options(&topic, payload, PublishOptions::new().qos(QoS::AtLeastOnce))
+            .await
+            .map_err(|_| CommandError::Mqtt)?;
+
+        let result = loop {
+            let message = match embassy_time::with_timeout(
+                embassy_time::Duration::from_secs(5),
+                sub.next_message(),
+            )
+            .await
+            {
+                Ok(Some(m)) => m,
+                Ok(None) => break Err(CommandError::Mqtt),
+                Err(_) => break Err(CommandError::Timeout),
+            };
+
+            match Topic::from_str(message.topic_name()) {
+                Some(Topic::ResponseAccepted(_)) => break Ok(()),
+                Some(Topic::ResponseRejected(_)) => break Err(CommandError::Rejected(0)),
+                _ => continue,
+            }
+        };
+
+        let _ = sub.unsubscribe().await;
+        result
+    }
+}
+
+/// Parse an inbound command request from an MQTT message.
+///
+/// Returns `None` if the topic is not a command request topic for the active
+/// payload format, the executionId exceeds [`MAX_EXECUTION_ID_LEN`], or the
+/// payload fails to deserialize.
+///
+/// [`MAX_EXECUTION_ID_LEN`]: crate::commands::MAX_EXECUTION_ID_LEN
+pub fn parse_command_request<'m, P>(message: &'m mut impl MqttMessage) -> Option<CommandRequest<P>>
+where
+    P: Deserialize<'m>,
+{
+    // Step 1: extract the executionId by copy so the immutable borrow of
+    // `topic_name()` ends before we acquire `payload_mut()` (JSON path).
+    let execution_id: heapless::String<{ crate::commands::MAX_EXECUTION_ID_LEN }> = {
+        let topic = message.topic_name();
+        match Topic::from_str(topic)? {
+            Topic::Request(id) => heapless::String::try_from(id).ok()?,
+            _ => return None,
+        }
+    };
+
+    // Step 2: deserialize the payload.
+    #[cfg(feature = "commands_cbor")]
+    let payload = {
+        let mut de = minicbor_serde::Deserializer::new(message.payload());
+        P::deserialize(&mut de).ok()?
+    };
+    #[cfg(not(feature = "commands_cbor"))]
+    let payload = serde_json_core::from_slice::<P>(message.payload_mut())
+        .ok()?
+        .0;
+
+    Some(CommandRequest {
+        execution_id,
+        payload,
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::mqtt::QoS;
+
+    /// Hand-rolled `MqttMessage` for unit tests; `MockSubscription` does not
+    /// deliver messages.
+    struct TestMessage {
+        topic: heapless::String<256>,
+        payload: heapless::Vec<u8, 512>,
+    }
+    impl MqttMessage for TestMessage {
+        fn topic_name(&self) -> &str {
+            self.topic.as_str()
+        }
+        fn payload(&self) -> &[u8] {
+            self.payload.as_slice()
+        }
+        fn payload_mut(&mut self) -> &mut [u8] {
+            self.payload.as_mut_slice()
+        }
+        fn qos(&self) -> QoS {
+            QoS::AtMostOnce
+        }
+        fn dup(&self) -> bool {
+            false
+        }
+        fn retain(&self) -> bool {
+            false
+        }
+    }
+
+    #[derive(Debug, PartialEq, serde::Deserialize)]
+    #[cfg_attr(feature = "commands_cbor", derive(serde::Serialize))]
+    struct MyCmd<'a> {
+        action: &'a str,
+    }
+
+    #[cfg(not(feature = "commands_cbor"))]
+    #[test]
+    fn parse_request_json_happy_path() {
+        let mut msg = TestMessage {
+            topic: heapless::String::try_from(
+                "$aws/commands/things/myThing/executions/abc-123/request/json",
+            )
+            .unwrap(),
+            payload: heapless::Vec::from_slice(br#"{"action":"reboot"}"#).unwrap(),
+        };
+
+        let req = parse_command_request::<MyCmd<'_>>(&mut msg).expect("parse");
+        assert_eq!(req.execution_id.as_str(), "abc-123");
+        assert_eq!(req.payload, MyCmd { action: "reboot" });
+    }
+
+    #[cfg(not(feature = "commands_cbor"))]
+    #[test]
+    fn parse_request_returns_none_for_response_topic() {
+        let mut msg = TestMessage {
+            topic: heapless::String::try_from(
+                "$aws/commands/things/myThing/executions/abc/response/accepted/json",
+            )
+            .unwrap(),
+            payload: heapless::Vec::from_slice(b"{}").unwrap(),
+        };
+        // Use a unit type to avoid the borrow checker complaining about an
+        // unused borrow if parse returned Some.
+        assert!(parse_command_request::<()>(&mut msg).is_none());
+    }
+
+    #[cfg(feature = "commands_cbor")]
+    #[test]
+    fn parse_request_cbor_happy_path() {
+        // Build a CBOR map: { "action": "reboot" }
+        let mut buf = [0u8; 64];
+        let mut ser =
+            minicbor_serde::Serializer::new(minicbor::encode::write::Cursor::new(&mut buf[..]));
+        serde::Serialize::serialize(&MyCmd { action: "reboot" }, &mut ser).unwrap();
+        let len = ser.into_encoder().writer().position();
+
+        let mut msg = TestMessage {
+            topic: heapless::String::try_from(
+                "$aws/commands/things/myThing/executions/abc-123/request/cbor",
+            )
+            .unwrap(),
+            payload: heapless::Vec::from_slice(&buf[..len]).unwrap(),
+        };
+
+        let req = parse_command_request::<MyCmd<'_>>(&mut msg).expect("parse");
+        assert_eq!(req.execution_id.as_str(), "abc-123");
+        assert_eq!(req.payload.action, "reboot");
+    }
+}

--- a/src/commands/stream.rs
+++ b/src/commands/stream.rs
@@ -137,8 +137,8 @@ impl<'a, C: MqttClient> CommandAgent<'a, C> {
             .mqtt
             .0
             .subscribe(&[
-                (accepted_topic.as_str(), QoS::AtMostOnce),
-                (rejected_topic.as_str(), QoS::AtMostOnce),
+                (accepted_topic.as_str(), QoS::AtLeastOnce),
+                (rejected_topic.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| CommandError::Mqtt)?;

--- a/src/commands/topics.rs
+++ b/src/commands/topics.rs
@@ -1,0 +1,245 @@
+use core::fmt::Write;
+
+use heapless::String;
+
+use super::error::CommandError;
+use crate::jobs::MAX_THING_NAME_LEN;
+
+/// Maximum executionId length the topic parser/formatter accommodates.
+/// AWS IoT executionIds are UUIDs (36 chars); 64 leaves headroom.
+pub const MAX_EXECUTION_ID_LEN: usize = 64;
+
+/// Maximum topic length for commands MQTT operations.
+///
+/// Longest topic:
+/// `$aws/commands/things/{thing}/executions/{executionId}/response/accepted/cbor`
+pub const MAX_COMMAND_TOPIC_LEN: usize = "$aws/commands/things/".len()
+    + MAX_THING_NAME_LEN
+    + "/executions/".len()
+    + MAX_EXECUTION_ID_LEN
+    + "/response/accepted/cbor".len();
+
+#[cfg(feature = "commands_cbor")]
+pub(crate) const PAYLOAD_FORMAT: &str = "cbor";
+#[cfg(not(feature = "commands_cbor"))]
+pub(crate) const PAYLOAD_FORMAT: &str = "json";
+
+/// Outbound topic formatter — analogue of `JobTopic` in `crate::jobs`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CommandTopic<'a> {
+    /// Wildcard subscribe: `$aws/commands/things/{thing}/executions/+/request/{format}`.
+    Subscribe,
+    /// Outbound publish: `$aws/commands/things/{thing}/executions/{id}/response/{format}`.
+    Response(&'a str),
+    /// Optional ack subscribe: `.../response/accepted/{format}`.
+    ResponseAccepted(&'a str),
+    /// Optional rejection subscribe: `.../response/rejected/{format}`.
+    ResponseRejected(&'a str),
+}
+
+impl<'a> CommandTopic<'a> {
+    const PREFIX: &'static str = "$aws/commands/things";
+
+    pub fn check(s: &str) -> bool {
+        s.starts_with(Self::PREFIX)
+    }
+
+    fn format_inner(&self, thing: &str, w: &mut dyn Write) -> core::fmt::Result {
+        match self {
+            Self::Subscribe => write!(
+                w,
+                "{}/{}/executions/+/request/{}",
+                Self::PREFIX,
+                thing,
+                PAYLOAD_FORMAT
+            ),
+            Self::Response(id) => write!(
+                w,
+                "{}/{}/executions/{}/response/{}",
+                Self::PREFIX,
+                thing,
+                id,
+                PAYLOAD_FORMAT
+            ),
+            Self::ResponseAccepted(id) => write!(
+                w,
+                "{}/{}/executions/{}/response/accepted/{}",
+                Self::PREFIX,
+                thing,
+                id,
+                PAYLOAD_FORMAT
+            ),
+            Self::ResponseRejected(id) => write!(
+                w,
+                "{}/{}/executions/{}/response/rejected/{}",
+                Self::PREFIX,
+                thing,
+                id,
+                PAYLOAD_FORMAT
+            ),
+        }
+    }
+
+    pub fn format<const L: usize>(&self, thing: &str) -> Result<String<L>, CommandError> {
+        let mut s = String::new();
+        self.format_inner(thing, &mut s)
+            .map_err(|_| CommandError::Overflow)?;
+        Ok(s)
+    }
+}
+
+/// Parsed inbound topic (cloud → device). Mirrors `crate::jobs::Topic`.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Topic<'a> {
+    /// Cloud → device command request. The executionId is borrowed from the
+    /// MQTT topic path (the wire protocol does not require it in the payload).
+    Request(&'a str),
+    /// Cloud → device ack of our response publish.
+    ResponseAccepted(&'a str),
+    /// Cloud → device rejection of our response publish.
+    ResponseRejected(&'a str),
+}
+
+impl<'a> Topic<'a> {
+    /// Parse a topic name, returning the variant and (where applicable) the
+    /// borrowed executionId.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &'a str) -> Option<Self> {
+        // Segments: [0]=$aws [1]=commands [2]=things [3]=<thing>
+        //           [4]=executions [5]=<executionId>
+        //           [6]=request|response [7]=<format>|accepted|rejected
+        //           [8]=<format>
+        let tt = s.splitn(9, '/').collect::<heapless::Vec<&str, 9>>();
+        match (tt.first(), tt.get(1), tt.get(2), tt.get(4)) {
+            (Some(&"$aws"), Some(&"commands"), Some(&"things"), Some(&"executions")) => {
+                let id = *tt.get(5)?;
+                if id.is_empty() {
+                    return None;
+                }
+                match (tt.get(6), tt.get(7), tt.get(8)) {
+                    (Some(&"request"), Some(fmt), None) if *fmt == PAYLOAD_FORMAT => {
+                        Some(Topic::Request(id))
+                    }
+                    (Some(&"response"), Some(&"accepted"), Some(fmt)) if *fmt == PAYLOAD_FORMAT => {
+                        Some(Topic::ResponseAccepted(id))
+                    }
+                    (Some(&"response"), Some(&"rejected"), Some(fmt)) if *fmt == PAYLOAD_FORMAT => {
+                        Some(Topic::ResponseRejected(id))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn format_subscribe() {
+        let topic = CommandTopic::Subscribe
+            .format::<MAX_COMMAND_TOPIC_LEN>("myThing")
+            .unwrap();
+        let expected = if cfg!(feature = "commands_cbor") {
+            "$aws/commands/things/myThing/executions/+/request/cbor"
+        } else {
+            "$aws/commands/things/myThing/executions/+/request/json"
+        };
+        assert_eq!(topic.as_str(), expected);
+    }
+
+    #[test]
+    fn format_response() {
+        let topic = CommandTopic::Response("abc-123")
+            .format::<MAX_COMMAND_TOPIC_LEN>("myThing")
+            .unwrap();
+        let expected = if cfg!(feature = "commands_cbor") {
+            "$aws/commands/things/myThing/executions/abc-123/response/cbor"
+        } else {
+            "$aws/commands/things/myThing/executions/abc-123/response/json"
+        };
+        assert_eq!(topic.as_str(), expected);
+    }
+
+    #[test]
+    fn format_response_accepted_and_rejected() {
+        let accepted = CommandTopic::ResponseAccepted("abc-123")
+            .format::<MAX_COMMAND_TOPIC_LEN>("myThing")
+            .unwrap();
+        let rejected = CommandTopic::ResponseRejected("abc-123")
+            .format::<MAX_COMMAND_TOPIC_LEN>("myThing")
+            .unwrap();
+        let suffix = if cfg!(feature = "commands_cbor") {
+            "cbor"
+        } else {
+            "json"
+        };
+        assert_eq!(
+            accepted.as_str(),
+            format!("$aws/commands/things/myThing/executions/abc-123/response/accepted/{suffix}")
+        );
+        assert_eq!(
+            rejected.as_str(),
+            format!("$aws/commands/things/myThing/executions/abc-123/response/rejected/{suffix}")
+        );
+    }
+
+    #[test]
+    fn from_str_request() {
+        let suffix = if cfg!(feature = "commands_cbor") {
+            "cbor"
+        } else {
+            "json"
+        };
+        let s = format!("$aws/commands/things/myThing/executions/abc-123/request/{suffix}");
+        assert_eq!(Topic::from_str(&s), Some(Topic::Request("abc-123")));
+    }
+
+    #[test]
+    fn from_str_response_accepted_and_rejected() {
+        let suffix = if cfg!(feature = "commands_cbor") {
+            "cbor"
+        } else {
+            "json"
+        };
+        let acc =
+            format!("$aws/commands/things/myThing/executions/abc-123/response/accepted/{suffix}");
+        let rej =
+            format!("$aws/commands/things/myThing/executions/abc-123/response/rejected/{suffix}");
+        assert_eq!(
+            Topic::from_str(&acc),
+            Some(Topic::ResponseAccepted("abc-123"))
+        );
+        assert_eq!(
+            Topic::from_str(&rej),
+            Some(Topic::ResponseRejected("abc-123"))
+        );
+    }
+
+    #[test]
+    fn from_str_rejects_invalid() {
+        // Wrong prefix
+        assert!(Topic::from_str("$aws/things/myThing/jobs/abc/get").is_none());
+        // Wrong format suffix (json when cbor enabled, or vice versa)
+        let wrong_fmt = if cfg!(feature = "commands_cbor") {
+            "$aws/commands/things/myThing/executions/abc/request/json"
+        } else {
+            "$aws/commands/things/myThing/executions/abc/request/cbor"
+        };
+        assert!(Topic::from_str(wrong_fmt).is_none());
+        // Empty executionId
+        let suffix = if cfg!(feature = "commands_cbor") {
+            "cbor"
+        } else {
+            "json"
+        };
+        let empty_id = format!("$aws/commands/things/myThing/executions//request/{suffix}");
+        assert!(Topic::from_str(&empty_id).is_none());
+        // Garbage
+        assert!(Topic::from_str("nonsense/topic").is_none());
+    }
+}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,0 +1,189 @@
+use serde::Serialize;
+
+use crate::commands::data_types::{
+    CommandStatus, MAX_REASON_CODE_LEN, MAX_REASON_DESCRIPTION_LEN, StatusReason,
+    UpdateCommandExecutionRequest,
+};
+use crate::mqtt::{PayloadError, ToPayload};
+
+/// Type-state builder for an `UpdateCommandExecution` payload.
+///
+/// The generic `R` is the type of the optional `result` field — it evolves on
+/// `result(...)` to accept any user-provided `Serialize` type, mirroring
+/// `crate::jobs::update::Update<'a, S>`.
+pub struct Update<'a, R: Serialize = ()> {
+    status: CommandStatus,
+    execution_id: Option<&'a str>,
+    status_reason: Option<StatusReason<'a>>,
+    result: Option<&'a R>,
+}
+
+impl<'a> Update<'a, ()> {
+    /// Create a new update with the given status.
+    pub fn new(status: CommandStatus) -> Self {
+        Self {
+            status,
+            execution_id: None,
+            status_reason: None,
+            result: None,
+        }
+    }
+}
+
+impl<'a, R: Serialize> Update<'a, R> {
+    /// Echo the executionId in the payload body. Optional — AWS already knows
+    /// the id from the topic path.
+    pub fn execution_id(mut self, id: &'a str) -> Self {
+        self.execution_id = Some(id);
+        self
+    }
+
+    /// Set the `statusReason` field.
+    ///
+    /// AWS limits: `code` ≤ 64 chars matching `[A-Z0-9_-]+`; `description` ≤ 1024 chars.
+    pub fn status_reason(mut self, code: &'a str, description: Option<&'a str>) -> Self {
+        debug_assert!(code.len() <= MAX_REASON_CODE_LEN);
+        debug_assert!(description.map(|d| d.len()).unwrap_or(0) <= MAX_REASON_DESCRIPTION_LEN);
+        self.status_reason = Some(StatusReason {
+            reason_code: code,
+            reason_description: description,
+        });
+        self
+    }
+
+    /// Attach a `result`. Type-state: the returned builder's `R` becomes `T`.
+    pub fn result<T: Serialize>(self, result: &'a T) -> Update<'a, T> {
+        Update {
+            status: self.status,
+            execution_id: self.execution_id,
+            status_reason: self.status_reason,
+            result: Some(result),
+        }
+    }
+}
+
+impl<R: Serialize> ToPayload for Update<'_, R> {
+    fn max_size(&self) -> usize {
+        // Upper bound: executionId (64) + statusReason (1024 + 64 + framing)
+        // + status enum + result allocator. Caller pays only what they use.
+        2048
+    }
+
+    fn encode(&self, buf: &mut [u8]) -> Result<usize, PayloadError> {
+        let req = UpdateCommandExecutionRequest {
+            execution_id: self.execution_id,
+            status: self.status,
+            status_reason: self.status_reason.clone(),
+            result: self.result,
+        };
+
+        #[cfg(feature = "commands_cbor")]
+        {
+            let mut serializer =
+                minicbor_serde::Serializer::new(minicbor::encode::write::Cursor::new(&mut *buf));
+            req.serialize(&mut serializer)
+                .map_err(|_| PayloadError::EncodingFailed)?;
+            Ok(serializer.into_encoder().writer().position())
+        }
+
+        #[cfg(not(feature = "commands_cbor"))]
+        {
+            serde_json_core::to_slice(&req, buf).map_err(|_| PayloadError::BufferSize)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[cfg(not(feature = "commands_cbor"))]
+    use crate::commands::data_types::{CommandResultEntry, ResultMap};
+
+    #[cfg(not(feature = "commands_cbor"))]
+    fn encode<R: Serialize>(u: &Update<'_, R>) -> heapless::String<2048> {
+        let mut buf = [0u8; 2048];
+        let len = u.encode(&mut buf).unwrap();
+        let s = core::str::from_utf8(&buf[..len]).unwrap();
+        heapless::String::try_from(s).unwrap()
+    }
+
+    #[cfg(not(feature = "commands_cbor"))]
+    #[test]
+    fn json_in_progress_minimal() {
+        let upd: Update<'_, ()> = Update::new(CommandStatus::InProgress).execution_id("e1");
+        let s = encode(&upd);
+        assert_eq!(s.as_str(), r#"{"executionId":"e1","status":"IN_PROGRESS"}"#);
+    }
+
+    #[cfg(not(feature = "commands_cbor"))]
+    #[test]
+    fn json_failed_with_status_reason() {
+        let upd: Update<'_, ()> = Update::new(CommandStatus::Failed)
+            .execution_id("e1")
+            .status_reason("E_BAD", Some("car battery low"));
+        let s = encode(&upd);
+        assert_eq!(
+            s.as_str(),
+            r#"{"executionId":"e1","status":"FAILED","statusReason":{"reasonCode":"E_BAD","reasonDescription":"car battery low"}}"#
+        );
+    }
+
+    #[cfg(not(feature = "commands_cbor"))]
+    #[test]
+    fn json_succeeded_with_result_map() {
+        let mut map = ResultMap::new();
+        map.insert("out", CommandResultEntry::String { s: "ok" })
+            .unwrap();
+        let upd = Update::new(CommandStatus::Succeeded)
+            .execution_id("e1")
+            .result(&map);
+        let s = encode(&upd);
+        assert_eq!(
+            s.as_str(),
+            r#"{"executionId":"e1","status":"SUCCEEDED","result":{"out":{"s":"ok"}}}"#
+        );
+    }
+
+    #[cfg(not(feature = "commands_cbor"))]
+    #[test]
+    fn json_succeeded_with_bool_and_bin_results() {
+        let mut map = ResultMap::new();
+        map.insert("done", CommandResultEntry::Bool { b: true })
+            .unwrap();
+        map.insert("blob", CommandResultEntry::Bin { bin: "AAA=" })
+            .unwrap();
+        let upd = Update::new(CommandStatus::Succeeded).result(&map);
+        let s = encode(&upd);
+        // LinearMap preserves insertion order.
+        assert_eq!(
+            s.as_str(),
+            r#"{"status":"SUCCEEDED","result":{"done":{"b":true},"blob":{"bin":"AAA="}}}"#
+        );
+    }
+
+    #[cfg(feature = "commands_cbor")]
+    #[test]
+    fn cbor_round_trip_succeeded() {
+        use serde::Deserialize;
+
+        // Slim view used only to decode and confirm the CBOR branch produced
+        // the documented field shape. We deliberately avoid making the full
+        // `UpdateCommandExecutionRequest` `Deserialize`, since its `result`
+        // field is `Option<&R>` (a non-trivial Deserialize bound for users).
+        #[derive(Deserialize)]
+        struct DecodedRequest<'a> {
+            #[serde(rename = "executionId")]
+            execution_id: Option<&'a str>,
+            status: CommandStatus,
+        }
+
+        let upd: Update<'_, ()> = Update::new(CommandStatus::Succeeded).execution_id("e1");
+        let mut buf = [0u8; 2048];
+        let len = upd.encode(&mut buf).unwrap();
+
+        let mut de = minicbor_serde::Deserializer::new(&buf[..len]);
+        let decoded = DecodedRequest::deserialize(&mut de).unwrap();
+        assert_eq!(decoded.execution_id, Some("e1"));
+        assert_eq!(decoded.status, CommandStatus::Succeeded);
+    }
+}

--- a/src/defender_metrics/README.md
+++ b/src/defender_metrics/README.md
@@ -1,0 +1,137 @@
+# AWS IoT Device Defender (Metrics)
+
+Publish device-side security and operational metrics to AWS IoT Device
+Defender. The cloud aggregates them, applies behavior profiles, and raises
+alarms on deviation.
+
+See the [AWS IoT Device Defender documentation][aws-docs] for the full
+service specification (reserved metrics, behavior profiles, audit findings).
+This module covers the device-side **publish-metrics** flow only.
+
+[aws-docs]: https://docs.aws.amazon.com/iot/latest/developerguide/device-defender.html
+
+## Workflow
+
+1. **Build** a [`Metric`] with a [`Header`] (`report_id` + `version`),
+   optional standard [`Metrics`] (TCP/UDP listeners, network stats, TCP
+   connections), and optional `custom_metrics` of your own type.
+2. **Publish** via [`MetricHandler::publish_metric`]. The handler subscribes
+   to the `accepted` / `rejected` reply topics first, then publishes, then
+   awaits the cloud's reply.
+3. The handler returns `Ok(())` on `accepted`, or [`MetricError`] on
+   rejection or transport failure.
+
+## Topic table
+
+| Direction | Purpose | Topic |
+|---|---|---|
+| Pub | Publish report | `$aws/things/{Thing}/defender/metrics/{format}` |
+| Sub | Cloud accepted | `$aws/things/{Thing}/defender/metrics/{format}/accepted` |
+| Sub | Cloud rejected | `$aws/things/{Thing}/defender/metrics/{format}/rejected` |
+
+`{format}` is `cbor` when the `metric_cbor` feature is enabled, `json`
+otherwise.
+
+## Standard vs custom metrics
+
+[`Metrics`] carries the AWS-defined standard metrics (`listening_tcp_ports`,
+`listening_udp_ports`, `network_stats`, `tcp_connections`). Use the helpers
+in [`crate::defender_metrics::aws_types`] to build them.
+
+`custom_metrics` is generic over any `Serialize` type. The
+[`CustomMetric`] enum covers the four AWS-supported value kinds:
+
+| Variant | JSON shape | Purpose |
+|---|---|---|
+| `CustomMetric::Number(i64)` | `{"number": 1}` | Single numeric value |
+| `CustomMetric::NumberList(&[u64])` | `{"number_list": [1,2,3]}` | List of numbers |
+| `CustomMetric::StringList(&[&str])` | `{"string_list": ["a","b"]}` | List of strings |
+| `CustomMetric::IpList(&[&str])` | `{"ip_list": ["172.0.0.1"]}` | List of IPs |
+
+Each custom metric must be wrapped in a single-element array
+(`[CustomMetric; 1]`) to match the AWS schema; the [`LinearMap`] keys are the
+metric names you registered via `CreateCustomMetric`.
+
+## Example
+
+```rust
+use core::str::FromStr;
+use heapless::{LinearMap, String};
+use rustot::defender_metrics::{
+    MetricHandler,
+    data_types::{CustomMetric, Header, Metric},
+};
+
+async fn report<C: rustot::mqtt::MqttClient>(mqtt: &C) {
+    // Custom metrics keyed by the names registered with CreateCustomMetric.
+    let mut custom: LinearMap<String<32>, [CustomMetric; 1], 4> = LinearMap::new();
+    custom.insert(
+        String::from_str("Battery_Level").unwrap(),
+        [CustomMetric::Number(85)],
+    ).unwrap();
+    custom.insert(
+        String::from_str("Wifi_Signal_dBm").unwrap(),
+        [CustomMetric::Number(-62)],
+    ).unwrap();
+
+    let metric = Metric::builder()
+        .header(Header::default())          // report_id from monotonic clock, v=1.0
+        .custom_metrics(custom)
+        .build();
+
+    let handler = MetricHandler::new(mqtt);
+    handler.publish_metric(metric, 2048).await.expect("defender publish");
+}
+```
+
+The `2048` is the maximum payload size the engine is allowed to allocate on
+the stack for the encoded report — size it for the largest report you'll
+publish.
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `metric_cbor` | yes | Encode reports as CBOR via `minicbor-serde`; topic suffix becomes `cbor`. Disable for JSON. |
+
+Only one format is active per build, mirroring `provision_cbor` /
+`commands_cbor`.
+
+## Limitations
+
+- **No on-device audit support.** Device Defender audits run server-side; this
+  module only handles the metrics-publish topic.
+- **`Header.report_id` defaults to the monotonic `embassy_time::Instant`**
+  rather than wall-clock epoch milliseconds. Override
+  `Header { report_id, version }` if you have an RTC and want true epoch ids.
+
+## Testing
+
+Unit tests cover JSON / CBOR serialization for each `CustomMetric` variant
+and the `Version` text format:
+
+```bash
+cargo test --lib defender_metrics::
+```
+
+The integration test (`tests/metric.rs`) publishes a representative custom
+report against a real AWS IoT endpoint and asserts an `accepted` reply:
+
+```bash
+RUST_LOG=trace \
+  THING_NAME=MyTestThing \
+  AWS_HOSTNAME=xxxxxxxx-ats.iot.eu-west-1.amazonaws.com \
+  cargo test --test metric --features "metric_cbor,log"
+```
+
+`tests/secrets/identity.pfx` must hold a valid AWS IoT identity for the
+thing; `IDENTITY_PASSWORD` may be set if the file is password-protected.
+
+[`MetricHandler::publish_metric`]: https://docs.rs/rustot/latest/rustot/defender_metrics/struct.MetricHandler.html#method.publish_metric
+[`Metric`]: https://docs.rs/rustot/latest/rustot/defender_metrics/data_types/struct.Metric.html
+[`Metrics`]: https://docs.rs/rustot/latest/rustot/defender_metrics/data_types/struct.Metrics.html
+[`Header`]: https://docs.rs/rustot/latest/rustot/defender_metrics/data_types/struct.Header.html
+[`CustomMetric`]: https://docs.rs/rustot/latest/rustot/defender_metrics/data_types/enum.CustomMetric.html
+[`MetricError`]: https://docs.rs/rustot/latest/rustot/defender_metrics/errors/enum.MetricError.html
+[`LinearMap`]: https://docs.rs/heapless/latest/heapless/struct.LinearMap.html
+[`crate::defender_metrics::aws_types`]: https://docs.rs/rustot/latest/rustot/defender_metrics/aws_types/index.html

--- a/src/jobs/README.md
+++ b/src/jobs/README.md
@@ -1,0 +1,152 @@
+# AWS IoT Jobs
+
+Receive remote operations from the cloud, drive a job-execution state machine,
+and report progress and final status. Unlike Commands, jobs are queued, can be
+described and re-described, and survive disconnects via the cloud-side queue.
+
+See the [AWS IoT Jobs documentation][aws-docs] for the full service
+specification.
+
+[aws-docs]: https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html
+
+## Workflow
+
+1. **Subscribe** to `$aws/things/{ThingName}/jobs/notify-next` (and the
+   `$next/get/accepted` reply topic).
+2. **Describe** the next pending job by publishing on
+   `$aws/things/{ThingName}/jobs/$next/get` — the response carries the
+   `jobDocument`. [`JobAgent::subscribe`] does both in one call.
+3. **Deserialize** the job document into your own `Deserialize` type
+   (typically a tagged enum of supported job kinds) using
+   [`parse_job_message`].
+4. **Update** status via `$aws/things/{ThingName}/jobs/{jobId}/update`:
+   `IN_PROGRESS` (with optional `statusDetails` for progress), then a terminal
+   `SUCCEEDED` / `FAILED` / `REJECTED`. [`JobAgent::report_progress`],
+   [`succeed_job`], [`fail_job`], and [`reject_job`] handle this.
+5. The cloud publishes a fresh `notify-next` whenever the queue head changes,
+   so the loop re-runs with the next pending job automatically.
+
+## Topic table
+
+| Direction | Purpose | Topic |
+|---|---|---|
+| Sub  | Next-job notifications        | `$aws/things/{Thing}/jobs/notify-next` |
+| Pub  | Describe job by id            | `$aws/things/{Thing}/jobs/{jobId}/get` (or `$next/get`) |
+| Sub  | Describe response             | `$aws/things/{Thing}/jobs/{jobId}/get/accepted` / `.../rejected` |
+| Pub  | Get pending list              | `$aws/things/{Thing}/jobs/get` |
+| Pub  | Start next pending            | `$aws/things/{Thing}/jobs/start-next` |
+| Pub  | Update execution              | `$aws/things/{Thing}/jobs/{jobId}/update` |
+| Sub  | Update response               | `$aws/things/{Thing}/jobs/{jobId}/update/accepted` / `.../rejected` |
+
+The full [`JobTopic`] enum covers every variant.
+
+## Status values
+
+| Value | Cloud-set | Device-set | Terminal |
+|---|---|---|---|
+| `QUEUED`      | yes | — | no |
+| `IN_PROGRESS` | —   | yes | no |
+| `SUCCEEDED`   | —   | yes | yes |
+| `FAILED`      | —   | yes | yes |
+| `REJECTED`    | —   | yes | yes |
+| `CANCELED`    | yes | — | yes |
+| `REMOVED`     | yes | — | yes |
+
+`statusDetails` is a free-form `LinearMap<&str, &str, 8>` ([`StatusDetails`]);
+both the device and the cloud may carry arbitrary key/value pairs across
+updates.
+
+## Example
+
+```rust
+use rustot::jobs::stream::{JobAgent, parse_job_message};
+use rustot::mqtt::{Mqtt, MqttClient, MqttSubscription};
+
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum MyJob<'a> {
+    Reboot { delay_secs: u32 },
+    Reset,
+    Custom { kind: &'a str },
+}
+
+async fn run<C: MqttClient>(mqtt: Mqtt<&C>) {
+    let agent = JobAgent::new(&mqtt);
+
+    loop {
+        let mut sub = agent.subscribe().await.unwrap();
+
+        while let Some(mut msg) = sub.next_message().await {
+            let Some(execution) = parse_job_message::<MyJob>(&mut msg) else { continue };
+            let job_id = execution.job_id;
+
+            match execution.job_document {
+                Some(MyJob::Reboot { delay_secs }) => {
+                    agent.report_progress(job_id, &("scheduled", delay_secs)).await.ok();
+                    // ... schedule reboot ...
+                    agent.succeed_job::<()>(job_id, None).await.ok();
+                }
+                Some(MyJob::Reset) => {
+                    agent.succeed_job::<()>(job_id, None).await.ok();
+                }
+                Some(MyJob::Custom { kind }) => {
+                    agent.reject_job(job_id, kind).await.ok();
+                }
+                None => {}
+            }
+        }
+
+        // Subscription closed (clean session / disconnect): re-subscribe.
+    }
+}
+```
+
+### What the helpers publish
+
+- `report_progress(job_id, &details)` — QoS 0, fire-and-forget. Sets
+  `IN_PROGRESS` and serializes `details` into `statusDetails`.
+- `succeed_job(job_id, details)` / `fail_job(...)` / `reject_job(...)` —
+  QoS 1, publish then await `update/accepted` (or `update/rejected`) from
+  the cloud with a 5-second timeout.
+
+## Cargo features
+
+The Jobs module has no dedicated feature flags — it is compiled in
+unconditionally as part of the default build, since [`transfer`] and
+[`commands`] both build on top of it.
+
+[`transfer`]: ../transfer
+[`commands`]: ../commands
+
+## Limitations
+
+- **JSON only.** Jobs payloads are JSON; CBOR is not part of the AWS Jobs
+  topic schema.
+- **One pending / running job tracked at a time** in
+  [`MAX_PENDING_JOBS`] / [`MAX_RUNNING_JOBS`]. Bump the consts if your
+  application needs to track more.
+
+## Testing
+
+Unit tests cover topic format/parse, request-payload serialization, and
+response deserialization:
+
+```bash
+cargo test --lib jobs::
+```
+
+The Jobs module is exercised end-to-end by the OTA integration test
+(`tests/ota_mqtt.rs`), which uses [`JobAgent`] + [`parse_job_message`] to
+drive a real `CreateOTAUpdate`-issued job through to completion.
+
+[`JobAgent`]: https://docs.rs/rustot/latest/rustot/jobs/stream/struct.JobAgent.html
+[`JobAgent::subscribe`]: https://docs.rs/rustot/latest/rustot/jobs/stream/struct.JobAgent.html#method.subscribe
+[`JobAgent::report_progress`]: https://docs.rs/rustot/latest/rustot/jobs/stream/struct.JobAgent.html#method.report_progress
+[`succeed_job`]: https://docs.rs/rustot/latest/rustot/jobs/stream/struct.JobAgent.html#method.succeed_job
+[`fail_job`]: https://docs.rs/rustot/latest/rustot/jobs/stream/struct.JobAgent.html#method.fail_job
+[`reject_job`]: https://docs.rs/rustot/latest/rustot/jobs/stream/struct.JobAgent.html#method.reject_job
+[`parse_job_message`]: https://docs.rs/rustot/latest/rustot/jobs/stream/fn.parse_job_message.html
+[`JobTopic`]: https://docs.rs/rustot/latest/rustot/jobs/enum.JobTopic.html
+[`StatusDetails`]: https://docs.rs/rustot/latest/rustot/jobs/type.StatusDetails.html
+[`MAX_PENDING_JOBS`]: https://docs.rs/rustot/latest/rustot/jobs/constant.MAX_PENDING_JOBS.html
+[`MAX_RUNNING_JOBS`]: https://docs.rs/rustot/latest/rustot/jobs/constant.MAX_RUNNING_JOBS.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;
 
+pub mod commands;
 pub mod defender_metrics;
 pub mod jobs;
 pub mod mqtt;

--- a/src/provisioning/README.md
+++ b/src/provisioning/README.md
@@ -1,48 +1,162 @@
-# AWS IoT Fleet Provisioner
+# AWS IoT Fleet Provisioning
 
-By using AWS IoT fleet provisioning, AWS IoT can generate and securely deliver device certificates and
-private keys to your devices when they connect to AWS IoT for the first time. AWS IoT provides client
-certificates that are signed by the Amazon Root certificate authority (CA).
-There are two ways to use fleet provisioning:
+Securely exchange a bootstrap "claim" certificate (shared across a fleet) for
+a unique per-device certificate when the device first connects. The
+per-device certificate is then used for all subsequent AWS IoT operations.
 
-- By claim (implemented by this crate)
-- By trusted user (**not** implemented by this crate)
+This module implements **provisioning by claim**. **Provisioning by trusted
+user** is out of scope.
 
-## Provisioning by claim
+See the [AWS IoT Fleet Provisioning documentation][aws-docs] for service
+architecture, IAM/policy setup, and pre-provisioning hooks.
 
-Devices can be manufactured with a provisioning claim certificate and private key (which are special
-purpose credentials) embedded in them. If these certificates are registered with AWS IoT, the service can
-exchange them for unique device certificates that the device can use for regular operations. This process
-includes the following steps:
+[aws-docs]: https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html
 
-**Before you deliver the device**
+## Cloud-side prerequisites
 
-1. Call `CreateProvisioningTemplate` to create a provisioning template. This API
-   returns a template ARN. For more information, see Device provisioning MQTT
-   API documentation.
+Done once, before devices are deployed:
 
-   You can also create a fleet provisioning template in the AWS IoT console.
+1. `CreateProvisioningTemplate` — creates a fleet-provisioning template (also
+   doable in the AWS IoT console under *Onboard → Fleet provisioning
+   templates*).
+2. Generate a claim certificate + private key.
+3. Register the claim certificate with AWS IoT and attach an IoT policy that
+   restricts the certificate to provisioning operations only.
+4. Attach the `AWSIoTThingsRegistration` managed policy to the provisioning
+   IAM role.
+5. Manufacture devices with the claim certificate + private key embedded.
 
-   - a. From the navigation pane, choose Onboard, then choose
-     Fleet provisioning templates.
-   - b. Choose Create and follow the prompts.
+`tests/provisioning_infrastructure/` contains the basic AWS infrastructure
+files (template, policy, pre-provisioning Lambda) used by the integration
+test. **Note**: the example pre-provisioning hook blindly accepts any
+request — replace it with your own validation logic in production.
 
-2. Create certificates and associated private keys to be used as provisioning claim certificates.
-3. Register these certificates with AWS IoT and associate an IoT policy that restricts the use of the
-   certificates. The following example IoT policy restricts the use of the certificate associated with this
-   policy to provisioning devices.
-4. Give the AWS IoT service permission to create or update IoT resources such as things and certificates
-   in your account when provisioning devices. Do this by attaching the AWSIoTThingsRegistration
-   managed policy to an IAM role (called the provisioning role) that trusts the AWS IoT service principal.
-5. Manufacture the device with the provisioning claim certificate securely
-   embedded in it.
+## Workflow (device side)
 
-<hr>
+1. Connect to AWS IoT MQTT using the claim certificate.
+2. Call [`FleetProvisioner::provision`] (or [`provision_csr`] /
+   [`provision_cbor`]). The function:
+   - Subscribes to the create-cert + register-thing reply topics.
+   - Publishes `CreateKeysAndCertificate` (or `CreateCertificateFromCsr`).
+   - Receives the new certificate; calls your [`CredentialHandler`] to
+     persist it.
+   - Publishes `RegisterThing` with the template name, ownership token, and
+     any user-supplied parameters.
+   - Returns the provisioned device configuration (deserialized into your
+     own `DeserializeOwned` type) on success.
+3. Reconnect with the new per-device certificate.
 
-## Example / Test
+## Topic table
 
-You can find an example of how to use this crate for provisioning in the `tests/provisioning.rs` file. This example can be run by `RUST_LOG=trace TEMPLATE_NAME="provision_template_name" THING_NAME="MyTestThing" AWS_HOSTNAME=xxxxxxxx-ats.iot.eu-west-1.amazonaws.com cargo test --test 'provisioning' --features "ota_mqtt_data,log"`, assuming you have an `tests/secrets/claim_identity.pfx` file with the claiming credentials. If your `claim_identity.pfx` is password protected, it can be supplied by setting the `IDENTITY_PASSWORD` env variable.
+| Direction | Purpose | Topic |
+|---|---|---|
+| Pub | Create keys & certificate         | `$aws/certificates/create/{format}` |
+| Sub | CreateKeys reply                  | `$aws/certificates/create/{format}/accepted` / `.../rejected` |
+| Pub | Create certificate from CSR       | `$aws/certificates/create-from-csr/{format}` |
+| Sub | CreateFromCsr reply               | `$aws/certificates/create-from-csr/{format}/accepted` / `.../rejected` |
+| Pub | Register thing                    | `$aws/provisioning-templates/{template}/provision/{format}` |
+| Sub | RegisterThing reply               | `$aws/provisioning-templates/{template}/provision/{format}/accepted` / `.../rejected` |
 
-Basic AWS infrastructure files needed for the example/test can be found in `tests/provisioning_infrastructure`. Do note that the pre-provision lambda handler will blindly allow any request to provision.
+`{format}` is `cbor` when the `provision_cbor` feature is enabled, `json`
+otherwise. The CBOR variant uses smaller wire payloads at the cost of pulling
+in `minicbor`.
 
-pfx identity files can be created from a set of device certificate and private key using OpenSSL as: `openssl pkcs12 -export -out claim_identity.pfx -inkey private.pem.key -in certificate.pem.crt -certfile root-ca.pem`
+## Example
+
+```rust
+use rustot::provisioning::{Credentials, CredentialHandler, Error, FleetProvisioner};
+
+#[derive(Default)]
+struct Storage { /* ... */ }
+impl CredentialHandler for Storage {
+    async fn store_credentials(&mut self, c: Credentials<'_>) -> Result<(), Error> {
+        // Persist `c.certificate_pem`, `c.private_key`, `c.certificate_id`
+        // somewhere durable (flash, secure element, etc.).
+        Ok(())
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct DeviceConfig {
+    thing_name: heapless::String<128>,
+    // ... whatever your provisioning template emits ...
+}
+
+async fn provision<M: rustot::mqtt::MqttClient>(mqtt: &M) {
+    let mut storage = Storage::default();
+
+    let parameters = serde_json::json!({
+        "SerialNumber": "1234567890",
+        "DeviceLocation": "factory-7",
+    });
+
+    let cfg: Option<DeviceConfig> = FleetProvisioner::provision(
+        mqtt,
+        "MyProvisioningTemplate",
+        Some(&parameters),
+        &mut storage,
+    )
+    .await
+    .expect("provisioning");
+
+    if let Some(cfg) = cfg {
+        log::info!("Provisioned as {}", cfg.thing_name);
+    }
+}
+```
+
+For higher security, generate the private key on-device and submit a CSR via
+[`provision_csr`] — the private key never leaves the device.
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `provision_cbor` | yes | Encode payloads as CBOR via `minicbor-serde`; topic suffix becomes `cbor`. Disable for JSON. |
+
+When enabled, [`FleetProvisioner::provision_cbor`] is also available
+explicitly; otherwise only the JSON entry points compile.
+
+## Limitations
+
+- **By-claim only.** Provisioning by trusted user is not implemented.
+- **Single attempt.** No automatic retry / backoff; wrap calls if you need
+  it.
+- **No certificate rotation.** Once provisioned, the device uses the issued
+  certificate; rotation is a separate AWS feature.
+
+## Testing
+
+Unit tests cover topic format/parse and request/response serialization:
+
+```bash
+cargo test --lib provisioning::
+```
+
+The integration test (`tests/provisioning.rs`) runs against a real AWS IoT
+endpoint:
+
+```bash
+RUST_LOG=trace \
+  TEMPLATE_NAME=provision_template_name \
+  THING_NAME=MyTestThing \
+  AWS_HOSTNAME=xxxxxxxx-ats.iot.eu-west-1.amazonaws.com \
+  cargo test --test provisioning --features "provision_cbor,log"
+```
+
+`tests/secrets/claim_identity.pfx` must hold the claim certificate. If
+password-protected, supply `IDENTITY_PASSWORD`.
+
+`pfx` files can be built from a certificate + private key with:
+
+```bash
+openssl pkcs12 -export \
+  -out claim_identity.pfx \
+  -inkey private.pem.key -in certificate.pem.crt -certfile root-ca.pem
+```
+
+[`FleetProvisioner::provision`]: https://docs.rs/rustot/latest/rustot/provisioning/struct.FleetProvisioner.html#method.provision
+[`provision_csr`]: https://docs.rs/rustot/latest/rustot/provisioning/struct.FleetProvisioner.html#method.provision_csr
+[`provision_cbor`]: https://docs.rs/rustot/latest/rustot/provisioning/struct.FleetProvisioner.html#method.provision_cbor
+[`FleetProvisioner::provision_cbor`]: https://docs.rs/rustot/latest/rustot/provisioning/struct.FleetProvisioner.html#method.provision_cbor
+[`CredentialHandler`]: https://docs.rs/rustot/latest/rustot/provisioning/trait.CredentialHandler.html

--- a/src/shadows/README.md
+++ b/src/shadows/README.md
@@ -1,11 +1,187 @@
-# AWS IoT Shadows
+# AWS IoT Device Shadows
 
-<hr>
+Synchronise a device's `reported` and `desired` state with the cloud's
+authoritative shadow document. This module wraps the AWS IoT Device Shadow
+service and adds optional KV-backed persistence so a device can resume from
+its last known state across reboots.
 
-## Example / Test
+See the [AWS IoT Device Shadow documentation][aws-docs] for the service
+specification (named shadows, classic vs named, deltas).
 
-You can find an example of how to use this crate for iot shadow states in the `tests/shadows.rs` file. This example can be run by `RUST_LOG=trace THING_NAME="MyTestThing" AWS_HOSTNAME=xxxxxxxx-ats.iot.eu-west-1.amazonaws.com cargo test --test 'shadows' --features "log"`, assuming you have an `tests/secrets/identity.pfx` file with valid AWS IoT credentials. If your `identity.pfx` is password protected, it can be supplied by setting the `IDENTITY_PASSWORD` env variable.
+[aws-docs]: https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html
 
-pfx identity files can be created from a set of device certificate and private key using OpenSSL as: `openssl pkcs12 -export -out identity.pfx -inkey private.pem.key -in certificate.pem.crt -certfile root-ca.pem`
+## Workflow
 
-The example functions as a CI integration test, that is run against Factbirds integration account on every PR. This test will run through a statemachine of shadow delete, updates and gets from both device & cloud side with assertions in between.
+1. **Define your shadow type** with the `#[shadow_root]` and `#[shadow_node]`
+   attribute macros from `rustot_derive`. The macros generate a `Reported`,
+   `Desired`, and `Delta` representation, plus FNV1A hashes for
+   change-detection.
+2. **Pick a [`StateStore`]** — [`InMemory`] for ephemeral, [`FileKVStore`]
+   (std-only), [`SequentialKVStore`] (flash via `sequential-storage`), or
+   your own.
+3. **Construct a [`Shadow`]** with `Shadow::new(&store, &mqtt)`.
+4. **Drive the lifecycle**:
+   - [`load`] — repopulate from the KV store on boot.
+   - [`create_shadow`] — initialize the cloud shadow on first run.
+   - [`sync_shadow`] — pull the cloud's current state.
+   - [`wait_delta`] — block until the cloud sends a delta; apply it.
+   - [`update_reported`] — push device-side changes to the cloud.
+   - [`commit`] — flush dirty fields back to the KV store.
+
+## Topic table
+
+| Direction | Purpose | Topic |
+|---|---|---|
+| Pub | Get shadow                | `$aws/things/{Thing}/shadow/get` |
+| Sub | Get reply                 | `$aws/things/{Thing}/shadow/get/accepted` / `.../rejected` |
+| Pub | Update shadow             | `$aws/things/{Thing}/shadow/update` |
+| Sub | Update reply              | `$aws/things/{Thing}/shadow/update/accepted` / `.../rejected` |
+| Sub | Delta from cloud          | `$aws/things/{Thing}/shadow/update/delta` |
+| Sub | Documents (full)          | `$aws/things/{Thing}/shadow/update/documents` |
+| Pub | Delete shadow             | `$aws/things/{Thing}/shadow/delete` |
+| Sub | Delete reply              | `$aws/things/{Thing}/shadow/delete/accepted` / `.../rejected` |
+
+Named shadows replace `/shadow/` with `/shadow/name/{shadowName}/`.
+
+## Example
+
+```rust
+use rustot::shadows::{InMemory, Shadow};
+use rustot_derive::{shadow_node, shadow_root};
+
+#[shadow_root]
+#[derive(Default)]
+struct DeviceState {
+    network: Network,
+    sensors: Sensors,
+}
+
+#[shadow_node]
+#[derive(Default)]
+struct Network {
+    ssid: heapless::String<32>,
+    rssi_dbm: i16,
+}
+
+#[shadow_node]
+#[derive(Default)]
+struct Sensors {
+    temperature_c: f32,
+    occupied: bool,
+}
+
+async fn run<C: rustot::mqtt::MqttClient>(mqtt: &C) {
+    let store = InMemory::<DeviceState>::default();
+    let shadow = Shadow::new(&store, mqtt);
+
+    // First boot: initialize cloud-side shadow with the local default.
+    shadow.create_shadow().await.ok();
+
+    // Pull cloud state so we converge before publishing anything.
+    let _ = shadow.sync_shadow().await;
+
+    loop {
+        // Block until the cloud requests a change.
+        let (state, delta) = shadow.wait_delta().await.unwrap();
+        if let Some(delta) = delta {
+            // Apply the delta to local hardware here.
+            log::info!("delta requested: {:?}", delta);
+            shadow.update_reported(state).await.ok();
+        }
+    }
+}
+```
+
+For periodic publishing of sensor changes alongside delta handling, drive
+`wait_delta` and `update_reported` from independent tasks against the same
+`Shadow`.
+
+## KV persistence
+
+With the `shadows_kv_persist` feature, fields can be persisted individually
+(field-level dirty tracking) to any [`KVStore`]. Backing implementations:
+
+| Store | Feature | Notes |
+|---|---|---|
+| [`InMemory`] | always available | RAM only; no persistence. |
+| [`FileKVStore`] | `std` + `shadows_kv_persist` | One file per field; useful in tests / std targets. |
+| [`SequentialKVStore`] | `sequential_storage` | Flash-backed via `sequential-storage`. |
+| Bring your own | `shadows_kv_persist` | Implement [`KVStore`] for whatever you have. |
+
+[`load`] returns a [`LoadResult`] indicating how many fields were restored,
+defaulted, or migrated. [`commit`] returns [`CommitStats`] for telemetry.
+
+## Multi-shadow manager
+
+With the `shadows_multi` feature (std-only), [`crate::shadows::multi`]
+provides a manager for runtime-named shadows with wildcard subscriptions —
+useful when the device tracks an unbounded set of shadow instances (e.g. one
+per attached peripheral).
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `shadows_kv_persist`  | yes | Field-level KV persistence traits and `FileKVStore` (std). |
+| `sequential_storage`  | no  | Flash-backed `SequentialKVStore`. Implies `shadows_kv_persist`. |
+| `shadows_builders`    | no  | Generate `bon` builder methods on shadow structs (downstream must add `bon`). |
+| `shadows_multi`       | no  | Runtime-named shadows with wildcard subscriptions (`std`-only; AWS SDK). |
+
+## Limitations
+
+- **Persistent sessions recommended.** Without them, deltas published while
+  the device is offline are lost.
+- **One unnamed (classic) shadow per `Shadow` instance.** Use named shadows
+  or the `shadows_multi` manager for multiple.
+- **Field migrations are explicit.** Renaming a field requires a migration
+  hook ([`MigrationSource`]); the macros do not silently rename.
+
+## Testing
+
+Unit tests cover topic format/parse, codegen output for the derive macros,
+and KV round-trips:
+
+```bash
+cargo test --lib shadows::
+```
+
+The integration test (`tests/shadows.rs`) runs through delete / update / get
+sequences against a real AWS IoT endpoint:
+
+```bash
+RUST_LOG=trace \
+  THING_NAME=MyTestThing \
+  AWS_HOSTNAME=xxxxxxxx-ats.iot.eu-west-1.amazonaws.com \
+  cargo test --test shadows --features "log"
+```
+
+`tests/secrets/identity.pfx` must hold a valid AWS IoT identity for the
+thing; `IDENTITY_PASSWORD` may be set if the file is password-protected.
+
+`pfx` files can be built from a certificate + private key with:
+
+```bash
+openssl pkcs12 -export \
+  -out identity.pfx \
+  -inkey private.pem.key -in certificate.pem.crt -certfile root-ca.pem
+```
+
+This test runs as a CI integration test in Factbird's AWS account on every
+PR.
+
+[`Shadow`]: https://docs.rs/rustot/latest/rustot/shadows/struct.Shadow.html
+[`StateStore`]: https://docs.rs/rustot/latest/rustot/shadows/trait.StateStore.html
+[`InMemory`]: https://docs.rs/rustot/latest/rustot/shadows/struct.InMemory.html
+[`FileKVStore`]: https://docs.rs/rustot/latest/rustot/shadows/struct.FileKVStore.html
+[`SequentialKVStore`]: https://docs.rs/rustot/latest/rustot/shadows/struct.SequentialKVStore.html
+[`KVStore`]: https://docs.rs/rustot/latest/rustot/shadows/trait.KVStore.html
+[`LoadResult`]: https://docs.rs/rustot/latest/rustot/shadows/enum.LoadResult.html
+[`CommitStats`]: https://docs.rs/rustot/latest/rustot/shadows/struct.CommitStats.html
+[`MigrationSource`]: https://docs.rs/rustot/latest/rustot/shadows/trait.MigrationSource.html
+[`load`]: https://docs.rs/rustot/latest/rustot/shadows/struct.Shadow.html#method.load
+[`commit`]: https://docs.rs/rustot/latest/rustot/shadows/struct.Shadow.html#method.commit
+[`create_shadow`]: https://docs.rs/rustot/latest/rustot/shadows/struct.Shadow.html#method.create_shadow
+[`sync_shadow`]: https://docs.rs/rustot/latest/rustot/shadows/struct.Shadow.html#method.sync_shadow
+[`wait_delta`]: https://docs.rs/rustot/latest/rustot/shadows/struct.Shadow.html#method.wait_delta
+[`update_reported`]: https://docs.rs/rustot/latest/rustot/shadows/struct.Shadow.html#method.update_reported
+[`crate::shadows::multi`]: https://docs.rs/rustot/latest/rustot/shadows/multi/index.html

--- a/src/transfer/README.md
+++ b/src/transfer/README.md
@@ -1,0 +1,161 @@
+# File Transfer & OTA
+
+A file-transfer engine that downloads files described by AWS IoT Job
+documents, with bitmap-tracked block retries and progress reporting. Built on
+top of [`crate::jobs`](../jobs).
+
+Two entry points:
+
+- [`Transfer::perform`] — generic file transfer; needs only a
+  [`TransferPal`].
+- [`Transfer::perform_ota`] — OTA firmware update; needs an [`OtaPal`]
+  (which extends [`TransferPal`]) and adds self-test, image-state, and
+  reset/activation hooks.
+
+The OTA path is wire-compatible with the Amazon FreeRTOS [`afr_ota`][afr]
+job-document format produced by AWS's [`CreateOTAUpdate`][create-ota]
+control-plane API.
+
+[afr]: https://docs.aws.amazon.com/freertos/latest/userguide/ota-mqtt-protocol.html
+[create-ota]: https://docs.aws.amazon.com/iot/latest/apireference/API_CreateOTAUpdate.html
+
+## Workflow
+
+1. Receive a job document via [`crate::jobs`] and deserialize it (an
+   [`OtaJob`] for the FreeRTOS format, or your own [`JobDocument`]
+   implementation).
+2. Build a [`JobContext`] from the parsed execution.
+3. Pick a data interface (MQTT streams or HTTP pre-signed URL) — the engine
+   negotiates against the `protocols` field in the job document.
+4. Call [`Transfer::perform`] (generic) or [`Transfer::perform_ota`]
+   (firmware). The engine:
+   - drives block requests over the chosen data interface,
+   - tracks completed blocks via a [`Bitmap`] for resumption / retry,
+   - reports progress (`IN_PROGRESS` with `statusDetails`) back to Jobs,
+   - calls into your `Pal` to write blocks, finalize, abort, or activate,
+   - publishes a terminal Jobs status on completion or failure.
+5. (OTA only) After reset, the device re-enters self-test; your `OtaPal`
+   accepts or rejects the new image and reports the outcome.
+
+## Data interfaces
+
+| Interface | Cargo feature | Notes |
+|---|---|---|
+| MQTT (IoT Streams) | `transfer_mqtt` | Default. Requests blocks over `$aws/things/{thing}/streams/{stream}/get/cbor` and receives them on `.../data/cbor`. CBOR-only. |
+| HTTP (S3 presigned URL)  | `transfer_http`         | No HTTP client included. Plug your own. |
+| HTTP via `reqwest` | `transfer_http_reqwest` | `std`-only convenience implementation built on `reqwest`. |
+
+Both interfaces can coexist in one build — the engine picks whichever the job
+document advertises.
+
+## Job document formats
+
+| Format | Type | Notes |
+|---|---|---|
+| Amazon FreeRTOS `afr_ota` | [`OtaJob`] | Default for OTA. Compatible with `CreateOTAUpdate`. |
+| Custom | impl [`JobDocument`] | For non-OTA file transfers or custom OTA shapes. |
+
+The wire-format fields (`fileid`, `filesize`, `streamname`, `update_data_url`,
+`sig-sha256-ecdsa`, …) follow the `afr_ota` schema 1:1.
+
+## PAL responsibilities
+
+The platform abstraction layer (your code) handles flash / filesystem writes
+and image lifecycle. Two traits, one extending the other:
+
+- [`TransferPal`] — `create_file`, `write_block`, `close_file`, `abort`,
+  `status_details`. All that's needed for generic file transfer.
+- [`OtaPal`] — adds `set_platform_image_state`, `get_platform_image_state`,
+  `activate_new_image`, `reset_device`, plus signature verification hooks. The
+  engine drives the [`ImageState`] state machine
+  (`Unknown` → `Testing` → `Accepted` / `Rejected` / `Aborted`).
+
+OTA reasons surface through [`ImageStateReason`] and [`PalError`], with
+numeric error codes:
+
+| Range | Meaning |
+|---|---|
+| `1xxx` | PAL-level errors (signature mismatch, write failure, …) |
+| `2xxx` | Image-state reasons (newer job, version check, user abort, …) |
+
+## Example (OTA, MQTT)
+
+```rust
+use rustot::jobs::stream::{JobAgent, parse_job_message};
+use rustot::mqtt::{Mqtt, OwnedMessage};
+use rustot::transfer::{Transfer, config::Config, encoding::afr_ota::OtaJob, error::TransferError};
+
+async fn run_ota<C: rustot::mqtt::MqttClient, P: rustot::transfer::pal::OtaPal>(
+    mqtt: Mqtt<&C>,
+    pal: &mut P,
+) -> Result<(), TransferError> {
+    let agent = JobAgent::new(&mqtt);
+    let mut sub = agent.subscribe().await.map_err(|_| TransferError::Mqtt)?;
+
+    let message = sub.next_message().await.ok_or(TransferError::Mqtt)?;
+    let mut owned = OwnedMessage::<256, 4096>::from_ref(&message).unwrap();
+    drop(message);
+    sub.unsubscribe().await.ok();
+
+    let execution = parse_job_message::<OtaJob>(&mut owned)
+        .ok_or(TransferError::InvalidJobDocument)?;
+
+    let ctx = build_job_context(execution)?; // user code, see tests/common
+    let cfg = Config { block_size: 4096, ..Default::default() };
+
+    Transfer::perform_ota(&mqtt, &mqtt, &ctx, pal, &cfg).await
+}
+```
+
+A complete working PAL is in
+[`tests/common/file_handler.rs`](../../tests/common/file_handler.rs).
+
+## Cargo features
+
+| Feature | Default | Effect |
+|---|---|---|
+| `transfer_mqtt`         | yes | Build the MQTT data interface (uses `minicbor`). |
+| `transfer_http`         | no  | Build the HTTP data interface (no client baked in). |
+| `transfer_http_reqwest` | no  | `std`-only convenience: HTTP via `reqwest` + `rustls`. |
+
+## Limitations
+
+- **CBOR only on the MQTT data interface.** AWS IoT Streams require CBOR.
+- **One file per job.** The `afr_ota` schema allows multiple files but the
+  engine tracks one active transfer at a time.
+- **Self-test policy is delegated to the PAL.** The engine drives the state
+  transitions; your code decides whether the new image passes self-test.
+
+## Testing
+
+Unit tests cover bitmap accounting, block validation, and topic / encoding
+round-trips:
+
+```bash
+cargo test --lib transfer::
+```
+
+End-to-end OTA against real AWS IoT (`tests/ota_mqtt.rs`) requires an
+`identity.pfx` under `tests/secrets/` and AWS credentials. The test issues a
+real `CreateOTAUpdate`, drives the device through the full job lifecycle,
+and asserts cloud-side `SUCCEEDED`:
+
+```bash
+RUST_LOG=trace \
+  THING_NAME=MyTestThing \
+  AWS_HOSTNAME=xxxxxxxx-ats.iot.eu-west-1.amazonaws.com \
+  cargo test --test ota_mqtt --features "transfer_mqtt,log"
+```
+
+[`Transfer::perform`]: https://docs.rs/rustot/latest/rustot/transfer/struct.Transfer.html#method.perform
+[`Transfer::perform_ota`]: https://docs.rs/rustot/latest/rustot/transfer/struct.Transfer.html#method.perform_ota
+[`TransferPal`]: https://docs.rs/rustot/latest/rustot/transfer/pal/trait.TransferPal.html
+[`OtaPal`]: https://docs.rs/rustot/latest/rustot/transfer/pal/trait.OtaPal.html
+[`OtaJob`]: https://docs.rs/rustot/latest/rustot/transfer/encoding/afr_ota/struct.OtaJob.html
+[`JobDocument`]: https://docs.rs/rustot/latest/rustot/transfer/encoding/trait.JobDocument.html
+[`JobContext`]: https://docs.rs/rustot/latest/rustot/transfer/encoding/struct.JobContext.html
+[`Bitmap`]: https://docs.rs/rustot/latest/rustot/transfer/encoding/struct.Bitmap.html
+[`ImageState`]: https://docs.rs/rustot/latest/rustot/transfer/pal/enum.ImageState.html
+[`ImageStateReason`]: https://docs.rs/rustot/latest/rustot/transfer/pal/enum.ImageStateReason.html
+[`PalError`]: https://docs.rs/rustot/latest/rustot/transfer/pal/enum.PalError.html
+[`crate::jobs`]: ../jobs

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -24,9 +24,7 @@ use common::network::TlsNetwork;
 use embassy_futures::select;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use mqttrust::{Config, DomainBroker, State, transport::embedded_nal::NalTransport};
-use rustot::commands::{
-    CommandAgent, CommandResultEntry, ResultMap, parse_command_request,
-};
+use rustot::commands::{CommandAgent, CommandResultEntry, ResultMap, parse_command_request};
 use rustot::mqtt::Mqtt;
 use serde::Deserialize;
 use serial_test::serial;
@@ -52,9 +50,8 @@ async fn test_commands() {
     // path the device uses to encode its responses).
     let payload = {
         let mut buf = [0u8; 256];
-        let mut ser = minicbor_serde::Serializer::new(minicbor::encode::write::Cursor::new(
-            &mut buf[..],
-        ));
+        let mut ser =
+            minicbor_serde::Serializer::new(minicbor::encode::write::Cursor::new(&mut buf[..]));
         serde::Serialize::serialize(
             &serde_json::json!({ "action": "echo", "value": 42 }),
             &mut ser,
@@ -107,20 +104,21 @@ async fn run_happy_path(ctx: &aws_commands::CommandTestContext) -> Result<(), St
         let mqtt = Mqtt(&client);
         let agent = CommandAgent::new(&mqtt);
 
-        let mut sub = agent.subscribe().await.map_err(|e| format!("subscribe: {e:?}"))?;
+        let mut sub = agent
+            .subscribe()
+            .await
+            .map_err(|e| format!("subscribe: {e:?}"))?;
         log::info!("Device subscribed; triggering execution");
 
         // Now that we're listening, ask the cloud to send the command.
         let exec_id = ctx.start_execution().await?;
         exec_id_cell.set(exec_id.clone()).ok();
 
-        let mut msg = embassy_time::with_timeout(
-            embassy_time::Duration::from_secs(30),
-            sub.next_message(),
-        )
-        .await
-        .map_err(|_| "timed out waiting for command request")?
-        .ok_or("subscription closed before command arrived")?;
+        let mut msg =
+            embassy_time::with_timeout(embassy_time::Duration::from_secs(30), sub.next_message())
+                .await
+                .map_err(|_| "timed out waiting for command request")?
+                .ok_or("subscription closed before command arrived")?;
 
         let req = parse_command_request::<TestCommand>(&mut msg)
             .ok_or("failed to parse command request")?;
@@ -138,7 +136,12 @@ async fn run_happy_path(ctx: &aws_commands::CommandTestContext) -> Result<(), St
                 req.execution_id.as_str()
             ));
         }
-        if req.payload != (TestCommand { action: "echo", value: 42 }) {
+        if req.payload
+            != (TestCommand {
+                action: "echo",
+                value: 42,
+            })
+        {
             return Err(format!("unexpected payload: {:?}", req.payload));
         }
 

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -1,0 +1,193 @@
+#![cfg(feature = "commands_cbor")]
+#![allow(async_fn_in_trait)]
+#![feature(type_alias_impl_trait)]
+
+//! ## Integration test of `AWS IoT Commands`
+//!
+//! Drives the full device-side flow against a real AWS IoT endpoint:
+//!
+//! 1. Setup creates a fresh `Command` resource (under the `AWS-IoT` namespace)
+//!    in the target account.
+//! 2. The device subscribes to the wildcard request topic.
+//! 3. The harness triggers `StartCommandExecution` against the test thing.
+//! 4. The device parses the command, publishes `IN_PROGRESS`, then `SUCCEEDED`
+//!    with a small `result` map, and awaits the cloud's `accepted` ack.
+//! 5. The harness polls `GetCommandExecution` until terminal and asserts
+//!    `SUCCEEDED`. Cleanup deletes the Command resource.
+
+mod common;
+
+use aws_sdk_iot::types::CommandExecutionStatus;
+use common::aws_commands;
+use common::credentials;
+use common::network::TlsNetwork;
+use embassy_futures::select;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use mqttrust::{Config, DomainBroker, State, transport::embedded_nal::NalTransport};
+use rustot::commands::{
+    CommandAgent, CommandResultEntry, ResultMap, parse_command_request,
+};
+use rustot::mqtt::Mqtt;
+use serde::Deserialize;
+use serial_test::serial;
+use static_cell::StaticCell;
+
+/// Payload schema delivered to the device for this test.
+#[derive(Debug, Deserialize, PartialEq)]
+struct TestCommand<'a> {
+    action: &'a str,
+    value: i32,
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_commands() {
+    let _ = env_logger::Builder::from_default_env()
+        .filter_module("serial_test", log::LevelFilter::Warn)
+        .try_init();
+
+    log::info!("Starting Commands integration test...");
+
+    // Build the CBOR payload the device will receive (same minicbor-serde
+    // path the device uses to encode its responses).
+    let payload = {
+        let mut buf = [0u8; 256];
+        let mut ser = minicbor_serde::Serializer::new(minicbor::encode::write::Cursor::new(
+            &mut buf[..],
+        ));
+        serde::Serialize::serialize(
+            &serde_json::json!({ "action": "echo", "value": 42 }),
+            &mut ser,
+        )
+        .expect("encode CBOR test payload");
+        let len = ser.into_encoder().writer().position();
+        buf[..len].to_vec()
+    };
+
+    let ctx = match aws_commands::setup(payload, "application/cbor").await {
+        Some(ctx) => ctx,
+        None => {
+            log::info!("Skipping Commands test: no valid AWS credentials or setup failed");
+            return;
+        }
+    };
+
+    let test_result = aws_commands::catch_unwind_future(run_happy_path(&ctx)).await;
+
+    ctx.cleanup().await;
+
+    match test_result {
+        Ok(inner) => inner.expect("Device-side flow failed"),
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+async fn run_happy_path(ctx: &aws_commands::CommandTestContext) -> Result<(), String> {
+    let (thing_name, identity) = credentials::identity();
+    let hostname = credentials::HOSTNAME.unwrap();
+
+    static NETWORK: StaticCell<TlsNetwork> = StaticCell::new();
+    let network = NETWORK.init(TlsNetwork::new(hostname.to_owned(), identity));
+
+    let broker =
+        DomainBroker::<_, 128>::new_with_port(hostname, 8883, network).map_err(|_| "broker")?;
+    let config = Config::builder()
+        .client_id(thing_name.try_into().map_err(|_| "client_id")?)
+        .keepalive_interval(embassy_time::Duration::from_secs(50))
+        .build();
+
+    static STATE: StaticCell<State<NoopRawMutex, 4096, { 4096 * 4 }>> = StaticCell::new();
+    let state = STATE.init(State::new());
+    let (mut stack, client) = mqttrust::new(state, config);
+
+    // (executionId, terminal_status) shared between device and harness tasks.
+    let exec_id_cell: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::new();
+
+    let device_fut = async {
+        let mqtt = Mqtt(&client);
+        let agent = CommandAgent::new(&mqtt);
+
+        let mut sub = agent.subscribe().await.map_err(|e| format!("subscribe: {e:?}"))?;
+        log::info!("Device subscribed; triggering execution");
+
+        // Now that we're listening, ask the cloud to send the command.
+        let exec_id = ctx.start_execution().await?;
+        exec_id_cell.set(exec_id.clone()).ok();
+
+        let mut msg = embassy_time::with_timeout(
+            embassy_time::Duration::from_secs(30),
+            sub.next_message(),
+        )
+        .await
+        .map_err(|_| "timed out waiting for command request")?
+        .ok_or("subscription closed before command arrived")?;
+
+        let req = parse_command_request::<TestCommand>(&mut msg)
+            .ok_or("failed to parse command request")?;
+
+        log::info!(
+            "Device received command: executionId={} payload={:?}",
+            req.execution_id.as_str(),
+            req.payload,
+        );
+
+        if req.execution_id.as_str() != exec_id.as_str() {
+            return Err(format!(
+                "executionId mismatch: cloud said {}, topic said {}",
+                exec_id,
+                req.execution_id.as_str()
+            ));
+        }
+        if req.payload != (TestCommand { action: "echo", value: 42 }) {
+            return Err(format!("unexpected payload: {:?}", req.payload));
+        }
+
+        // Optional progress report.
+        agent
+            .report_in_progress(req.execution_id.as_str(), None)
+            .await
+            .map_err(|e| format!("report_in_progress: {e:?}"))?;
+
+        // Build a result echoing the action back, then succeed.
+        let mut result = ResultMap::new();
+        result
+            .insert("echoed", CommandResultEntry::String { s: "echo" })
+            .map_err(|_| "result insert")?;
+        agent
+            .succeed(req.execution_id.as_str(), Some(&result))
+            .await
+            .map_err(|e| format!("succeed: {e:?}"))?;
+
+        log::info!("Device succeeded execution {}", req.execution_id.as_str());
+        Ok::<(), String>(())
+    };
+
+    let mut transport = NalTransport::new(network, broker);
+
+    let device_outcome = match embassy_time::with_timeout(
+        embassy_time::Duration::from_secs(60),
+        select::select(stack.run(&mut transport), device_fut),
+    )
+    .await
+    .map_err(|_| "outer test timeout (60s)")?
+    {
+        select::Either::First(_) => unreachable!("MQTT stack returned"),
+        select::Either::Second(result) => result,
+    };
+    device_outcome?;
+
+    // Cloud-side assertion.
+    let exec_id = exec_id_cell
+        .get()
+        .ok_or("device task did not record an executionId")?;
+    let status = ctx
+        .wait_for_terminal(exec_id, std::time::Duration::from_secs(15))
+        .await?;
+    assert_eq!(
+        status,
+        CommandExecutionStatus::Succeeded,
+        "cloud-side status mismatch (executionId={exec_id})"
+    );
+
+    Ok(())
+}

--- a/tests/common/aws_commands.rs
+++ b/tests/common/aws_commands.rs
@@ -1,0 +1,303 @@
+//! AWS Commands test helper — manages Command resource lifecycle for
+//! integration tests.
+//!
+//! Modeled after [`super::aws_ota`] but slimmer: there is no S3 upload, no
+//! code-signing dance, and the trigger API lives in the data plane
+//! (`aws-sdk-iotjobsdataplane::start_command_execution`).
+
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_sdk_iot::primitives::Blob;
+use aws_sdk_iot::types::{CommandExecutionStatus, CommandNamespace, CommandPayload};
+
+const TARGET_ACCOUNT_ID: &str = "411974994697";
+pub const THING_NAME: &str = "rustot-test";
+const REGION: &str = "eu-west-1";
+const CROSS_ACCOUNT_ROLE: &str = "ExternalAccessProvisionIoT";
+
+/// Context returned by [`setup`] — holds everything needed for cleanup,
+/// triggering, and cloud-side assertions.
+pub struct CommandTestContext {
+    /// Assumed-role credentials (for IoT operations in the target account)
+    iot_creds: SharedCredentialsProvider,
+    /// ARN of the Command resource created by setup
+    command_arn: String,
+    /// ARN of the test thing
+    thing_arn: String,
+    /// AWS region
+    region: aws_config::Region,
+}
+
+impl CommandTestContext {
+    pub fn command_arn(&self) -> &str {
+        &self.command_arn
+    }
+
+    /// Trigger a command execution against the test thing and return the
+    /// generated `executionId`.
+    pub async fn start_execution(&self) -> Result<String, String> {
+        let cfg = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(self.region.clone())
+            .credentials_provider(self.iot_creds.clone())
+            .load()
+            .await;
+        let client = aws_sdk_iotjobsdataplane::Client::new(&cfg);
+
+        let resp = client
+            .start_command_execution()
+            .target_arn(&self.thing_arn)
+            .command_arn(&self.command_arn)
+            .send()
+            .await
+            .map_err(|e| format!("StartCommandExecution failed: {e}"))?;
+
+        let id = resp
+            .execution_id()
+            .ok_or("StartCommandExecution returned no executionId")?
+            .to_owned();
+        log::info!("Started command execution: {id}");
+        Ok(id)
+    }
+
+    /// Fetch the current cloud-side execution status.
+    pub async fn execution_status(
+        &self,
+        execution_id: &str,
+    ) -> Result<CommandExecutionStatus, String> {
+        let cfg = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(self.region.clone())
+            .credentials_provider(self.iot_creds.clone())
+            .load()
+            .await;
+        let client = aws_sdk_iot::Client::new(&cfg);
+
+        let resp = client
+            .get_command_execution()
+            .execution_id(execution_id)
+            .target_arn(&self.thing_arn)
+            .send()
+            .await
+            .map_err(|e| format!("GetCommandExecution failed: {e}"))?;
+
+        resp.status()
+            .cloned()
+            .ok_or_else(|| "GetCommandExecution returned no status".to_owned())
+    }
+
+    /// Poll [`execution_status`] until a terminal status is observed or the
+    /// deadline elapses.
+    pub async fn wait_for_terminal(
+        &self,
+        execution_id: &str,
+        deadline: std::time::Duration,
+    ) -> Result<CommandExecutionStatus, String> {
+        let start = std::time::Instant::now();
+        loop {
+            let status = self.execution_status(execution_id).await?;
+            let terminal = matches!(
+                status,
+                CommandExecutionStatus::Succeeded
+                    | CommandExecutionStatus::Failed
+                    | CommandExecutionStatus::Rejected
+                    | CommandExecutionStatus::TimedOut
+            );
+            if terminal {
+                return Ok(status);
+            }
+            if start.elapsed() >= deadline {
+                return Err(format!(
+                    "Timed out waiting for terminal status (last seen: {status:?})"
+                ));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Cleanup: delete the Command resource. Best-effort — failures are logged.
+    pub async fn cleanup(&self) {
+        log::info!("Cleaning up Command test resources...");
+
+        let cfg = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(self.region.clone())
+            .credentials_provider(self.iot_creds.clone())
+            .load()
+            .await;
+        let client = aws_sdk_iot::Client::new(&cfg);
+
+        match client
+            .delete_command()
+            .command_id(command_id_from_arn(&self.command_arn))
+            .send()
+            .await
+        {
+            Ok(_) => log::info!("Deleted Command: {}", self.command_arn),
+            Err(e) => log::warn!("Failed to delete Command {}: {}", self.command_arn, e),
+        }
+    }
+}
+
+/// Set up an AWS Command resource for the test.
+///
+/// Returns `Some(CommandTestContext)` if credentials are available and role
+/// assumption succeeds, or `None` if the test should be skipped.
+///
+/// `payload_bytes` is the raw command payload delivered verbatim to the
+/// device on the request topic. `content_type` selects which `request/<fmt>`
+/// topic AWS routes to (`application/json` → `request/json`,
+/// `application/cbor` → `request/cbor`).
+pub async fn setup(
+    payload_bytes: Vec<u8>,
+    content_type: &str,
+) -> Option<CommandTestContext> {
+    let region = aws_config::Region::new(REGION);
+
+    let mgmt_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region.clone())
+        .load()
+        .await;
+    let sts_client = aws_sdk_sts::Client::new(&mgmt_config);
+
+    if let Err(e) = sts_client.get_caller_identity().send().await {
+        log::warn!(
+            "No valid AWS credentials available, skipping Commands test: {}",
+            e
+        );
+        return None;
+    }
+
+    let role_arn = format!("arn:aws:iam::{TARGET_ACCOUNT_ID}:role/{CROSS_ACCOUNT_ROLE}");
+    let assumed = match sts_client
+        .assume_role()
+        .role_arn(&role_arn)
+        .role_session_name("RustotCommandsIntegration")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!(
+                "Failed to assume role {}, skipping Commands test: {}",
+                role_arn,
+                e
+            );
+            return None;
+        }
+    };
+
+    let assumed_creds = assumed.credentials()?;
+    let expiration =
+        std::time::SystemTime::UNIX_EPOCH.checked_add(std::time::Duration::from_millis(
+            assumed_creds.expiration().to_millis().unwrap_or(0) as u64,
+        ));
+    let iot_creds_provider = aws_credential_types::Credentials::new(
+        assumed_creds.access_key_id(),
+        assumed_creds.secret_access_key(),
+        Some(assumed_creds.session_token().to_owned()),
+        expiration,
+        "commands-test-assumed-role",
+    );
+    let iot_creds = SharedCredentialsProvider::new(iot_creds_provider);
+
+    // Verify identity is in the target account.
+    let iot_sts_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region.clone())
+        .credentials_provider(iot_creds.clone())
+        .load()
+        .await;
+    if let Ok(id) = aws_sdk_sts::Client::new(&iot_sts_config)
+        .get_caller_identity()
+        .send()
+        .await
+        && id.account().unwrap_or_default() != TARGET_ACCOUNT_ID
+    {
+        log::warn!(
+            "Assumed role is in account {} but expected {}, skipping",
+            id.account().unwrap_or("unknown"),
+            TARGET_ACCOUNT_ID
+        );
+        return None;
+    }
+
+    // Create the Command resource. The id is unique per run so concurrent
+    // tests don't collide.
+    let command_id = format!("rustot-test-{}", uuid::Uuid::new_v4());
+    let iot_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        .region(region.clone())
+        .credentials_provider(iot_creds.clone())
+        .load()
+        .await;
+    let iot_client = aws_sdk_iot::Client::new(&iot_config);
+
+    let payload = CommandPayload::builder()
+        .content(Blob::new(payload_bytes))
+        .content_type(content_type.to_owned())
+        .build();
+
+    let create_resp = match iot_client
+        .create_command()
+        .command_id(&command_id)
+        .namespace(CommandNamespace::AwsIoT)
+        .payload(payload)
+        .display_name("Rustot integration test")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!("CreateCommand failed, skipping Commands test: {}", e);
+            return None;
+        }
+    };
+
+    let command_arn = create_resp
+        .command_arn()
+        .expect("CreateCommand returned no ARN")
+        .to_owned();
+
+    log::info!("Created Command: {command_arn}");
+
+    let thing_arn = format!("arn:aws:iot:{REGION}:{TARGET_ACCOUNT_ID}:thing/{THING_NAME}");
+
+    Some(CommandTestContext {
+        iot_creds,
+        command_arn,
+        thing_arn,
+        region,
+    })
+}
+
+/// Async-safe panic catcher (mirrors [`super::aws_ota::catch_unwind_future`]).
+pub async fn catch_unwind_future<F, T>(f: F) -> Result<T, Box<dyn std::any::Any + Send>>
+where
+    F: Future<Output = T>,
+{
+    CatchUnwindFuture {
+        inner: Box::pin(AssertUnwindSafe(f)),
+    }
+    .await
+}
+
+struct CatchUnwindFuture<F> {
+    inner: Pin<Box<F>>,
+}
+
+impl<F: Future> Future for CatchUnwindFuture<AssertUnwindSafe<F>> {
+    type Output = Result<F::Output, Box<dyn std::any::Any + Send>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let inner = &mut self.inner;
+        match std::panic::catch_unwind(AssertUnwindSafe(|| inner.as_mut().poll(cx))) {
+            Ok(Poll::Pending) => Poll::Pending,
+            Ok(Poll::Ready(val)) => Poll::Ready(Ok(val)),
+            Err(panic) => Poll::Ready(Err(panic)),
+        }
+    }
+}
+
+fn command_id_from_arn(arn: &str) -> &str {
+    arn.rsplit_once('/').map(|(_, id)| id).unwrap_or(arn)
+}

--- a/tests/common/aws_commands.rs
+++ b/tests/common/aws_commands.rs
@@ -149,10 +149,7 @@ impl CommandTestContext {
 /// device on the request topic. `content_type` selects which `request/<fmt>`
 /// topic AWS routes to (`application/json` → `request/json`,
 /// `application/cbor` → `request/cbor`).
-pub async fn setup(
-    payload_bytes: Vec<u8>,
-    content_type: &str,
-) -> Option<CommandTestContext> {
+pub async fn setup(payload_bytes: Vec<u8>, content_type: &str) -> Option<CommandTestContext> {
     let region = aws_config::Region::new(REGION);
 
     let mgmt_config = aws_config::defaults(aws_config::BehaviorVersion::latest())

--- a/tests/common/aws_commands.rs
+++ b/tests/common/aws_commands.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_sdk_iot::error::ProvideErrorMetadata;
 use aws_sdk_iot::primitives::Blob;
 use aws_sdk_iot::types::{CommandExecutionStatus, CommandNamespace, CommandPayload};
 
@@ -53,7 +54,14 @@ impl CommandTestContext {
             .command_arn(&self.command_arn)
             .send()
             .await
-            .map_err(|e| format!("StartCommandExecution failed: {e}"))?;
+            .map_err(|e| {
+                format!(
+                    "StartCommandExecution failed: code={:?} message={:?} raw={:?}",
+                    e.code(),
+                    e.message(),
+                    e
+                )
+            })?;
 
         let id = resp
             .execution_id()
@@ -81,7 +89,14 @@ impl CommandTestContext {
             .target_arn(&self.thing_arn)
             .send()
             .await
-            .map_err(|e| format!("GetCommandExecution failed: {e}"))?;
+            .map_err(|e| {
+                format!(
+                    "GetCommandExecution failed: code={:?} message={:?} raw={:?}",
+                    e.code(),
+                    e.message(),
+                    e
+                )
+            })?;
 
         resp.status()
             .cloned()

--- a/tests/common/aws_commands.rs
+++ b/tests/common/aws_commands.rs
@@ -31,6 +31,10 @@ pub struct CommandTestContext {
     thing_arn: String,
     /// AWS region
     region: aws_config::Region,
+    /// Account-specific endpoint for `aws-sdk-iotjobsdataplane`, resolved via
+    /// `iot:DescribeEndpoint(endpointType="iot:Jobs")`. The SDK's default
+    /// regional endpoint returns AccessDenied for command executions.
+    jobs_data_endpoint: String,
 }
 
 impl CommandTestContext {
@@ -41,12 +45,15 @@ impl CommandTestContext {
     /// Trigger a command execution against the test thing and return the
     /// generated `executionId`.
     pub async fn start_execution(&self) -> Result<String, String> {
-        let cfg = aws_config::defaults(aws_config::BehaviorVersion::latest())
+        let shared = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .region(self.region.clone())
             .credentials_provider(self.iot_creds.clone())
             .load()
             .await;
-        let client = aws_sdk_iotjobsdataplane::Client::new(&cfg);
+        let cfg = aws_sdk_iotjobsdataplane::config::Builder::from(&shared)
+            .endpoint_url(&self.jobs_data_endpoint)
+            .build();
+        let client = aws_sdk_iotjobsdataplane::Client::from_conf(cfg);
 
         let resp = client
             .start_command_execution()
@@ -244,6 +251,28 @@ pub async fn setup(payload_bytes: Vec<u8>, content_type: &str) -> Option<Command
         .await;
     let iot_client = aws_sdk_iot::Client::new(&iot_config);
 
+    // Resolve the account-specific Jobs Data endpoint. The default regional
+    // endpoint is AccessDenied for command executions.
+    let jobs_data_endpoint = match iot_client
+        .describe_endpoint()
+        .endpoint_type("iot:Jobs")
+        .send()
+        .await
+    {
+        Ok(r) => match r.endpoint_address {
+            Some(host) => format!("https://{host}"),
+            None => {
+                log::warn!("DescribeEndpoint(iot:Jobs) returned no address, skipping");
+                return None;
+            }
+        },
+        Err(e) => {
+            log::warn!("DescribeEndpoint(iot:Jobs) failed, skipping: {e}");
+            return None;
+        }
+    };
+    log::info!("Resolved Jobs Data endpoint: {jobs_data_endpoint}");
+
     let payload = CommandPayload::builder()
         .content(Blob::new(payload_bytes))
         .content_type(content_type.to_owned())
@@ -279,6 +308,7 @@ pub async fn setup(payload_bytes: Vec<u8>, content_type: &str) -> Option<Command
         command_arn,
         thing_arn,
         region,
+        jobs_data_endpoint,
     })
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,6 @@
 #[allow(dead_code)]
+pub mod aws_commands;
+#[allow(dead_code)]
 pub mod aws_ota;
 pub mod credentials;
 pub mod file_handler;


### PR DESCRIPTION
## Summary

- Add `src/commands/` implementing the device-side flow for AWS IoT Remote Commands ([service docs](https://docs.aws.amazon.com/iot/latest/developerguide/iot-remote-command.html)). The module mirrors the conventions of `jobs` / `provisioning` / `defender_metrics`: a `CommandAgent` analogous to `JobAgent`, a `parse_command_request` free function, a type-state `Update<'a, R>` builder, `CommandTopic` / `Topic` with feature-switched JSON / CBOR suffix, and a `CommandError` with the standard serde `From` impls.
- Gate the payload format behind a new `commands_cbor` feature (added to `default`), wired analogously to `provision_cbor` / `metric_cbor`. Targets registered Things only; the `clients/` form is deferred.
- Overhaul the root `README.md` (service table, design / toolchain / Cargo features sections, OTA `afr_ota` + `CreateOTAUpdate` callout) and bring every service module's README into a common shape (workflow, topic table, reference tables, worked code example, Cargo features, limitations, testing). New READMEs for `commands`, `jobs`, `defender_metrics`, `transfer`; overhauled READMEs for `provisioning`, `shadows`.

Unit tests cover topic format/parse round-trips, JSON `Update` payload-shape regression guards, a CBOR encode→decode round-trip, and `parse_command_request` happy-path plus topic-mismatch. Verified building under default features, `mqtt_mqttrust` JSON-only, `mqtt_mqttrust + commands_cbor`, and `mqtt_rumqttc + commands_cbor`; clippy clean for new code.