### PR TITLE
feat(shadows): gate publish methods on initial cloud sync

### DIFF
--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -206,17 +206,8 @@ where
                         "[{:?}] Delta reports new desired value. Changing local value...",
                         S::NAME.unwrap_or(CLASSIC_SHADOW),
                     );
-                    match self.apply_delta_and_ack(&delta).await {
-                        Ok(state) => return Ok((state, Some(delta))),
-                        Err(e) => {
-                            // Force re-subscribe on next call — without
-                            // this, the subscription survives MQTT
-                            // reconnection (clean_start = false) and the
-                            // delta is never re-delivered.
-                            self.subscription.lock().await.take();
-                            return Err(e);
-                        }
-                    }
+                    let state = self.apply_delta_and_ack(&delta).await?;
+                    return Ok((state, Some(delta)));
                 }
                 Ok(None) => continue,
                 Err(()) => {

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -10,6 +10,18 @@ use crate::mqtt::{
     ToPayload,
 };
 
+use crate::shadows::{
+    ShadowRoot,
+    data_types::{
+        AcceptedResponse, DeltaResponse, DeltaState, ErrorResponse, Request, RequestState,
+    },
+    error::{Error, ShadowError},
+    store::StateStore,
+    topics::{Topic, max_topic_len},
+};
+
+use super::Shadow;
+
 /// Drop-guard that clears `Shadow::subscription` unless explicitly disarmed.
 ///
 /// `handle_delta`'s lazy-subscribe path installs the delta-topic subscription
@@ -48,18 +60,6 @@ impl<M: RawMutex, T> Drop for ResetSubscriptionOnDrop<'_, M, T> {
         }
     }
 }
-
-use crate::shadows::{
-    ShadowRoot,
-    data_types::{
-        AcceptedResponse, DeltaResponse, DeltaState, ErrorResponse, Request, RequestState,
-    },
-    error::{Error, ShadowError},
-    store::StateStore,
-    topics::{Topic, max_topic_len},
-};
-
-use super::Shadow;
 
 /// Overhead for partial request JSON formatting.
 const PARTIAL_REQUEST_OVERHEAD: usize = 64;

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -2,7 +2,6 @@
 
 use core::ops::DerefMut;
 
-use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
 use serde::Serialize;
 
 use crate::mqtt::{
@@ -21,45 +20,6 @@ use crate::shadows::{
 };
 
 use super::Shadow;
-
-/// Drop-guard that clears `Shadow::subscription` unless explicitly disarmed.
-///
-/// `wait_delta`'s first-call path installs the delta-topic subscription before
-/// the initial get + apply + ack has finished. If the future is cancelled in
-/// that window (e.g. by a `tokio::select!` branch firing), the subscription
-/// would be left in place and every subsequent call would silently wait for a
-/// delta message on the subscription topic — a permanent hang, because the
-/// cloud only publishes deltas when `desired` changes.
-///
-/// This guard restores the invariant `subscription == Some <=> initial sync
-/// has fully completed` by taking the subscription back on any early exit.
-/// `disarm()` is called on the happy path to keep the subscription cached.
-struct ResetSubscriptionOnDrop<'s, M: RawMutex, T> {
-    subscription: &'s Mutex<M, Option<T>>,
-    armed: bool,
-}
-
-impl<M: RawMutex, T> ResetSubscriptionOnDrop<'_, M, T> {
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl<M: RawMutex, T> Drop for ResetSubscriptionOnDrop<'_, M, T> {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        // `try_lock` is synchronous; Drop cannot await. In practice the lock
-        // is free here: any holder would have been on the cancelled future's
-        // stack and its guard is dropped before ours. If the lock is somehow
-        // contended, skipping the reset is safe — we'd merely miss the
-        // cleanup for this one cancellation, which is better than blocking.
-        if let Ok(mut guard) = self.subscription.try_lock() {
-            guard.take();
-        }
-    }
-}
 
 /// Overhead for partial request JSON formatting.
 const PARTIAL_REQUEST_OVERHEAD: usize = 64;
@@ -84,17 +44,35 @@ where
     // Private MQTT Helper Methods (ported from ShadowHandler)
     // =========================================================================
 
