### PR TITLE
fix(shadows): accept bare-string unit variants in externally-tagged parse_delta

### DIFF
--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -118,6 +118,9 @@ pub(crate) fn generate_simple_enum_code(
     // Track if we have any newtype variants (requires special parse_delta)
     let mut has_newtype_variants = false;
     let mut parse_delta_arms: Vec<TokenStream> = Vec::new();
+    // Bare-string fast-path arms for externally-tagged enums: serde serializes
+    // unit variants as `"name"` (no surrounding object), so accept that form.
+    let mut bare_string_unit_arms: Vec<TokenStream> = Vec::new();
 
     // Collect variant info
     let mut delta_variants = Vec::new();
@@ -196,6 +199,13 @@ pub(crate) fn generate_simple_enum_code(
                     // Externally-tagged: check if variant name is a key
                     parse_delta_arms.push(quote! {
                         if scanner.field_bytes(#serde_name).is_some() {
+                            return Ok(Self::Delta::#variant_ident);
+                        }
+                    });
+                    // Bare-string form: serde emits unit variants as `"name"`.
+                    let quoted = format!("\"{}\"", serde_name);
+                    bare_string_unit_arms.push(quote! {
+                        if trimmed == #quoted.as_bytes() {
                             return Ok(Self::Delta::#variant_ident);
                         }
                     });
@@ -526,9 +536,20 @@ pub(crate) fn generate_simple_enum_code(
                 }
             }
         } else {
-            // Externally-tagged enum: variant name is the object key
-            // JSON: { "Wpa": { "ssid": "...", "password": "..." } }
+            // Externally-tagged enum: variant name is the object key for
+            // newtype variants (`{"static": {...}}`) and a bare string for
+            // unit variants (`"dhcp"`). Both forms come back from AWS because
+            // that's exactly what serde serializes.
             quote! {
+                // Bare-string fast-path for unit variants. Anything else
+                // (objects, null, whitespace-only) falls through to the
+                // FieldScanner below.
+                let trimmed = json.trim_ascii();
+                if let Some(&b'"') = trimmed.first() {
+                    #(#bare_string_unit_arms)*
+                    return Err(#krate::shadows::ParseError::UnknownVariant);
+                }
+
                 // Scan for variant names as keys
                 let scanner = #krate::shadows::tag_scanner::FieldScanner::scan(json, &[#(#variant_name_strs),*])
                     .map_err(#krate::shadows::ParseError::Scan)?;

--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -118,8 +118,7 @@ pub(crate) fn generate_simple_enum_code(
     // Track if we have any newtype variants (requires special parse_delta)
     let mut has_newtype_variants = false;
     let mut parse_delta_arms: Vec<TokenStream> = Vec::new();
-    // Bare-string fast-path arms for externally-tagged enums: serde serializes
-    // unit variants as `"name"` (no surrounding object), so accept that form.
+    // Bare-string match arms for unit variants; only used by externally-tagged enums.
     let mut bare_string_unit_arms: Vec<TokenStream> = Vec::new();
 
     // Collect variant info
@@ -202,7 +201,6 @@ pub(crate) fn generate_simple_enum_code(
                             return Ok(Self::Delta::#variant_ident);
                         }
                     });
-                    // Bare-string form: serde emits unit variants as `"name"`.
                     let quoted = format!("\"{}\"", serde_name);
                     bare_string_unit_arms.push(quote! {
                         if trimmed == #quoted.as_bytes() {
@@ -536,25 +534,20 @@ pub(crate) fn generate_simple_enum_code(
                 }
             }
         } else {
-            // Externally-tagged enum: variant name is the object key for
-            // newtype variants (`{"static": {...}}`) and a bare string for
-            // unit variants (`"dhcp"`). Both forms come back from AWS because
-            // that's exactly what serde serializes.
+            // Externally-tagged enum: serde emits unit variants as `"name"`
+            // and newtype variants as `{"name": ...}`, so accept both shapes
+            // here. Anything that does not start with `"` falls through to
+            // the object-form scanner.
             quote! {
-                // Bare-string fast-path for unit variants. Anything else
-                // (objects, null, whitespace-only) falls through to the
-                // FieldScanner below.
                 let trimmed = json.trim_ascii();
                 if let Some(&b'"') = trimmed.first() {
                     #(#bare_string_unit_arms)*
                     return Err(#krate::shadows::ParseError::UnknownVariant);
                 }
 
-                // Scan for variant names as keys
                 let scanner = #krate::shadows::tag_scanner::FieldScanner::scan(json, &[#(#variant_name_strs),*])
                     .map_err(#krate::shadows::ParseError::Scan)?;
 
-                // Try each variant (arms include the if-let checks)
                 #(#parse_delta_arms)*
 
                 Err(#krate::shadows::ParseError::MissingVariant)

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -957,64 +957,61 @@ async fn test_enum_serde_rename_affects_variant_key() {
 // 6.4 parse_delta accepts both bare-string and object forms
 // =========================================================================
 //
-// For an externally-tagged enum with mixed unit + newtype variants, serde
-// serializes the unit variants as a bare string (`"dhcp"`) and the newtype
-// variants as `{"static": {...}}`. Both shapes come back from AWS via the
-// shadow desired/delta payload, so parse_delta must accept both — otherwise
-// the device loops forever on InvalidPayload.
+// Serde emits externally-tagged unit variants as `"bar"` and newtype
+// variants as `{"baz": {...}}`. parse_delta has to accept both so
+// round-tripping its own output through the shadow does not break.
+
+#[shadow_node]
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct BazInner {
+    qux: u32,
+}
 
 #[shadow_node]
 #[derive(Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-enum IpSettingsLc {
+enum Foo {
     #[default]
-    Dhcp,
-    Static(StaticIpCfg),
+    Bar,
+    Baz(BazInner),
 }
 
 #[tokio::test]
 async fn test_externally_tagged_parse_delta_bare_string_unit_variant() {
     use crate::shadows::NullResolver;
 
-    let delta = IpSettingsLc::parse_delta(br#""dhcp""#, "", &NullResolver)
+    let delta = Foo::parse_delta(br#""bar""#, "", &NullResolver)
         .await
-        .expect("bare-string form should parse");
-
-    let mut state = IpSettingsLc::Static(StaticIpCfg::default());
+        .unwrap();
+    let mut state = Foo::Baz(BazInner::default());
     state.apply_delta(&delta);
-    assert!(matches!(state, IpSettingsLc::Dhcp));
+    assert!(matches!(state, Foo::Bar));
 }
 
 #[tokio::test]
 async fn test_externally_tagged_parse_delta_bare_string_with_whitespace() {
     use crate::shadows::NullResolver;
 
-    let delta = IpSettingsLc::parse_delta(b"  \n\"dhcp\"\t ", "", &NullResolver)
+    let delta = Foo::parse_delta(b"  \n\"bar\"\t ", "", &NullResolver)
         .await
-        .expect("whitespace around bare string should be tolerated");
-
-    let mut state = IpSettingsLc::Static(StaticIpCfg::default());
+        .unwrap();
+    let mut state = Foo::Baz(BazInner::default());
     state.apply_delta(&delta);
-    assert!(matches!(state, IpSettingsLc::Dhcp));
+    assert!(matches!(state, Foo::Bar));
 }
 
 #[tokio::test]
 async fn test_externally_tagged_parse_delta_object_newtype_variant() {
     use crate::shadows::NullResolver;
 
-    let json = br#"{"static": {"address": [192, 168, 1, 50], "gateway": [192, 168, 1, 1]}}"#;
-    let delta = IpSettingsLc::parse_delta(json, "", &NullResolver)
+    let delta = Foo::parse_delta(br#"{"baz": {"qux": 42}}"#, "", &NullResolver)
         .await
-        .expect("object form should still parse");
-
-    let mut state = IpSettingsLc::Dhcp;
+        .unwrap();
+    let mut state = Foo::Bar;
     state.apply_delta(&delta);
     match state {
-        IpSettingsLc::Static(cfg) => {
-            assert_eq!(cfg.address.as_slice(), &[192, 168, 1, 50]);
-            assert_eq!(cfg.gateway.as_slice(), &[192, 168, 1, 1]);
-        }
-        _ => panic!("expected Static after applying object-form delta"),
+        Foo::Baz(inner) => assert_eq!(inner.qux, 42),
+        _ => panic!("expected Baz"),
     }
 }
 
@@ -1022,7 +1019,7 @@ async fn test_externally_tagged_parse_delta_object_newtype_variant() {
 async fn test_externally_tagged_parse_delta_unknown_bare_string_errors() {
     use crate::shadows::{NullResolver, ParseError};
 
-    let result = IpSettingsLc::parse_delta(br#""bogus""#, "", &NullResolver).await;
+    let result = Foo::parse_delta(br#""qux""#, "", &NullResolver).await;
     assert!(matches!(result, Err(ParseError::UnknownVariant)));
 }
 

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -954,6 +954,79 @@ async fn test_enum_serde_rename_affects_variant_key() {
 }
 
 // =========================================================================
+// 6.4 parse_delta accepts both bare-string and object forms
+// =========================================================================
+//
+// For an externally-tagged enum with mixed unit + newtype variants, serde
+// serializes the unit variants as a bare string (`"dhcp"`) and the newtype
+// variants as `{"static": {...}}`. Both shapes come back from AWS via the
+// shadow desired/delta payload, so parse_delta must accept both — otherwise
+// the device loops forever on InvalidPayload.
+
+#[shadow_node]
+#[derive(Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum IpSettingsLc {
+    #[default]
+    Dhcp,
+    Static(StaticIpCfg),
+}
+
+#[tokio::test]
+async fn test_externally_tagged_parse_delta_bare_string_unit_variant() {
+    use crate::shadows::NullResolver;
+
+    let delta = IpSettingsLc::parse_delta(br#""dhcp""#, "", &NullResolver)
+        .await
+        .expect("bare-string form should parse");
+
+    let mut state = IpSettingsLc::Static(StaticIpCfg::default());
+    state.apply_delta(&delta);
+    assert!(matches!(state, IpSettingsLc::Dhcp));
+}
+
+#[tokio::test]
+async fn test_externally_tagged_parse_delta_bare_string_with_whitespace() {
+    use crate::shadows::NullResolver;
+
+    let delta = IpSettingsLc::parse_delta(b"  \n\"dhcp\"\t ", "", &NullResolver)
+        .await
+        .expect("whitespace around bare string should be tolerated");
+
+    let mut state = IpSettingsLc::Static(StaticIpCfg::default());
+    state.apply_delta(&delta);
+    assert!(matches!(state, IpSettingsLc::Dhcp));
+}
+
+#[tokio::test]
+async fn test_externally_tagged_parse_delta_object_newtype_variant() {
+    use crate::shadows::NullResolver;
+
+    let json = br#"{"static": {"address": [192, 168, 1, 50], "gateway": [192, 168, 1, 1]}}"#;
+    let delta = IpSettingsLc::parse_delta(json, "", &NullResolver)
+        .await
+        .expect("object form should still parse");
+
+    let mut state = IpSettingsLc::Dhcp;
+    state.apply_delta(&delta);
+    match state {
+        IpSettingsLc::Static(cfg) => {
+            assert_eq!(cfg.address.as_slice(), &[192, 168, 1, 50]);
+            assert_eq!(cfg.gateway.as_slice(), &[192, 168, 1, 1]);
+        }
+        _ => panic!("expected Static after applying object-form delta"),
+    }
+}
+
+#[tokio::test]
+async fn test_externally_tagged_parse_delta_unknown_bare_string_errors() {
+    use crate::shadows::{NullResolver, ParseError};
+
+    let result = IpSettingsLc::parse_delta(br#""bogus""#, "", &NullResolver).await;
+    assert!(matches!(result, Err(ParseError::UnknownVariant)));
+}
+
+// =========================================================================
 // Phase 7 Tests: Delta Apply and Save
 // =========================================================================
 


### PR DESCRIPTION
## Summary

For an externally-tagged enum with mixed unit + newtype variants (e.g. `IpSettings { Dhcp, Static(...) }`), the derived `parse_delta` only handled the object form (`{"dhcp": ...}`, `{"static": {...}}`). Serde itself serializes unit variants as a bare string (`"dhcp"`), and AWS echoes that shape back via shadow desired/delta — so devices loop on `InvalidPayload` whenever the cloud has the unit variant set.

This adds a bare-string fast-path before the `FieldScanner` call: trim ASCII whitespace, and if the value starts with `"`, match it against each unit variant's quoted name; fall through to the existing object-form scanner otherwise. Brings the macro's behaviour into line with what `serde::Deserialize` already accepts.

Found via factbird-mini [#667](https://github.com/FactbirdHQ/factbird-mini/issues/667).

## Test plan

- [x] `cargo test --lib --features std,shadows_kv_persist` — 177 pass (incl. 4 new in `src/shadows/shadow/tests.rs` under `6.4 parse_delta accepts both bare-string and object forms`)
- [x] Verified end-to-end against factbird-mini wifi shadow tests via local `[patch]` — the previously failing `parse_known_network_with_bare_string_ip_settings` regression now passes