### PR TITLE
feat: introduce MaxJsonSize trait for JSON encode buffer sizing

### DIFF
--- a/src/commands/data_types.rs
+++ b/src/commands/data_types.rs
@@ -67,6 +67,14 @@ pub enum CommandResultEntry<'a> {
 /// Default-sized result map type for ergonomic use.
 pub type ResultMap<'a> = heapless::LinearMap<&'a str, CommandResultEntry<'a>, MAX_RESULT_ENTRIES>;
 
+// Sized for the typical Commands result: up to MAX_RESULT_ENTRIES (10) keys
+// (≤64 chars each) holding short strings, booleans, or base64 blobs (≤512
+// chars). 4 KB covers the worst case with framing while staying well under
+// AWS IoT Commands' per-update size cap.
+impl crate::mqtt::MaxJsonSize for ResultMap<'_> {
+    const MAX_JSON_SIZE: usize = 4096;
+}
+
 /// Outbound payload sent to
 /// `$aws/commands/things/{thing}/executions/{id}/response/{format}`.
 #[derive(Debug, PartialEq, Serialize)]

--- a/src/commands/stream.rs
+++ b/src/commands/stream.rs
@@ -44,18 +44,25 @@ impl<'a, C: MqttClient> CommandAgent<'a, C> {
         Self { mqtt }
     }
 
-    /// Subscribe to `executions/+/request/{format}` (single topic, QoS 0).
+    /// Subscribe to `executions/+/request/{format}` (single topic).
+    ///
+    /// QoS 1 so the broker can queue incoming command requests across
+    /// transient client disconnects (with a persistent session) — at QoS 0
+    /// the broker drops any request that lands in the disconnect window.
     pub async fn subscribe(&self) -> Result<C::Subscription<'a, 1>, CommandError> {
         let thing = self.mqtt.0.client_id();
         let topic = CommandTopic::Subscribe.format::<MAX_COMMAND_TOPIC_LEN>(thing)?;
         self.mqtt
             .0
-            .subscribe(&[(topic.as_str(), QoS::AtMostOnce)])
+            .subscribe(&[(topic.as_str(), QoS::AtLeastOnce)])
             .await
             .map_err(|_| CommandError::Mqtt)
     }
 