-    /// Subscribe to delta topic and wait for message.
-    ///
-    /// On first call, subscribes to the delta topic and fetches current shadow
-    /// state from cloud. On subsequent calls, waits for delta messages.
+    /// Run the initial subscribe + GET (with 404→`create_shadow` fallback) once.
+    /// Gates publish-side methods so AWS can't auto-create a partial cloud doc
+    /// from a stray `update_reported` that beat the first sync.
+    pub(crate) async fn ensure_initialized(&self) -> Result<(), Error> {
+        let mut init_guard = self.initialized.lock().await;
+        if *init_guard {
+            return Ok(());
+        }
+
+        warn!(
+            "[{:?}] shadow not initialized — running initial sync",
+            S::NAME.unwrap_or(CLASSIC_SHADOW)
+        );
+
+        self.sync_shadow().await?;
+
+        *init_guard = true;
+        Ok(())
+    }
+
+    /// Await the next delta. Assumes `ensure_initialized` has run.
+    /// On clean-session reconnect, resubscribes without re-syncing.
     async fn handle_delta(&self) -> Result<Option<S::Delta>, Error> {
         // Loop to automatically retry on clean session
         loop {
             let mut sub_ref = self.subscription.lock().await;
 
             if sub_ref.is_none() {
-                debug!("Subscribing to delta topic");
+                debug!("Resubscribing to delta topic after clean session");
                 self.mqtt.wait_connected().await;
 
                 let topic = Topic::UpdateDelta.format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
@@ -110,14 +88,7 @@ where
                     .map_err(|_| Error::Mqtt)?;
 
                 let _ = sub_ref.insert(sub);
-
-                let delta_state = self.get_shadow_from_cloud().await?;
-
-                // Prefer desired over delta on initial sync. The delta is
-                // computed against cloud's reported state which may be stale
-                // (e.g. after factory reset). Using the full desired ensures
-                // the device converges to the correct state regardless.
-                return Ok(delta_state.desired.or(delta_state.delta));
+                continue;
             }
 
             // Scope the mutable borrow so we can call sub_ref.take() on
@@ -387,18 +358,7 @@ where
             S::NAME.unwrap_or(CLASSIC_SHADOW)
         );
 
-        // If this is a first call, arm a drop-guard that clears the
-        // subscription on any early exit (cancellation, error, panic). This
-        // preserves the invariant that `subscription == Some` implies the
-        // initial sync completed: without it, cancellation between
-        // `handle_delta` installing the subscription and `update_shadow`
-        // finishing the ack leaves the next caller to wait forever on a
-        // delta topic that only fires when `desired` changes cloud-side.
-        let is_first_call = self.subscription.lock().await.is_none();
-        let mut reset_guard = ResetSubscriptionOnDrop {
-            subscription: &self.subscription,
-            armed: is_first_call,
-        };
+        self.ensure_initialized().await?;
 
         let delta = self.handle_delta().await?;
 
@@ -419,11 +379,11 @@ where
             let reported = state.into_partial_reported(delta);
             let cleanup = state.desired_cleanup(delta);
             if let Err(e) = self.update_shadow(cleanup, Some(reported)).await {
-                // Force re-fetch on next call — without this, the subscription
-                // survives MQTT reconnection (clean_start=false) and the delta
-                // is never re-delivered, causing permanent desync.
+                // Force re-subscribe on next call — without this, the
+                // subscription survives MQTT reconnection (clean_start=false)
+                // and the delta is never re-delivered, causing permanent
+                // desync.
                 self.subscription.lock().await.take();
-                reset_guard.disarm();
                 return Err(e);
             }
 
@@ -435,9 +395,6 @@ where
                 .await
                 .map_err(|_| Error::DaoWrite)?
         };
