### PR TITLE
fix: Use QoS::AtLeastOnce for shadow/provisioning/OTA control topics

### DIFF
--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -4,7 +4,9 @@ pub mod topics;
 
 use core::future::Future;
 
-use crate::mqtt::{DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, QoS};
+use crate::mqtt::{
+    DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, PublishOptions, QoS,
+};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 pub use error::Error;
@@ -224,16 +226,20 @@ impl FleetProvisioner {
             Topic::RegisterThingRejected(template_name, payload_format).format::<150>()?;
         let mut register_subscription = mqtt
             .subscribe::<2>(&[
-                (register_accepted_topic.as_str(), QoS::AtMostOnce),
-                (register_rejected_topic.as_str(), QoS::AtMostOnce),
+                (register_accepted_topic.as_str(), QoS::AtLeastOnce),
+                (register_rejected_topic.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| Error::Mqtt)?;
 
         let publish_topic = Topic::RegisterThing(template_name, payload_format).format::<69>()?;
-        mqtt.publish(publish_topic.as_str(), payload)
-            .await
-            .map_err(|_| Error::Mqtt)?;
+        mqtt.publish_with_options(
+            publish_topic.as_str(),
+            payload,
+            PublishOptions::new().qos(QoS::AtLeastOnce),
+        )
+        .await
+        .map_err(|_| Error::Mqtt)?;
 
         let mut message = register_subscription
             .next_message()
@@ -276,8 +282,8 @@ impl FleetProvisioner {
 
             let subscription = mqtt
                 .subscribe(&[
-                    (rejected_topic.as_str(), QoS::AtMostOnce),
-                    (accepted_topic.as_str(), QoS::AtMostOnce),
+                    (rejected_topic.as_str(), QoS::AtLeastOnce),
+                    (accepted_topic.as_str(), QoS::AtLeastOnce),
                 ])
                 .await
                 .map_err(|_| Error::Mqtt)?;
@@ -307,9 +313,13 @@ impl FleetProvisioner {
             );
 
             let publish_topic = Topic::CreateCertificateFromCsr(payload_format).format::<40>()?;
-            mqtt.publish(publish_topic.as_str(), payload)
-                .await
-                .map_err(|_| Error::Mqtt)?;
+            mqtt.publish_with_options(
+                publish_topic.as_str(),
+                payload,
+                PublishOptions::new().qos(QoS::AtLeastOnce),
+            )
+            .await
+            .map_err(|_| Error::Mqtt)?;
 
             Ok(subscription)
         } else {
@@ -320,16 +330,20 @@ impl FleetProvisioner {
 
             let subscription = mqtt
                 .subscribe(&[
-                    (accepted_topic.as_str(), QoS::AtMostOnce),
-                    (rejected_topic.as_str(), QoS::AtMostOnce),
+                    (accepted_topic.as_str(), QoS::AtLeastOnce),
+                    (rejected_topic.as_str(), QoS::AtLeastOnce),
                 ])
                 .await
                 .map_err(|_| Error::Mqtt)?;
 
             let publish_topic = Topic::CreateKeysAndCertificate(payload_format).format::<29>()?;
-            mqtt.publish(publish_topic.as_str(), b"".as_slice())
-                .await
-                .map_err(|_| Error::Mqtt)?;
+            mqtt.publish_with_options(
+                publish_topic.as_str(),
+                b"".as_slice(),
+                PublishOptions::new().qos(QoS::AtLeastOnce),
+            )
+            .await
+            .map_err(|_| Error::Mqtt)?;
 
             Ok(subscription)
         }

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -6,7 +6,8 @@ use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
 use serde::Serialize;
 
 use crate::mqtt::{
-    DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, QoS, ToPayload,
+    DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, PublishOptions, QoS,
+    ToPayload,
 };
 
 use crate::shadows::{
@@ -104,7 +105,7 @@ where
 
                 let sub = self
                     .mqtt
-                    .subscribe(&[(topic.as_str(), QoS::AtMostOnce)])
+                    .subscribe(&[(topic.as_str(), QoS::AtLeastOnce)])
                     .await
                     .map_err(|_| Error::Mqtt)?;
 
@@ -331,8 +332,8 @@ where
         let sub = self
             .mqtt
             .subscribe(&[
-                (accepted_topic.as_str(), QoS::AtMostOnce),
-                (rejected_topic.as_str(), QoS::AtMostOnce),
+                (accepted_topic.as_str(), QoS::AtLeastOnce),
+                (rejected_topic.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| Error::Mqtt)?;
@@ -344,7 +345,11 @@ where
             S::NAME,
         )?;
         self.mqtt
-            .publish(topic_name.as_str(), payload)
+            .publish_with_options(
+                topic_name.as_str(),
+                payload,
+                PublishOptions::new().qos(QoS::AtLeastOnce),
+            )
             .await
             .map_err(|_| Error::Mqtt)?;
 

--- a/src/transfer/control_interface/mqtt.rs
+++ b/src/transfer/control_interface/mqtt.rs
@@ -82,8 +82,8 @@ impl<C: MqttClient> ControlInterface for Mqtt<&'_ C> {
             Some(
                 self.0
                     .subscribe(&[
-                        (accepted_topic.as_str(), QoS::AtMostOnce),
-                        (rejected_topic.as_str(), QoS::AtMostOnce),
+                        (accepted_topic.as_str(), QoS::AtLeastOnce),
+                        (rejected_topic.as_str(), QoS::AtLeastOnce),
                     ])
                     .await
                     .map_err(|_| TransferError::Mqtt)?,


### PR DESCRIPTION
## Summary
- Bump request/response topic pairs (shadow get/update/delete, fleet-provisioning register, OTA streaming control) from `AtMostOnce` to `AtLeastOnce`.
- Switch the matching publishes to `publish_with_options(...QoS::AtLeastOnce)` so the publish QoS matches the subscription.

A transient drop between SUBSCRIBE and the broker's accepted/rejected reply silently loses the response with QoS 0, parking the caller on `next_message().await`. AtLeastOnce gives the broker a chance to redeliver.

Split out from the broader subscription/disconnect work (rustot #121) so it can land independently.

## Test plan
- [ ] `cargo check` (default features) passes
- [ ] Existing shadow + provisioning integration tests still pass
- [ ] Hardware: shadow round-trips work normally; no regressions during reconnect cycles