-    /// Fire-and-forget IN_PROGRESS report (QoS 0).
+    /// Report IN_PROGRESS for a command execution.
+    ///
+    /// QoS 1 so a transient broker disconnect doesn't silently drop the
+    /// progress update.
     pub async fn report_in_progress(
         &self,
         execution_id: &str,
@@ -70,7 +77,7 @@ impl<'a, C: MqttClient> CommandAgent<'a, C> {
             .format::<MAX_COMMAND_TOPIC_LEN>(self.mqtt.0.client_id())?;
         self.mqtt
             .0
-            .publish(&topic, upd)
+            .publish_with_options(&topic, upd, PublishOptions::new().qos(QoS::AtLeastOnce))
             .await
             .map_err(|_| CommandError::Mqtt)
     }

--- a/src/commands/stream.rs
+++ b/src/commands/stream.rs
@@ -8,7 +8,9 @@ use crate::commands::{
     topics::{CommandTopic, MAX_COMMAND_TOPIC_LEN, Topic},
     update::Update,
 };
-use crate::mqtt::{MaxJsonSize, Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
+use crate::mqtt::{
+    MaxJsonSize, Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS,
+};
 
 /// Helper for the AWS IoT Commands subscribe / response lifecycle.
 ///

--- a/src/commands/stream.rs
+++ b/src/commands/stream.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::commands::data_types::CommandRequest;
 use crate::commands::{
@@ -8,7 +8,7 @@ use crate::commands::{
     topics::{CommandTopic, MAX_COMMAND_TOPIC_LEN, Topic},
     update::Update,
 };
-use crate::mqtt::{Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
+use crate::mqtt::{MaxJsonSize, Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
 
 /// Helper for the AWS IoT Commands subscribe / response lifecycle.
 ///
@@ -83,7 +83,7 @@ impl<'a, C: MqttClient> CommandAgent<'a, C> {
     }
 
     /// Publish `SUCCEEDED` and wait for cloud `accepted`/`rejected`.
-    pub async fn succeed<R: Serialize>(
+    pub async fn succeed<R: MaxJsonSize>(
         &self,
         execution_id: &str,
         result: Option<&R>,
@@ -129,7 +129,7 @@ impl<'a, C: MqttClient> CommandAgent<'a, C> {
         self.publish_and_wait(execution_id, upd).await
     }
 
-    async fn publish_and_wait<R: Serialize>(
+    async fn publish_and_wait<R: MaxJsonSize>(
         &self,
         execution_id: &str,
         payload: Update<'_, R>,

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,17 +1,25 @@
+// Used as a method call (`req.serialize(...)`) only on the cbor encoding branch.
+#[cfg_attr(not(feature = "commands_cbor"), allow(unused_imports))]
 use serde::Serialize;
 
 use crate::commands::data_types::{
     CommandStatus, MAX_REASON_CODE_LEN, MAX_REASON_DESCRIPTION_LEN, StatusReason,
     UpdateCommandExecutionRequest,
 };
-use crate::mqtt::{PayloadError, ToPayload};
+use crate::mqtt::{MaxJsonSize, PayloadError, ToPayload};
+
+/// JSON-framing overhead for [`UpdateCommandExecutionRequest`]: executionId
+/// (≤64), statusReason (≤1024 + ≤64 + framing), status enum, and the JSON
+/// object itself with all its keys.
+const UPDATE_FRAMING_OVERHEAD: usize = 1280;
 
 /// Type-state builder for an `UpdateCommandExecution` payload.
 ///
 /// The generic `R` is the type of the optional `result` field — it evolves on
-/// `result(...)` to accept any user-provided `Serialize` type, mirroring
-/// `crate::jobs::update::Update<'a, S>`.
-pub struct Update<'a, R: Serialize = ()> {
+/// `result(...)` to accept any user-provided [`MaxJsonSize`] type, mirroring
+/// `crate::jobs::update::Update<'a, S>`. The encode buffer is sized from
+/// `R::MAX_JSON_SIZE` plus framing overhead.
+pub struct Update<'a, R: MaxJsonSize = ()> {
     status: CommandStatus,
     execution_id: Option<&'a str>,
     status_reason: Option<StatusReason<'a>>,
@@ -30,7 +38,7 @@ impl<'a> Update<'a, ()> {
     }
 }
 
-impl<'a, R: Serialize> Update<'a, R> {
+impl<'a, R: MaxJsonSize> Update<'a, R> {
     /// Echo the executionId in the payload body. Optional — AWS already knows
     /// the id from the topic path.
     pub fn execution_id(mut self, id: &'a str) -> Self {
@@ -52,7 +60,8 @@ impl<'a, R: Serialize> Update<'a, R> {
     }
 
     /// Attach a `result`. Type-state: the returned builder's `R` becomes `T`.
-    pub fn result<T: Serialize>(self, result: &'a T) -> Update<'a, T> {
+    /// `T` must impl [`MaxJsonSize`] so the encode buffer can be sized to fit.
+    pub fn result<T: MaxJsonSize>(self, result: &'a T) -> Update<'a, T> {
         Update {
             status: self.status,
             execution_id: self.execution_id,
@@ -62,11 +71,9 @@ impl<'a, R: Serialize> Update<'a, R> {
     }
 }
 
-impl<R: Serialize> ToPayload for Update<'_, R> {
+impl<R: MaxJsonSize> ToPayload for Update<'_, R> {
     fn max_size(&self) -> usize {
-        // Upper bound: executionId (64) + statusReason (1024 + 64 + framing)
-        // + status enum + result allocator. Caller pays only what they use.
-        2048
+        R::MAX_JSON_SIZE + UPDATE_FRAMING_OVERHEAD
     }
 
     fn encode(&self, buf: &mut [u8]) -> Result<usize, PayloadError> {
@@ -100,11 +107,17 @@ mod test {
     use crate::commands::data_types::{CommandResultEntry, ResultMap};
 
     #[cfg(not(feature = "commands_cbor"))]
-    fn encode<R: Serialize>(u: &Update<'_, R>) -> heapless::String<2048> {
+    fn encode<R: MaxJsonSize>(u: &Update<'_, R>) -> heapless::String<2048> {
         let mut buf = [0u8; 2048];
         let len = u.encode(&mut buf).unwrap();
         let s = core::str::from_utf8(&buf[..len]).unwrap();
         heapless::String::try_from(s).unwrap()
+    }
+
+    // Test impl: ResultMap entries are short strings/booleans/blobs.
+    #[cfg(not(feature = "commands_cbor"))]
+    impl MaxJsonSize for ResultMap<'_> {
+        const MAX_JSON_SIZE: usize = 1024;
     }
 
     #[cfg(not(feature = "commands_cbor"))]

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -114,12 +114,6 @@ mod test {
         heapless::String::try_from(s).unwrap()
     }
 
-    // Test impl: ResultMap entries are short strings/booleans/blobs.
-    #[cfg(not(feature = "commands_cbor"))]
-    impl MaxJsonSize for ResultMap<'_> {
-        const MAX_JSON_SIZE: usize = 1024;
-    }
-
     #[cfg(not(feature = "commands_cbor"))]
     #[test]
     fn json_in_progress_minimal() {

--- a/src/defender_metrics/mod.rs
+++ b/src/defender_metrics/mod.rs
@@ -1,5 +1,6 @@
 use crate::mqtt::{
-    DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, QoS, ToPayload,
+    DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, PublishOptions, QoS,
+    ToPayload,
 };
 use data_types::Metric;
 use errors::{ErrorResponse, MetricError};
@@ -113,8 +114,8 @@ impl<'m, C: MqttClient> MetricHandler<'m, C> {
         let sub = self
             .mqtt
             .subscribe(&[
-                (accepted.as_str(), QoS::AtMostOnce),
-                (rejected.as_str(), QoS::AtMostOnce),
+                (accepted.as_str(), QoS::AtLeastOnce),
+                (rejected.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| MetricError::Mqtt)?;
@@ -122,7 +123,11 @@ impl<'m, C: MqttClient> MetricHandler<'m, C> {
         let topic_name = Topic::Publish.format::<MAX_DEFENDER_TOPIC_LEN>(self.mqtt.client_id())?;
 
         self.mqtt
-            .publish(topic_name.as_str(), payload)
+            .publish_with_options(
+                topic_name.as_str(),
+                payload,
+                PublishOptions::new().qos(QoS::AtLeastOnce),
+            )
             .await
             .map_err(|_| {
                 error!("ERROR PUBLISHING PAYLOAD");

--- a/src/jobs/stream.rs
+++ b/src/jobs/stream.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::mqtt::{Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
+use crate::mqtt::{MaxJsonSize, Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
 
 use super::{
     JobError, JobTopic, Jobs, MAX_JOB_ID_LEN, MAX_THING_NAME_LEN, Topic,
@@ -97,7 +97,7 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
     ///
     /// QoS 1 so a transient broker disconnect mid-job doesn't silently
     /// drop the progress update.
-    pub async fn report_progress<S: Serialize>(
+    pub async fn report_progress<S: MaxJsonSize>(
         &self,
         job_id: &str,
         status_details: &S,
@@ -123,7 +123,7 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
     /// Publishes a `SUCCEEDED` status update and waits for the cloud to
     /// acknowledge. Optional `status_details` can carry final result
     /// information.
-    pub async fn succeed_job<S: Serialize>(
+    pub async fn succeed_job<S: MaxJsonSize>(
         &self,
         job_id: &str,
         status_details: Option<&S>,
@@ -144,7 +144,7 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
     ///
     /// Publishes a `FAILED` status update and waits for the cloud to
     /// acknowledge. Optional `status_details` can carry failure information.
-    pub async fn fail_job<S: Serialize>(
+    pub async fn fail_job<S: MaxJsonSize>(
         &self,
         job_id: &str,
         status_details: Option<&S>,
@@ -176,7 +176,7 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
     }
 
     /// Publish a job update with QoS 1 and wait for the cloud to acknowledge.
-    async fn publish_and_wait<S: Serialize>(
+    async fn publish_and_wait<S: MaxJsonSize>(
         &self,
         job_id: &str,
         payload: Update<'_, S>,
@@ -236,6 +236,11 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
 #[derive(Serialize)]
 struct RejectDetails<'a> {
     reason: &'a str,
+}
+
+impl MaxJsonSize for RejectDetails<'_> {
+    // `{"reason":"..."}` framing + a generous reason string.
+    const MAX_JSON_SIZE: usize = 1024;
 }
 
 /// Parse a job execution from an MQTT message (from `notify-next` or

--- a/src/jobs/stream.rs
+++ b/src/jobs/stream.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::mqtt::{MaxJsonSize, Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS};
+use crate::mqtt::{
+    MaxJsonSize, Mqtt, MqttClient, MqttMessage, MqttSubscription, PublishOptions, QoS,
+};
 
 use super::{
     JobError, JobTopic, Jobs, MAX_JOB_ID_LEN, MAX_THING_NAME_LEN, Topic,

--- a/src/jobs/stream.rs
+++ b/src/jobs/stream.rs
@@ -67,8 +67,8 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
             .mqtt
             .0
             .subscribe(&[
-                (notify_topic.as_str(), QoS::AtMostOnce),
-                (describe_topic.as_str(), QoS::AtMostOnce),
+                (notify_topic.as_str(), QoS::AtLeastOnce),
+                (describe_topic.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| JobError::Mqtt)?;
@@ -78,7 +78,11 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
         let topic = describe.topic(client_id)?;
         self.mqtt
             .0
-            .publish(&topic, describe)
+            .publish_with_options(
+                &topic,
+                describe,
+                PublishOptions::new().qos(QoS::AtLeastOnce),
+            )
             .await
             .map_err(|_| JobError::Mqtt)?;
 
@@ -91,8 +95,8 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
     /// `status_details` can be any serializable type describing current
     /// progress.
     ///
-    /// Progress updates use QoS 0 (fire-and-forget) since they are
-    /// non-critical and frequent.
+    /// QoS 1 so a transient broker disconnect mid-job doesn't silently
+    /// drop the progress update.
     pub async fn report_progress<S: Serialize>(
         &self,
         job_id: &str,
@@ -109,7 +113,7 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
 
         self.mqtt
             .0
-            .publish(&topic, payload)
+            .publish_with_options(&topic, payload, PublishOptions::new().qos(QoS::AtLeastOnce))
             .await
             .map_err(|_| JobError::Mqtt)
     }
@@ -188,8 +192,8 @@ impl<'a, C: MqttClient> JobAgent<'a, C> {
             .mqtt
             .0
             .subscribe(&[
-                (accepted_topic.as_str(), QoS::AtMostOnce),
-                (rejected_topic.as_str(), QoS::AtMostOnce),
+                (accepted_topic.as_str(), QoS::AtLeastOnce),
+                (rejected_topic.as_str(), QoS::AtLeastOnce),
             ])
             .await
             .map_err(|_| JobError::Mqtt)?;

--- a/src/jobs/update.rs
+++ b/src/jobs/update.rs
@@ -1,7 +1,13 @@
 use serde::Serialize;
 
 use crate::jobs::{MAX_CLIENT_TOKEN_LEN, data_types::JobStatus};
-use crate::mqtt::{PayloadError, ToPayload};
+use crate::mqtt::{MaxJsonSize, PayloadError, ToPayload};
+
+/// JSON-framing overhead for [`UpdateJobExecutionRequest`]: status enum,
+/// optional flags, and the JSON object itself with all its keys. Add this to
+/// the caller's `status_details` [`MaxJsonSize::MAX_JSON_SIZE`] to size the
+/// encode buffer.
+const UPDATE_FRAMING_OVERHEAD: usize = MAX_CLIENT_TOKEN_LEN + 256;
 
 /// Updates the status of a job execution. You can optionally create a step
 /// timer by setting a value for the stepTimeoutInMinutes property. If you don't
@@ -70,8 +76,11 @@ pub struct UpdateJobExecutionRequest<'a, S: Serialize = ()> {
 ///
 /// The type parameter `S` represents the status details type. Use
 /// [`status_details`](Self::status_details) to set the status details and
-/// change the type parameter.
-pub struct Update<'a, S: Serialize = ()> {
+/// change the type parameter. The encode buffer for this update is sized
+/// from `S::MAX_JSON_SIZE` plus framing overhead, so callers carrying
+/// rich `status_details` payloads should impl [`MaxJsonSize`] with a
+/// generous upper bound.
+pub struct Update<'a, S: MaxJsonSize = ()> {
     status: JobStatus,
     client_token: Option<&'a str>,
     status_details: Option<&'a S>,
@@ -98,7 +107,7 @@ impl<'a> Update<'a, ()> {
     }
 }
 
-impl<'a, S: Serialize> Update<'a, S> {
+impl<'a, S: MaxJsonSize> Update<'a, S> {
     /// Set the client token for request correlation.
     pub fn client_token(self, client_token: &'a str) -> Self {
         assert!(client_token.len() < MAX_CLIENT_TOKEN_LEN);
@@ -111,9 +120,9 @@ impl<'a, S: Serialize> Update<'a, S> {
 
     /// Set the status details.
     ///
-    /// This method accepts any type that implements `Serialize`, allowing
-    /// different consumers to provide different status detail structures.
-    pub fn status_details<T: Serialize>(self, status_details: &'a T) -> Update<'a, T> {
+    /// `T` must impl [`MaxJsonSize`] so the publish path can size the encode
+    /// buffer to the worst-case JSON size of `T`.
+    pub fn status_details<T: MaxJsonSize>(self, status_details: &'a T) -> Update<'a, T> {
         Update {
             status: self.status,
             client_token: self.client_token,
@@ -167,9 +176,9 @@ impl<'a, S: Serialize> Update<'a, S> {
     }
 }
 
-impl<S: Serialize> ToPayload for Update<'_, S> {
+impl<S: MaxJsonSize> ToPayload for Update<'_, S> {
     fn max_size(&self) -> usize {
-        512
+        S::MAX_JSON_SIZE + UPDATE_FRAMING_OVERHEAD
     }
 
     fn encode(&self, buf: &mut [u8]) -> Result<usize, PayloadError> {
@@ -247,6 +256,9 @@ mod test {
         struct TestStatus {
             self_test: &'static str,
             progress: &'static str,
+        }
+        impl MaxJsonSize for TestStatus {
+            const MAX_JSON_SIZE: usize = 128;
         }
 
         let status = TestStatus {

--- a/src/mqtt/mod.rs
+++ b/src/mqtt/mod.rs
@@ -161,6 +161,35 @@ pub trait ToPayload {
     fn encode(&self, buf: &mut [u8]) -> Result<usize, PayloadError>;
 }
 
+/// Upper bound on the JSON-serialized size of `Self`.
+///
+/// Used by [`ToPayload`] implementations on generic-`Serialize` wrapper
+/// types (e.g. [`crate::jobs::Update`], [`crate::commands::Update`],
+/// [`crate::provisioning::RegisterThingRequest`]) to size their encode
+/// buffers. `serde_json_core::to_slice` writes into a fixed buffer and
+/// fails with [`PayloadError::BufferSize`] on overflow — when that happens
+/// inside a publish path the failure surfaces as a generic MQTT-style
+/// error and masks the real cause. Implementing this trait pre-sizes the
+/// buffer to the actual payload's needs without forcing a runtime knob on
+/// the caller.
+///
+/// `Serialize` is a super-trait: a `MAX_JSON_SIZE` only makes sense for
+/// types that actually have a JSON form to bound.
+pub trait MaxJsonSize: serde::Serialize {
+    /// Worst-case JSON-encoded size of `Self`, in bytes.
+    ///
+    /// Pick a generous upper bound — over-estimating wastes only a one-shot
+    /// allocation in the publish path, while under-estimating drops the
+    /// publish with [`PayloadError::BufferSize`].
+    const MAX_JSON_SIZE: usize;
+}
+
+/// `()` serializes to `null` (4 bytes). Keeps `Update<()>` and
+/// `RegisterThingRequest<()>` ergonomic for callers with no payload.
+impl MaxJsonSize for () {
+    const MAX_JSON_SIZE: usize = 4;
+}
+
 impl ToPayload for &[u8] {
     fn max_size(&self) -> usize {
         self.len()

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -5,9 +5,13 @@ pub mod topics;
 use core::future::Future;
 
 use crate::mqtt::{
-    DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, PublishOptions, QoS,
+    DeferredPayload, MaxJsonSize, MqttClient, MqttMessage, MqttSubscription, PayloadError,
+    PublishOptions, QoS,
 };
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{Deserialize, de::DeserializeOwned};
+// Used as a method call only on the cbor encoding branch below.
+#[cfg_attr(not(feature = "provision_cbor"), allow(unused_imports))]
+use serde::Serialize;
 
 pub use error::Error;
 
@@ -37,10 +41,10 @@ pub struct Credentials<'a> {
 pub struct FleetProvisioner;
 
 impl FleetProvisioner {
-    pub fn provision<'m, Cfg, M: MqttClient>(
+    pub fn provision<'m, Cfg, M: MqttClient, P: MaxJsonSize + 'm>(
         mqtt: &'m M,
         template_name: &'m str,
-        parameters: Option<impl Serialize + 'm>,
+        parameters: Option<P>,
         credential_handler: &'m mut impl CredentialHandler,
     ) -> impl Future<Output = Result<Option<Cfg>, Error>> + 'm
     where
@@ -56,10 +60,10 @@ impl FleetProvisioner {
         )
     }
 
-    pub fn provision_csr<'m, Cfg, M: MqttClient>(
+    pub fn provision_csr<'m, Cfg, M: MqttClient, P: MaxJsonSize + 'm>(
         mqtt: &'m M,
         template_name: &'m str,
-        parameters: Option<impl Serialize + 'm>,
+        parameters: Option<P>,
         csr: &'m str,
         credential_handler: &'m mut impl CredentialHandler,
     ) -> impl Future<Output = Result<Option<Cfg>, Error>> + 'm
@@ -77,10 +81,10 @@ impl FleetProvisioner {
     }
 
     #[cfg(feature = "provision_cbor")]
-    pub fn provision_cbor<'m, Cfg, M: MqttClient>(
+    pub fn provision_cbor<'m, Cfg, M: MqttClient, P: MaxJsonSize + 'm>(
         mqtt: &'m M,
         template_name: &'m str,
-        parameters: Option<impl Serialize + 'm>,
+        parameters: Option<P>,
         credential_handler: &'m mut impl CredentialHandler,
     ) -> impl Future<Output = Result<Option<Cfg>, Error>> + 'm
     where
@@ -97,10 +101,10 @@ impl FleetProvisioner {
     }
 
     #[cfg(feature = "provision_cbor")]
-    pub fn provision_csr_cbor<'m, Cfg, M: MqttClient>(
+    pub fn provision_csr_cbor<'m, Cfg, M: MqttClient, P: MaxJsonSize + 'm>(
         mqtt: &'m M,
         template_name: &'m str,
-        parameters: Option<impl Serialize + 'm>,
+        parameters: Option<P>,
         csr: &'m str,
         credential_handler: &'m mut impl CredentialHandler,
     ) -> impl Future<Output = Result<Option<Cfg>, Error>> + 'm
@@ -117,10 +121,10 @@ impl FleetProvisioner {
         )
     }
 
-    async fn provision_inner<Cfg, M: MqttClient>(
+    async fn provision_inner<Cfg, M: MqttClient, P: MaxJsonSize>(
         mqtt: &M,
         template_name: &str,
-        parameters: Option<impl Serialize>,
+        parameters: Option<P>,
         csr: Option<&str>,
         credential_handler: &mut impl CredentialHandler,
         payload_format: PayloadFormat,
@@ -198,6 +202,8 @@ impl FleetProvisioner {
             parameters,
         };
 
+        // 512-byte ownership token + framing (~64) + caller's parameters.
+        const REGISTER_FRAMING_OVERHEAD: usize = 576;
         let payload = DeferredPayload::new(
             |buf: &mut [u8]| {
                 Ok(match payload_format {
@@ -215,7 +221,7 @@ impl FleetProvisioner {
                         .map_err(|_| PayloadError::BufferSize)?,
                 })
             },
-            1024,
+            P::MAX_JSON_SIZE + REGISTER_FRAMING_OVERHEAD,
         );
 
         debug!("Starting RegisterThing");

--- a/src/transfer/status_details.rs
+++ b/src/transfer/status_details.rs
@@ -8,6 +8,8 @@ use core::fmt::Write;
 
 use serde::{Serialize, Serializer, ser::SerializeMap};
 
+use crate::mqtt::MaxJsonSize;
+
 /// Trait for types that can contribute fields to status details.
 ///
 /// Implement this trait to add custom fields to the job status details
@@ -31,6 +33,13 @@ use serde::{Serialize, Serializer, ser::SerializeMap};
 /// }
 /// ```
 pub trait StatusDetailsExt: Default {
+    /// Worst-case JSON size of the fields this extension contributes via
+    /// [`serialize_into_map`](Self::serialize_into_map). Used to size the
+    /// encode buffer when this extension is combined with the base
+    /// [`StatusDetails`] in [`CombinedStatusDetails`]. Pick a generous upper
+    /// bound — under-estimating drops the publish.
+    const MAX_EXTRA_JSON_SIZE: usize;
+
     /// Serialize this type's fields into an existing map.
     fn serialize_into_map<S: SerializeMap>(&self, map: &mut S) -> Result<(), S::Error>;
 
@@ -49,6 +58,8 @@ pub trait StatusDetailsExt: Default {
 
 /// Default implementation for `()` - no extra fields.
 impl StatusDetailsExt for () {
+    const MAX_EXTRA_JSON_SIZE: usize = 0;
+
     fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
         Ok(())
     }
@@ -162,6 +173,24 @@ impl<E: StatusDetailsExt> Serialize for CombinedStatusDetails<'_, E> {
     }
 }
 
+/// Worst-case JSON size of the base [`StatusDetails`] fields.
+///
+/// Each optional field contributes its key + quoted value + comma:
+/// - `self_test` (heapless::String<12>): ~28 bytes
+/// - `progress`  (heapless::String<16>): ~32 bytes
+/// - `reason`    (heapless::String<24>): ~36 bytes
+/// - `error_code` (u16, up to 5 digits): ~21 bytes
+/// Plus enclosing `{}` and a few bytes of slack for commas/whitespace.
+const STATUS_DETAILS_MAX_JSON_SIZE: usize = 192;
+
+impl MaxJsonSize for StatusDetails {
+    const MAX_JSON_SIZE: usize = STATUS_DETAILS_MAX_JSON_SIZE;
+}
+
+impl<E: StatusDetailsExt> MaxJsonSize for CombinedStatusDetails<'_, E> {
+    const MAX_JSON_SIZE: usize = STATUS_DETAILS_MAX_JSON_SIZE + E::MAX_EXTRA_JSON_SIZE;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,6 +227,9 @@ mod tests {
     }
 
     impl StatusDetailsExt for TestContext {
+        // `"device_temp":<3 digits>` plus a comma — generous bound.
+        const MAX_EXTRA_JSON_SIZE: usize = 32;
+
         fn serialize_into_map<S: SerializeMap>(&self, map: &mut S) -> Result<(), S::Error> {
             map.serialize_entry("device_temp", &self.device_temp)?;
             Ok(())

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -93,7 +93,7 @@ async fn run_happy_path(ctx: &aws_commands::CommandTestContext) -> Result<(), St
         .keepalive_interval(embassy_time::Duration::from_secs(50))
         .build();
 
-    static STATE: StaticCell<State<NoopRawMutex, 4096, { 4096 * 4 }>> = StaticCell::new();
+    static STATE: StaticCell<State<NoopRawMutex, 8192, { 4096 * 4 }>> = StaticCell::new();
     let state = STATE.init(State::new());
     let (mut stack, client) = mqttrust::new(state, config);
 

--- a/tests/common/file_handler.rs
+++ b/tests/common/file_handler.rs
@@ -15,6 +15,9 @@ pub struct TestStatusDetails {
 }
 
 impl StatusDetailsExt for TestStatusDetails {
+    // `"firmware_version":"<short string>"` plus comma framing — generous bound.
+    const MAX_EXTRA_JSON_SIZE: usize = 64;
+
     fn serialize_into_map<S: SerializeMap>(&self, map: &mut S) -> Result<(), S::Error> {
         map.serialize_entry("firmware_version", self.firmware_version)?;
         Ok(())

--- a/tests/provisioning.rs
+++ b/tests/provisioning.rs
@@ -51,6 +51,11 @@ struct Parameters<'a> {
     signature: &'a str,
 }
 
+impl rustot::mqtt::MaxJsonSize for Parameters<'_> {
+    // `{"uuid":"<36-char uuid>","signature":"<short>"}` plus framing — small.
+    const MAX_JSON_SIZE: usize = 256;
+}
+
 #[derive(Debug, Deserialize, PartialEq)]
 struct DeviceConfig {
     #[serde(rename = "SoftwareId")]
@@ -96,14 +101,14 @@ async fn test_provisioning() {
     let mut credential_handler = CredentialDAO { creds: None };
 
     #[cfg(not(feature = "provision_cbor"))]
-    let provision_fut = FleetProvisioner::provision::<DeviceConfig, _>(
+    let provision_fut = FleetProvisioner::provision::<DeviceConfig, _, _>(
         &client,
         &template_name,
         Some(parameters),
         &mut credential_handler,
     );
     #[cfg(feature = "provision_cbor")]
-    let provision_fut = FleetProvisioner::provision_cbor::<DeviceConfig, _>(
+    let provision_fut = FleetProvisioner::provision_cbor::<DeviceConfig, _, _>(
         &client,
         &template_name,
         Some(parameters),


### PR DESCRIPTION
## Summary

`Update::max_size()` (jobs and commands) and the provisioning register buffer were hardcoded values that overflow on non-trivial payloads — `serde_json_core::to_slice` returns `PayloadError::BufferSize` and the publish surfaces as `JobError::Mqtt` / `Error::BufferSize`. What's really a buffer-size bug looks like an MQTT/broker problem.

Observed on factbird-edge `factory_reset`: the post-cleanup `IN_PROGRESS` update carries a 3-participant report (~700 bytes JSON) and overflows the hardcoded 512-byte buffer every time.

Bumping the constants high penalises `mqttrust`/no_std users who pay for an embedded buffer they don't need. Make the size caller-known via the type system instead.

## What's new

```rust
/// Upper bound on the JSON-serialized size of `Self`. Used by `ToPayload`
/// implementations on generic-Serialize wrapper types to size their encode
/// buffers.
pub trait MaxJsonSize: serde::Serialize {
    const MAX_JSON_SIZE: usize;
}

impl MaxJsonSize for () {
    const MAX_JSON_SIZE: usize = 4;
}
```

`Serialize` is a super-trait — a `MAX_JSON_SIZE` only makes sense for a JSON-encodable type, and use sites get a single tighter bound (`S: MaxJsonSize`) instead of the compound `S: Serialize + MaxJsonSize`.

## Sites updated

| Site | Before | After |
|---|---|---|
| `jobs::Update<'a, S>` (and `report_progress` / `succeed_job` / `fail_job` / `publish_and_wait`) | `S: Serialize`, hardcoded 512 | `S: MaxJsonSize`, `S::MAX_JSON_SIZE + framing` |
| `commands::Update<'a, R>` (and `succeed` / `publish_and_wait`) | `R: Serialize`, hardcoded 2048 | `R: MaxJsonSize`, `R::MAX_JSON_SIZE + framing` |
| `provisioning::FleetProvisioner::provision*` `parameters` | `impl Serialize`, hardcoded 1024 | `impl MaxJsonSize`, `P::MAX_JSON_SIZE + framing` |
| `transfer::status_details::StatusDetailsExt` | (no size info) | gains `const MAX_EXTRA_JSON_SIZE: usize` |
| `StatusDetails`, `CombinedStatusDetails<E>` | (no `MaxJsonSize`) | impl `MaxJsonSize`; combined delegates to `E::MAX_EXTRA_JSON_SIZE` |

## Breaking change

Callers passing a custom `status_details` (jobs), `result` (commands), or provisioning `parameters` type need to add an impl:

```rust
impl MaxJsonSize for MyStatusDetails {
    const MAX_JSON_SIZE: usize = 1024;
}
```

`StatusDetailsExt` impls likewise need to declare `MAX_EXTRA_JSON_SIZE`.

## Test plan

- [x] `cargo check` (default features)
- [x] `cargo check --no-default-features --features std,mqtt_greengrass`
- [x] `cargo test --no-default-features --features std,mqtt_mqttrust,commands_cbor,metric_cbor --lib` — 88/88 still passing
- [ ] Hardware: factbird-edge factory_reset reaches a terminal state in cloud (CleanupCompleted progress reaches the cloud after the caller's status_details type declares an appropriate `MAX_JSON_SIZE`)

## Follow-ups (not in this PR)

- `JobError::Mqtt` mapping in `jobs/stream.rs` discards the underlying error type. Surfacing the typed error would prevent future buffer-overflow / serialization issues from being misdiagnosed as broker problems.
- `shadows::ShadowRoot::MAX_PAYLOAD_SIZE` follows a similar per-trait const pattern. Could optionally be unified under `MaxJsonSize` later, but that's a wider refactor.