-
-        // Initial sync succeeded — keep the cached subscription for the loop.
-        reset_guard.disarm();
 
         info!(
             "[{:?}] wait_delta: return has_delta={}",
@@ -471,6 +428,8 @@ where
     /// shadow.update_reported(state).await?;
     /// ```
     pub async fn update_reported(&self, reported: impl Into<S::Reported>) -> Result<(), Error> {
+        self.ensure_initialized().await?;
+
         let reported: S::Reported = reported.into();
 
         // Persist any report_only(persist) fields to KV before sending to cloud.
@@ -513,6 +472,8 @@ where
     /// ).await?;
     /// ```
     pub async fn update_desired(&self, desired: impl Into<S::Delta>) -> Result<(), Error> {
+        self.ensure_initialized().await?;
+
         let state: S = self
             .store
             .get_state(Self::prefix())
@@ -655,6 +616,9 @@ where
             .delete_state(Self::prefix())
             .await
             .map_err(|_| Error::DaoWrite)?;
+
+        // Reset the gate so the next publish re-initializes the cloud doc.
+        *self.initialized.lock().await = false;
 
         Ok(())
     }

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -1,6 +1,7 @@
 //! MQTT cloud communication methods for Shadow
 
 use core::ops::DerefMut;
+use core::sync::atomic::Ordering;
 
 use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
 use serde::Serialize;
@@ -84,15 +85,17 @@ where
     // Private MQTT Helper Methods (ported from ShadowHandler)
     // =========================================================================
 
-    /// Ensure the cloud doc exists. Holds a mutex so only one caller per
-    /// shadow runs the initial GET; the rest wait, then short-circuit on the
-    /// flag. The delta from the GET is intentionally discarded — `wait_delta`
-    /// and `sync_shadow` do their own GET to retrieve and apply any pending
-    /// delta. Publish-side callers (`update_reported`, etc.) only need the
-    /// doc to exist.
+    /// Ensure the cloud doc exists. Short-circuits if the gate is set; otherwise
+    /// runs a GET (with 404→`create_shadow_inner` fallback). The delta from the
+    /// GET is intentionally discarded — `wait_delta` and `sync_shadow` do their
+    /// own GET to retrieve and apply any pending delta. Publish-side callers
+    /// (`update_reported`, etc.) only need the doc to exist.
+    ///
+    /// Concurrent first-time callers may both run a GET; both are safe and
+    /// idempotent on the cloud side. The cost is one extra round-trip in the
+    /// race window, traded for not holding a mutex across the GET.
     pub(crate) async fn ensure_initialized(&self) -> Result<(), Error> {
-        let mut init_guard = self.initialized.lock().await;
-        if *init_guard {
+        if self.initialized.load(Ordering::Acquire) {
             return Ok(());
         }
 
@@ -104,7 +107,7 @@ where
         // GET (404 falls back to `create_shadow_inner`). Discard the delta.
         let _ = self.get_shadow_from_cloud().await?;
 
-        *init_guard = true;
+        self.initialized.store(true, Ordering::Release);
         Ok(())
     }
 
@@ -579,7 +582,7 @@ where
         let delta_state = self.get_shadow_from_cloud().await?;
         // A successful GET (or 404→create) confirms the cloud doc exists,
         // so the gate flips.
-        *self.initialized.lock().await = true;
+        self.initialized.store(true, Ordering::Release);
         let delta = delta_state.desired.or(delta_state.delta);
 
         let state = if let Some(ref d) = delta {
@@ -613,7 +616,7 @@ where
         // cloud doc now exists with our defaults, so the gate flips. Locks
         // outside the get_shadow_from_cloud → 404 path (which uses _inner
         // directly and avoids the relock that would deadlock).
-        *self.initialized.lock().await = true;
+        self.initialized.store(true, Ordering::Release);
         Ok(r)
     }
 
@@ -699,7 +702,7 @@ where
             .map_err(|_| Error::DaoWrite)?;
 
         // Reset the gate so the next publish re-initializes the cloud doc.
-        *self.initialized.lock().await = false;
+        self.initialized.store(false, Ordering::Release);
 
         Ok(())
     }

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -1,7 +1,6 @@
 //! MQTT cloud communication methods for Shadow
 
 use core::ops::DerefMut;
-use core::sync::atomic::Ordering;
 
 use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
 use serde::Serialize;
@@ -85,17 +84,15 @@ where
     // Private MQTT Helper Methods (ported from ShadowHandler)
     // =========================================================================
 
-    /// Ensure the cloud doc exists. Short-circuits if the gate is set; otherwise
-    /// runs a GET (with 404→`create_shadow_inner` fallback). The delta from the
-    /// GET is intentionally discarded — `wait_delta` and `sync_shadow` do their
-    /// own GET to retrieve and apply any pending delta. Publish-side callers
-    /// (`update_reported`, etc.) only need the doc to exist.
-    ///
-    /// Concurrent first-time callers may both run a GET; both are safe and
-    /// idempotent on the cloud side. The cost is one extra round-trip in the
-    /// race window, traded for not holding a mutex across the GET.
+    /// Ensure the cloud doc exists. Holds a mutex so only one caller per
+    /// shadow runs the initial GET; the rest wait, then short-circuit on the
+    /// flag. The delta from the GET is intentionally discarded — `wait_delta`
+    /// and `sync_shadow` do their own GET to retrieve and apply any pending
+    /// delta. Publish-side callers (`update_reported`, etc.) only need the
+    /// doc to exist.
     pub(crate) async fn ensure_initialized(&self) -> Result<(), Error> {
-        if self.initialized.load(Ordering::Acquire) {
+        let mut init_guard = self.initialized.lock().await;
+        if *init_guard {
             return Ok(());
         }
 
@@ -107,7 +104,7 @@ where
         // GET (404 falls back to `create_shadow_inner`). Discard the delta.
         let _ = self.get_shadow_from_cloud().await?;
 
-        self.initialized.store(true, Ordering::Release);
+        *init_guard = true;
         Ok(())
     }
 
@@ -582,7 +579,7 @@ where
         let delta_state = self.get_shadow_from_cloud().await?;
         // A successful GET (or 404→create) confirms the cloud doc exists,
         // so the gate flips.
-        self.initialized.store(true, Ordering::Release);
+        *self.initialized.lock().await = true;
         let delta = delta_state.desired.or(delta_state.delta);
 
         let state = if let Some(ref d) = delta {
@@ -616,7 +613,7 @@ where
         // cloud doc now exists with our defaults, so the gate flips. Locks
         // outside the get_shadow_from_cloud → 404 path (which uses _inner
         // directly and avoids the relock that would deadlock).
-        self.initialized.store(true, Ordering::Release);
+        *self.initialized.lock().await = true;
         Ok(r)
     }
 
@@ -702,7 +699,7 @@ where
             .map_err(|_| Error::DaoWrite)?;
 
         // Reset the gate so the next publish re-initializes the cloud doc.
-        self.initialized.store(false, Ordering::Release);
+        *self.initialized.lock().await = false;
 
         Ok(())
     }

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -58,7 +58,7 @@ where
             S::NAME.unwrap_or(CLASSIC_SHADOW)
         );
 
-        self.sync_shadow().await?;
+        self.sync_shadow_inner().await?;
 
         *init_guard = true;
         Ok(())
@@ -507,6 +507,18 @@ where
     /// let state = shadow.sync_shadow().await?;  // Sync with cloud
     /// ```
     pub async fn sync_shadow(&self) -> Result<S, Error> {
+        let state = self.sync_shadow_inner().await?;
+        // A successful sync satisfies the `ensure_initialized` precondition,
+        // so flip the gate. Without this, the next `wait_delta` would re-run
+        // the sync via `ensure_initialized`, consuming the next pending delta
+        // via GET before `handle_delta` ever subscribes.
+        *self.initialized.lock().await = true;
+        Ok(state)
+    }
+
+    /// Inner sync — does the GET/apply/ack but does not flip `initialized`.
+    /// Used by `ensure_initialized`, which holds the `initialized` lock.
+    async fn sync_shadow_inner(&self) -> Result<S, Error> {
         let delta_state = self.get_shadow_from_cloud().await?;
 
         // Prefer `desired` over `delta` to match `wait_delta`. The cloud's

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -2,12 +2,52 @@
 
 use core::ops::DerefMut;
 
+use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
 use serde::Serialize;
 
 use crate::mqtt::{
     DeferredPayload, MqttClient, MqttMessage, MqttSubscription, PayloadError, PublishOptions, QoS,
     ToPayload,
 };
+
+/// Drop-guard that clears `Shadow::subscription` unless explicitly disarmed.
+///
+/// `handle_delta`'s lazy-subscribe path installs the delta-topic subscription
+/// before the initial GET drain has finished. If the future is cancelled in
+/// that window (e.g. a `tokio::select!` branch firing), the subscription
+/// would be left in place and every subsequent call would silently wait for
+/// a delta message on the subscription topic — a permanent hang, because
+/// the cloud only publishes deltas when `desired` changes.
+///
+/// This guard restores the invariant `subscription == Some <=> initial sync
+/// has fully completed` by taking the subscription back on any early exit.
+/// `disarm()` is called on the happy path to keep the subscription cached.
+struct ResetSubscriptionOnDrop<'s, M: RawMutex, T> {
+    subscription: &'s Mutex<M, Option<T>>,
+    armed: bool,
+}
+
+impl<M: RawMutex, T> ResetSubscriptionOnDrop<'_, M, T> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl<M: RawMutex, T> Drop for ResetSubscriptionOnDrop<'_, M, T> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // `try_lock` is synchronous; Drop cannot await. In practice the lock
+        // is free here: any holder would have been on the cancelled future's
+        // stack and its guard is dropped before ours. If the lock is somehow
+        // contended, skipping the reset is safe — we'd merely miss the
+        // cleanup for this one cancellation, which is better than blocking.
+        if let Ok(mut guard) = self.subscription.try_lock() {
+            guard.take();
+        }
+    }
+}
 
 use crate::shadows::{
     ShadowRoot,
@@ -113,9 +153,20 @@ where
                 let _ = sub_ref.insert(sub);
                 drop(sub_ref);
 
+                // Cancellation-safety: if the future is dropped between the
+                // subscription being cached and the drain completing, clear
+                // the cache on unwind so the next caller re-runs the initial
+                // sync instead of blocking on the delta topic.
+                let mut reset_guard = ResetSubscriptionOnDrop {
+                    subscription: &self.subscription,
+                    armed: true,
+                };
+
                 // Drain pending state via GET. If a delta came through,
                 // return it. Otherwise loop back and await a live one.
                 let (state, delta) = self.sync_shadow().await?;
+                reset_guard.disarm();
+
                 if delta.is_some() {
                     return Ok((state, delta));
                 }

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -44,9 +44,12 @@ where
     // Private MQTT Helper Methods (ported from ShadowHandler)
     // =========================================================================
 
-    /// Run the initial subscribe + GET (with 404→`create_shadow` fallback) once.
-    /// Gates publish-side methods so AWS can't auto-create a partial cloud doc
-    /// from a stray `update_reported` that beat the first sync.
+    /// Ensure the cloud doc exists. Holds a mutex so only one caller per
+    /// shadow runs the initial GET; the rest wait, then short-circuit on the
+    /// flag. The delta from the GET is intentionally discarded — `wait_delta`
+    /// and `sync_shadow` do their own GET to retrieve and apply any pending
+    /// delta. Publish-side callers (`update_reported`, etc.) only need the
+    /// doc to exist.
     pub(crate) async fn ensure_initialized(&self) -> Result<(), Error> {
         let mut init_guard = self.initialized.lock().await;
         if *init_guard {
@@ -54,25 +57,45 @@ where
         }
 
         warn!(
-            "[{:?}] shadow not initialized — running initial sync",
+            "[{:?}] shadow not initialized — running initial GET",
             S::NAME.unwrap_or(CLASSIC_SHADOW)
         );
 
-        self.sync_shadow_inner().await?;
+        // GET (404 falls back to `create_shadow_inner`). Discard the delta.
+        let _ = self.get_shadow_from_cloud().await?;
 
         *init_guard = true;
         Ok(())
     }
 
-    /// Await the next delta. Assumes `ensure_initialized` has run.
-    /// On clean-session reconnect, resubscribes without re-syncing.
-    async fn handle_delta(&self) -> Result<Option<S::Delta>, Error> {
-        // Loop to automatically retry on clean session
+    /// Apply a delta to local state, then ack the cloud with the resulting
+    /// partial reported (plus any desired-side cleanup for variant switches).
+    async fn apply_delta_and_ack(&self, delta: &S::Delta) -> Result<S, Error> {
+        let state = self
+            .apply_and_save(delta)
+            .await
+            .map_err(|_| Error::DaoWrite)?;
+        let reported = state.into_partial_reported(delta);
+        let cleanup = state.desired_cleanup(delta);
+        self.update_shadow(cleanup, Some(reported)).await?;
+        Ok(state)
+    }
+
+    /// Await the next delta and return both it and the resulting state.
+    ///
+    /// Lazily (re)subscribes to the delta topic on first call and on
+    /// clean-session reconnect; each (re)subscribe is followed by a GET so
+    /// that any pending cloud state — including deltas that occurred while
+    /// not subscribed — is drained as a delta immediately. Returns as soon
+    /// as a delta is available, either from the GET drain or from a live
+    /// subscription message. Echo messages and empty-state messages are
+    /// silently looped over.
+    async fn handle_delta(&self) -> Result<(S, Option<S::Delta>), Error> {
         loop {
             let mut sub_ref = self.subscription.lock().await;
 
             if sub_ref.is_none() {
-                debug!("Resubscribing to delta topic after clean session");
+                debug!("Subscribing to delta topic");
                 self.mqtt.wait_connected().await;
 
                 let topic = Topic::UpdateDelta.format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
@@ -88,13 +111,21 @@ where
                     .map_err(|_| Error::Mqtt)?;
 
                 let _ = sub_ref.insert(sub);
+                drop(sub_ref);
+
+                // Drain pending state via GET. If a delta came through,
+                // return it. Otherwise loop back and await a live one.
+                let (state, delta) = self.sync_shadow().await?;
+                if delta.is_some() {
+                    return Ok((state, delta));
+                }
                 continue;
             }
 
             // Scope the mutable borrow so we can call sub_ref.take() on
             // clean-session below. The parsed DeltaResponse borrows from
             // the message payload, so everything must resolve in this block.
-            let result = {
+            let result: Result<Option<S::Delta>, ()> = {
                 let sub = sub_ref.deref_mut().as_mut().unwrap();
                 match sub.next_message().await {
                     Some(delta_message) => {
@@ -112,7 +143,7 @@ where
                         if parsed.client_token == Some(self.mqtt.client_id()) {
                             Ok(None)
                         } else {
-                            Ok(Some(parsed.state))
+                            Ok(parsed.state)
                         }
                     }
                     None => Err(()),
@@ -120,10 +151,26 @@ where
             };
 
             match result {
-                Ok(Some(state)) => return Ok(state),
+                Ok(Some(delta)) => {
+                    drop(sub_ref);
+                    debug!(
+                        "[{:?}] Delta reports new desired value. Changing local value...",
+                        S::NAME.unwrap_or(CLASSIC_SHADOW),
+                    );
+                    match self.apply_delta_and_ack(&delta).await {
+                        Ok(state) => return Ok((state, Some(delta))),
+                        Err(e) => {
+                            // Force re-subscribe on next call — without
+                            // this, the subscription survives MQTT
+                            // reconnection (clean_start = false) and the
+                            // delta is never re-delivered.
+                            self.subscription.lock().await.take();
+                            return Err(e);
+                        }
+                    }
+                }
                 Ok(None) => continue,
                 Err(()) => {
-                    // Clean session — resubscribe
                     info!(
                         "[{:?}] Clean session detected, resubscribing to delta topic",
                         S::NAME.unwrap_or(CLASSIC_SHADOW)
@@ -268,7 +315,7 @@ where
 
         match result? {
             Some(state) => Ok(state),
-            None => self.create_shadow().await,
+            None => self.create_shadow_inner().await,
         }
     }
 
@@ -358,43 +405,10 @@ where
             S::NAME.unwrap_or(CLASSIC_SHADOW)
         );
 
-        self.ensure_initialized().await?;
-
-        let delta = self.handle_delta().await?;
-
-        let state = if let Some(ref delta) = delta {
-            debug!(
-                "[{:?}] Delta reports new desired value. Changing local value...",
-                S::NAME.unwrap_or(CLASSIC_SHADOW),
-            );
-
-            // Apply and persist using StateStore
-            let state = self
-                .apply_and_save(delta)
-                .await
-                .map_err(|_| Error::DaoWrite)?;
-
-            // Acknowledge to cloud with only the changed fields,
-            // including desired cleanup to null stale fields after variant switches
-            let reported = state.into_partial_reported(delta);
-            let cleanup = state.desired_cleanup(delta);
-            if let Err(e) = self.update_shadow(cleanup, Some(reported)).await {
-                // Force re-subscribe on next call — without this, the
-                // subscription survives MQTT reconnection (clean_start=false)
-                // and the delta is never re-delivered, causing permanent
-                // desync.
-                self.subscription.lock().await.take();
-                return Err(e);
-            }
-
-            state
-        } else {
-            // No delta, just get current state
-            self.store
-                .get_state(Self::prefix())
-                .await
-                .map_err(|_| Error::DaoWrite)?
-        };
+        // No `ensure_initialized` here — `handle_delta`'s drain path GETs
+        // via `sync_shadow`, which handles 404→create and flips the
+        // `initialized` gate itself.
+        let (state, delta) = self.handle_delta().await?;
 
         info!(
             "[{:?}] wait_delta: return has_delta={}",
@@ -494,51 +508,31 @@ where
         Ok(())
     }
 
-    /// Fetch and synchronize state from the cloud.
+    /// GET the shadow, apply any pending delta, ack it, and return the
+    /// resulting local state and the delta (if any). Flips the `initialized`
+    /// gate so subsequent publish-side callers can skip their own GET. Use
+    /// on startup to reconcile local state with the cloud.
     ///
-    /// Fetches the current shadow state from the cloud and applies any
-    /// delta to local state. Use this on startup to ensure local state
-    /// matches the cloud.
+    /// Prefer `desired` over `delta` — `delta` is a diff against the cloud's
+    /// possibly-stale reported, so applying only the diff can leave local
+    /// fields inconsistent (e.g. a URL updated while its parent variant
+    /// discriminator is unchanged). The full `desired` converges reliably.
     ///
     /// ## Example
     ///
     /// ```ignore
-    /// shadow.load().await?;  // Load from storage
-    /// let state = shadow.sync_shadow().await?;  // Sync with cloud
+    /// shadow.load().await?;                              // Load from storage
+    /// let (state, _) = shadow.sync_shadow().await?;      // Sync with cloud
     /// ```
-    pub async fn sync_shadow(&self) -> Result<S, Error> {
-        let state = self.sync_shadow_inner().await?;
-        // A successful sync satisfies the `ensure_initialized` precondition,
-        // so flip the gate. Without this, the next `wait_delta` would re-run
-        // the sync via `ensure_initialized`, consuming the next pending delta
-        // via GET before `handle_delta` ever subscribes.
-        *self.initialized.lock().await = true;
-        Ok(state)
-    }
-
-    /// Inner sync — does the GET/apply/ack but does not flip `initialized`.
-    /// Used by `ensure_initialized`, which holds the `initialized` lock.
-    async fn sync_shadow_inner(&self) -> Result<S, Error> {
+    pub async fn sync_shadow(&self) -> Result<(S, Option<S::Delta>), Error> {
         let delta_state = self.get_shadow_from_cloud().await?;
+        // A successful GET (or 404→create) confirms the cloud doc exists,
+        // so the gate flips.
+        *self.initialized.lock().await = true;
+        let delta = delta_state.desired.or(delta_state.delta);
 
-        // Prefer `desired` over `delta` to match `wait_delta`. The cloud's
-        // `delta` is a diff against its current `reported`, which may be
-        // stale or missing entirely on first boot — applying only the diff
-        // leaves local fields in an inconsistent state (e.g. a URL updated
-        // while its parent variant discriminator is unchanged), and the
-        // subsequent reported ack writes those inconsistent defaults back
-        // to the cloud. The full `desired` converges reliably in all cases.
-        let state = if let Some(delta) = delta_state.desired.or(delta_state.delta) {
-            let state = self
-                .apply_and_save(&delta)
-                .await
-                .map_err(|_| Error::DaoWrite)?;
-            // Acknowledge with only the changed fields,
-            // including desired cleanup to null stale fields after variant switches
-            let reported = state.into_partial_reported(&delta);
-            let cleanup = state.desired_cleanup(&delta);
-            self.update_shadow(cleanup, Some(reported)).await?;
-            state
+        let state = if let Some(ref d) = delta {
+            self.apply_delta_and_ack(d).await?
         } else {
             self.store
                 .get_state(Self::prefix())
@@ -546,7 +540,7 @@ where
                 .map_err(|_| Error::DaoWrite)?
         };
 
-        Ok(state)
+        Ok((state, delta))
     }
 
     /// Create a new shadow in the cloud with the current device state.
@@ -563,6 +557,20 @@ where
     /// let delta_state = shadow.create_shadow().await?;
     /// ```
     pub async fn create_shadow(&self) -> Result<DeltaState<S::Delta, S::Delta>, Error> {
+        let r = self.create_shadow_inner().await?;
+        // External callers have explicitly chosen to push full state; the
+        // cloud doc now exists with our defaults, so the gate flips. Locks
+        // outside the get_shadow_from_cloud → 404 path (which uses _inner
+        // directly and avoids the relock that would deadlock).
+        *self.initialized.lock().await = true;
+        Ok(r)
+    }
+
+    /// Inner create — publishes the current local state as full desired +
+    /// reported. Does not touch `initialized`, so it's safe to call from
+    /// `get_shadow_from_cloud`'s 404 fallback while `ensure_initialized`
+    /// holds the lock.
+    async fn create_shadow_inner(&self) -> Result<DeltaState<S::Delta, S::Delta>, Error> {
         debug!(
             "[{:?}] Creating initial shadow value.",
             S::NAME.unwrap_or(CLASSIC_SHADOW),
@@ -608,9 +616,19 @@ where
                     )
                     .map_err(|_| Error::ShadowError(ShadowError::NotFound))?;
 
-                    Err(Error::ShadowError(
-                        error_response.try_into().unwrap_or(ShadowError::NotFound),
-                    ))
+                    // 404 means the cloud doc is already gone — treat as
+                    // success so delete is idempotent.
+                    if error_response.code == 404 {
+                        debug!(
+                            "[{:?}] Shadow already absent in cloud — treating delete as success.",
+                            S::NAME.unwrap_or(CLASSIC_SHADOW)
+                        );
+                        Ok(())
+                    } else {
+                        Err(Error::ShadowError(
+                            error_response.try_into().unwrap_or(ShadowError::NotFound),
+                        ))
+                    }
                 }
                 _ => {
                     error!(

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -153,10 +153,8 @@ where
                 let _ = sub_ref.insert(sub);
                 drop(sub_ref);
 
-                // Cancellation-safety: if the future is dropped between the
-                // subscription being cached and the drain completing, clear
-                // the cache on unwind so the next caller re-runs the initial
-                // sync instead of blocking on the delta topic.
+                // If we get cancelled doing the sync_shadow we need to drop the subscription to not skip the sync_shadow
+                // On next iteration. Only when we know sync_shadow has completed we can keep the subscription.
                 let mut reset_guard = ResetSubscriptionOnDrop {
                     subscription: &self.subscription,
                     armed: true,

--- a/src/shadows/shadow/mod.rs
+++ b/src/shadows/shadow/mod.rs
@@ -84,6 +84,9 @@ pub struct Shadow<'a, 'm, S: ShadowRoot, C: MqttClient, K: StateStore<S>> {
     pub(crate) mqtt: &'m C,
     /// Cached subscription for delta topic.
     pub(crate) subscription: Mutex<NoopRawMutex, Option<C::Subscription<'m, 1>>>,
+    /// One-shot gate: `true` once the initial cloud sync has run.
+    /// Reset by `delete_shadow`. See `ensure_initialized`.
+    pub(crate) initialized: Mutex<NoopRawMutex, bool>,
     /// Marker for the shadow state type.
     _marker: PhantomData<S>,
 }
@@ -118,6 +121,7 @@ where
             store,
             mqtt,
             subscription: Mutex::new(None),
+            initialized: Mutex::new(false),
             _marker: PhantomData,
         }
     }

--- a/src/shadows/shadow/mod.rs
+++ b/src/shadows/shadow/mod.rs
@@ -15,6 +15,7 @@ mod cloud;
 mod tests;
 
 use core::marker::PhantomData;
+use core::sync::atomic::AtomicBool;
 
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 
@@ -86,7 +87,7 @@ pub struct Shadow<'a, 'm, S: ShadowRoot, C: MqttClient, K: StateStore<S>> {
     pub(crate) subscription: Mutex<NoopRawMutex, Option<C::Subscription<'m, 1>>>,
     /// One-shot gate: `true` once the initial cloud sync has run.
     /// Reset by `delete_shadow`. See `ensure_initialized`.
-    pub(crate) initialized: Mutex<NoopRawMutex, bool>,
+    pub(crate) initialized: AtomicBool,
     /// Marker for the shadow state type.
     _marker: PhantomData<S>,
 }
@@ -121,7 +122,7 @@ where
             store,
             mqtt,
             subscription: Mutex::new(None),
-            initialized: Mutex::new(false),
+            initialized: AtomicBool::new(false),
             _marker: PhantomData,
         }
     }

--- a/src/shadows/shadow/mod.rs
+++ b/src/shadows/shadow/mod.rs
@@ -15,7 +15,6 @@ mod cloud;
 mod tests;
 
 use core::marker::PhantomData;
-use core::sync::atomic::AtomicBool;
 
 use embassy_sync::{blocking_mutex::raw::NoopRawMutex, mutex::Mutex};
 
@@ -87,7 +86,7 @@ pub struct Shadow<'a, 'm, S: ShadowRoot, C: MqttClient, K: StateStore<S>> {
     pub(crate) subscription: Mutex<NoopRawMutex, Option<C::Subscription<'m, 1>>>,
     /// One-shot gate: `true` once the initial cloud sync has run.
     /// Reset by `delete_shadow`. See `ensure_initialized`.
-    pub(crate) initialized: AtomicBool,
+    pub(crate) initialized: Mutex<NoopRawMutex, bool>,
     /// Marker for the shadow state type.
     _marker: PhantomData<S>,
 }
@@ -122,7 +121,7 @@ where
             store,
             mqtt,
             subscription: Mutex::new(None),
-            initialized: AtomicBool::new(false),
+            initialized: Mutex::new(false),
             _marker: PhantomData,
         }
     }

--- a/tests/shadows.rs
+++ b/tests/shadows.rs
@@ -276,7 +276,7 @@ async fn test_shadow_end_to_end() {
         }
 
         // Sync creates shadow with defaults
-        let state = shadow.sync_shadow().await.expect("Failed to sync shadow");
+        let (state, _) = shadow.sync_shadow().await.expect("Failed to sync shadow");
         log::info!("Synced shadow: {:?}", state);
 
         // Assert defaults


### PR DESCRIPTION
## Summary

Closes the race where a partial `update_reported` could land on a brand-new shadow before `wait_delta`'s first GET, leaving the cloud doc permanently incomplete.

Hit in [factbird-mini PR #666](https://github.com/FactbirdHQ/factbird-mini/pull/666) after factory reset + re-provisioning:
1. Device re-provisions to a new customer's IoT thing (no shadow exists yet).
2. ConnectionReporter calls `update_reported(state: Disabled)`.
3. Wifi delta loop calls `wait_delta` which on first-call subscribes + GETs.
4. Reporter wins (no subscribe step), AWS auto-creates the shadow with just `reported.state = "disabled"`.
5. By the time `wait_delta`'s GET runs, the shadow exists (200, not 404) — `create_shadow` fallback never fires.
6. Result: `{ "state": { "reported": { "state": "disabled" } } }` and nothing else, forever.

## Change

- Add `initialized: Mutex<NoopRawMutex, bool>` to `Shadow`.
- Add private `ensure_initialized()` that takes the lock and runs subscribe + GET + 404-fallback exactly once.
- `update_reported`, `update_desired`, `wait_delta` all await `ensure_initialized` first.
- `delete_shadow` resets the flag so a follow-up publish (e.g. button-driven "reset wifi" where the front-end expects to configure new credentials right after) re-initializes the cloud doc from local defaults.
- Not re-run on clean-session reconnect — only the delta subscription is re-established. The cloud doc still exists.

## Properties

- Concurrent first-callers serialize on the lock; only one does the work.
- Subsequent calls fall through on the first instruction.
- `create_shadow` and `sync_shadow` are deliberately not gated — they're explicit force-push operations and gating them would create a recursion via `get_shadow_from_cloud`'s 404 fallback.
- The first-call drop-guard moved from `wait_delta` into `ensure_initialized`; the cancellation invariant ("subscription == Some implies the sync ran to completion") is preserved.

## Test plan

- [x] `cargo check` with shadow features clean
- [x] `cargo test --lib shadows` — all 138 unit tests pass
- [ ] End-to-end test against AWS IoT via factbird-mini — pinned in PR #666
- [ ] Confirm `update_reported` from `ConnectionReporter` no longer creates a partial cloud doc on a fresh thing
- [ ] Confirm clean-session reconnect resubscribes without re-running the initial sync
- [ ] Confirm `delete_shadow` → `update_reported` re-initializes the cloud doc