### PR TITLE
fix: Use QoS::AtLeastOnce for jobs/commands/defender control topics

### DIFF
--- a/src/commands/stream.rs
+++ b/src/commands/stream.rs
@@ -44,18 +44,25 @@ impl<'a, C: MqttClient> CommandAgent<'a, C> {
         Self { mqtt }
     }
 
-    /// Subscribe to `executions/+/request/{format}` (single topic, QoS 0).
+    /// Subscribe to `executions/+/request/{format}` (single topic).
+    ///
+    /// QoS 1 so the broker can queue incoming command requests across
+    /// transient client disconnects (with a persistent session) — at QoS 0
+    /// the broker drops any request that lands in the disconnect window.
     pub async fn subscribe(&self) -> Result<C::Subscription<'a, 1>, CommandError> {
         let thing = self.mqtt.0.client_id();
         let topic = CommandTopic::Subscribe.format::<MAX_COMMAND_TOPIC_LEN>(thing)?;
         self.mqtt
             .0
-            .subscribe(&[(topic.as_str(), QoS::AtMostOnce)])
+            .subscribe(&[(topic.as_str(), QoS::AtLeastOnce)])
             .await
             .map_err(|_| CommandError::Mqtt)
     }
 
-    /// Fire-and-forget IN_PROGRESS report (QoS 0).
+    /// Report IN_PROGRESS for a command execution.
+    ///
+    /// QoS 1 so a transient broker disconnect doesn't silently drop the
+    /// progress update.
     pub async fn report_in_progress(
         &self,
         execution_id: &str,
@@ -70,7 +77,7 @@ impl<'a, C: MqttClient> CommandAgent<'a, C> {
             .format::<MAX_COMMAND_TOPIC_LEN>(self.mqtt.0.client_id())?;
         self.mqtt
             .0
-            .publish(&topic, upd)
+            .publish_with_options(&topic, upd, PublishOptions::new().qos(QoS::AtLeastOnce))
             .await
             .map_err(|_| CommandError::Mqtt)
     }

--- a/src/defender_metrics/mod.rs
+++ b/src/defender_metrics/mod.rs
@@ -1,5 +1,6 @@
 use crate::mqtt::{
-    DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, QoS, ToPayload,
+    DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, PublishOptions, QoS,
+    ToPayload,
 };
 use data_types::Metric;
 use errors::{ErrorResponse, MetricError};
@@ -113,8 +114,8 @@ impl<'m, C: MqttClient> MetricHandler<'m, C> {
         let sub = self
             .mqtt
             .subscribe(&[
-                (accepted.as_str(), QoS::AtMostOnce),
-                (rejected.as_str(), QoS::AtMostOnce),
+                (accepted.as_str(), QoS::AtLeastOnce),
+                (rejected.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| MetricError::Mqtt)?;
@@ -122,7 +123,11 @@ impl<'m, C: MqttClient> MetricHandler<'m, C> {
         let topic_name = Topic::Publish.format::<MAX_DEFENDER_TOPIC_LEN>(self.mqtt.client_id())?;
 
         self.mqtt
-            .publish(topic_name.as_str(), payload)
+            .publish_with_options(
+                topic_name.as_str(),
+                payload,
+                PublishOptions::new().qos(QoS::AtLeastOnce),
+            )
             .await
             .map_err(|_| {
                 error!("ERROR PUBLISHING PAYLOAD");

--- a/src/jobs/stream.rs
+++ b/src/jobs/stream.rs
@@ -67,8 +67,8 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
             .mqtt
             .0
             .subscribe(&[
-                (notify_topic.as_str(), QoS::AtMostOnce),
-                (describe_topic.as_str(), QoS::AtMostOnce),
+                (notify_topic.as_str(), QoS::AtLeastOnce),
+                (describe_topic.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| JobError::Mqtt)?;
@@ -78,7 +78,11 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
         let topic = describe.topic(client_id)?;
         self.mqtt
             .0
-            .publish(&topic, describe)
+            .publish_with_options(
+                &topic,
+                describe,
+                PublishOptions::new().qos(QoS::AtLeastOnce),
+            )
             .await
             .map_err(|_| JobError::Mqtt)?;
 
@@ -91,8 +95,8 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
     /// `status_details` can be any serializable type describing current
     /// progress.
     ///
-    /// Progress updates use QoS 0 (fire-and-forget) since they are
-    /// non-critical and frequent.
+    /// QoS 1 so a transient broker disconnect mid-job doesn't silently
+    /// drop the progress update.
     pub async fn report_progress<S: Serialize>(
         &self,
         job_id: &str,
@@ -109,7 +113,7 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
 
         self.mqtt
             .0
-            .publish(&topic, payload)
+            .publish_with_options(&topic, payload, PublishOptions::new().qos(QoS::AtLeastOnce))
             .await
             .map_err(|_| JobError::Mqtt)
     }
@@ -188,8 +192,8 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
             .mqtt
             .0
             .subscribe(&[
-                (accepted_topic.as_str(), QoS::AtMostOnce),
-                (rejected_topic.as_str(), QoS::AtMostOnce),
+                (accepted_topic.as_str(), QoS::AtLeastOnce),
+                (rejected_topic.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| JobError::Mqtt)?;


### PR DESCRIPTION
## Summary

Same pattern as #122 — bump remaining request/response topic pairs from `AtMostOnce` to `AtLeastOnce` across the modules that #122 didn't cover.

* **jobs/stream.rs**: `JobAgent::subscribe` (notify-next + describe-accepted), the describe publish, `report_progress` publish, and `publish_and_wait`'s update/accepted+rejected subscriptions.
* **commands/stream.rs**: `CommandAgent::subscribe` (executions/+/request) and `report_in_progress` publish.
* **defender_metrics/mod.rs**: `publish_and_subscribe`'s accepted+rejected subs and the metric publish.

Transfer's `data_interface` deliberately stays at QoS 0 — those are high-volume OTA data blocks with their own retry semantics, same as before #122.

## Why

Discovered during end-to-end testing of factory-reset on a Greengrass device. job-manager's `report_progress` publish landing ~5–10 s after a deployment-driven cleanup returned `JobError::Mqtt` because the broker had briefly dropped the connection during the cleanup phase; QoS 0 publishes were silently lost. Same `succeed_job`/`fail_job` ack-loss-on-reconnect risk on the `update/accepted` subscription.

## Test plan

- [x] `cargo check` (default features) passes
- [x] `cargo check --features std,mqtt_greengrass --no-default-features` passes
- [x] `cargo test --features std,mqtt_mqttrust,commands_cbor,metric_cbor --lib` — 88/88 passing
- [ ] Hardware: factbird-edge factory_reset end-to-end shows `report_progress` succeeding through the post-cleanup window and the IoT job execution reaches a terminal state in cloud