### PR TITLE
fix(shadows): ack map-entry removals as null in reported and desired

### DIFF
--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -323,12 +323,22 @@ pub struct DeltaLinearMap<K: Eq, D, const N: usize>(
 );
 
 /// Reported type for `heapless::LinearMap`-based shadow fields.
+///
+/// Entries are [`Patch`] so the partial-reported acknowledgment of an
+/// `Unset` delta can serialize the removed key as `null` — AWS deletes
+/// nulled keys from the reported document, keeping it in sync with the
+/// device after an entry removal. `Patch::Set` serializes transparently,
+/// so present entries keep the plain `key: value` wire format.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
-pub struct ReportedLinearMap<K: Eq, R, const N: usize>(pub heapless::LinearMap<K, R, N>);
+pub struct ReportedLinearMap<K: Eq, R, const N: usize>(pub heapless::LinearMap<K, Patch<R>, N>);
 
 impl<K: Eq, R, const N: usize> From<heapless::LinearMap<K, R, N>> for ReportedLinearMap<K, R, N> {
     fn from(map: heapless::LinearMap<K, R, N>) -> Self {
-        Self(map)
+        let mut reported = heapless::LinearMap::new();
+        for (key, value) in map.into_iter() {
+            let _ = reported.insert(key, Patch::Set(value));
+        }
+        Self(reported)
     }
 }
 
@@ -354,12 +364,14 @@ impl<K: Eq + Clone, R: crate::shadows::ReportedDiff, const N: usize> crate::shad
     for ReportedLinearMap<K, R, N>
 {
     fn diff(&mut self, old: &Self) -> bool {
-        // Collect keys to remove (unchanged entries)
+        // Collect keys to remove (unchanged entries). `Unset` entries are
+        // always retained — a removal must reach the cloud regardless of
+        // what was previously reported for the key.
         let remove_keys: heapless::Vec<K, N> = self
             .0
             .iter_mut()
-            .filter_map(|(k, v)| match old.0.get(k) {
-                Some(old_v) if !v.diff(old_v) => Some(k.clone()),
+            .filter_map(|(k, v)| match (v, old.0.get(k)) {
+                (Patch::Set(v), Some(Patch::Set(old_v))) => (!v.diff(old_v)).then(|| k.clone()),
                 _ => None,
             })
             .collect();
@@ -457,7 +469,7 @@ where
     fn into_reported(&self) -> Self::Reported {
         let mut reported = heapless::LinearMap::new();
         for (key, value) in self.iter() {
-            let _ = reported.insert(key.clone(), value.into_reported());
+            let _ = reported.insert(key.clone(), Patch::Set(value.into_reported()));
         }
         ReportedLinearMap(reported)
     }
@@ -477,20 +489,28 @@ where
                 match patch {
                     Patch::Set(inner_delta) => {
                         if let Some(v) = self.get(key) {
-                            let _ =
-                                reported.insert(key.clone(), v.into_partial_reported(inner_delta));
+                            let _ = reported.insert(
+                                key.clone(),
+                                Patch::Set(v.into_partial_reported(inner_delta)),
+                            );
                         } else {
                             // New key not yet in state — use default with delta
                             // applied, mirroring the apply_delta pattern.
                             let mut new_val = V::default();
                             new_val.apply_delta(inner_delta);
-                            let _ = reported
-                                .insert(key.clone(), new_val.into_partial_reported(inner_delta));
+                            let _ = reported.insert(
+                                key.clone(),
+                                Patch::Set(new_val.into_partial_reported(inner_delta)),
+                            );
                         }
                     }
                     Patch::Unset => {
-                        // Unset entries cannot be represented in ReportedLinearMap
-                        // The user must handle explicit null reporting separately
+                        // Acknowledge the removal as `null` so AWS deletes the
+                        // key from the reported document. Without this the
+                        // stale entry lingers, and re-adding an identical
+                        // entry later produces no delta (desired == stale
+                        // reported), so the device would never see the re-add.
+                        let _ = reported.insert(key.clone(), Patch::Unset);
                     }
                 }
             }
@@ -504,12 +524,23 @@ where
             let mut has_cleanup = false;
 
             for (key, patch) in patches.iter() {
-                if let Patch::Set(inner_delta) = patch
-                    && let Some(v) = self.get(key)
-                    && let Some(inner_cleanup) = v.desired_cleanup(inner_delta)
-                {
-                    let _ = result.insert(key.clone(), Patch::Set(inner_cleanup));
-                    has_cleanup = true;
+                match patch {
+                    Patch::Set(inner_delta) => {
+                        if let Some(v) = self.get(key)
+                            && let Some(inner_cleanup) = v.desired_cleanup(inner_delta)
+                        {
+                            let _ = result.insert(key.clone(), Patch::Set(inner_cleanup));
+                            has_cleanup = true;
+                        }
+                    }
+                    Patch::Unset => {
+                        // Null the `"unset"` tombstone in desired alongside the
+                        // reported-side null: otherwise desired keeps a value
+                        // for a key reported no longer has, leaving a pending
+                        // delta that re-fires on every shadow change.
+                        let _ = result.insert(key.clone(), Patch::Unset);
+                        has_cleanup = true;
+                    }
                 }
             }
 
@@ -984,6 +1015,57 @@ mod tests {
             map.get(&heapless::String::<4>::try_from("a").unwrap())
                 .is_none()
         );
+    }
+
+    #[test]
+    fn test_linear_map_unset_acks_null_in_reported_and_desired() {
+        let mut map: heapless::LinearMap<heapless::String<4>, u32, 4> = heapless::LinearMap::new();
+        let _ = map.insert(heapless::String::try_from("p1").unwrap(), 100);
+
+        let mut patches = heapless::LinearMap::new();
+        let _ = patches.insert(
+            heapless::String::try_from("p1").unwrap(),
+            Patch::<u32>::Unset,
+        );
+        let delta = DeltaLinearMap(Some(patches));
+        map.apply_delta(&delta);
+
+        // Reported ack must null the removed key so AWS deletes it — leaving
+        // it out would keep the stale entry, and a later re-add of an
+        // identical entry would produce no delta.
+        let reported = map.into_partial_reported(&delta);
+        let json = serde_json_core::to_string::<_, 64>(&reported).unwrap();
+        assert_eq!(json.as_str(), r#"{"p1":null}"#);
+
+        // Desired cleanup must null the "unset" tombstone, or it lingers as a
+        // permanent pending delta.
+        let cleanup = map
+            .desired_cleanup(&delta)
+            .expect("unset must produce desired cleanup");
+        let json = serde_json_core::to_string::<_, 64>(&cleanup).unwrap();
+        assert_eq!(json.as_str(), r#"{"p1":null}"#);
+    }
+
+    #[test]
+    fn test_reported_linear_map_diff_retains_unset() {
+        use crate::shadows::ReportedDiff;
+
+        let key = heapless::String::<4>::try_from("p1").unwrap();
+
+        let mut old: ReportedLinearMap<heapless::String<4>, u32, 4> = ReportedLinearMap::default();
+        let _ = old.0.insert(key.clone(), Patch::Set(100));
+
+        // Unset entries survive diff even when the old report had the key
+        let mut new: ReportedLinearMap<heapless::String<4>, u32, 4> = ReportedLinearMap::default();
+        let _ = new.0.insert(key.clone(), Patch::Unset);
+        assert!(new.diff(&old));
+        assert!(matches!(new.0.get(&key), Some(Patch::Unset)));
+
+        // Unchanged Set entries are still pruned
+        let mut unchanged: ReportedLinearMap<heapless::String<4>, u32, 4> =
+            ReportedLinearMap::default();
+        let _ = unchanged.0.insert(key.clone(), Patch::Set(100));
+        assert!(!unchanged.diff(&old));
     }
 
     #[test]

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -304,13 +304,19 @@ where
 pub struct DeltaHashMap<K: Eq + Hash, D>(pub Option<HashMap<K, Patch<D>>>);
 
 /// Reported type for `HashMap`-based shadow fields.
+///
+/// Entries are [`Patch`] so the partial-reported acknowledgment of an
+/// `Unset` delta can serialize the removed key as `null` — AWS deletes
+/// nulled keys from the reported document, keeping it in sync with the
+/// device after an entry removal. `Patch::Set` serializes transparently,
+/// so present entries keep the plain `key: value` wire format.
 #[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
 #[serde(transparent)]
-pub struct ReportedHashMap<K: Eq + Hash, R>(pub HashMap<K, R>);
+pub struct ReportedHashMap<K: Eq + Hash, R>(pub HashMap<K, Patch<R>>);
 
 impl<K: Eq + Hash, R> From<HashMap<K, R>> for ReportedHashMap<K, R> {
     fn from(map: HashMap<K, R>) -> Self {
-        Self(map)
+        Self(map.into_iter().map(|(k, v)| (k, Patch::Set(v))).collect())
     }
 }
 
@@ -337,9 +343,11 @@ impl<K: Eq + Hash, R: crate::shadows::ReportedDiff> crate::shadows::ReportedDiff
     for ReportedHashMap<K, R>
 {
     fn diff(&mut self, old: &Self) -> bool {
-        self.0.retain(|k, v| match old.0.get(k) {
-            Some(old_v) => v.diff(old_v),
-            None => true,
+        // `Unset` entries are always retained — a removal must reach the
+        // cloud regardless of what was previously reported for the key.
+        self.0.retain(|k, v| match (v, old.0.get(k)) {
+            (Patch::Set(v), Some(Patch::Set(old_v))) => v.diff(old_v),
+            _ => true,
         });
         !self.0.is_empty()
     }
@@ -432,7 +440,7 @@ where
     fn into_reported(&self) -> Self::Reported {
         let mut reported = HashMap::new();
         for (key, value) in self.iter() {
-            reported.insert(key.clone(), value.into_reported());
+            reported.insert(key.clone(), Patch::Set(value.into_reported()));
         }
         ReportedHashMap(reported)
     }
@@ -452,19 +460,28 @@ where
                 match patch {
                     Patch::Set(inner_delta) => {
                         if let Some(v) = self.get(key) {
-                            reported.insert(key.clone(), v.into_partial_reported(inner_delta));
+                            reported.insert(
+                                key.clone(),
+                                Patch::Set(v.into_partial_reported(inner_delta)),
+                            );
                         } else {
                             // New key not yet in state — use default with delta
                             // applied, mirroring the apply_delta pattern.
                             let mut new_val = V::default();
                             new_val.apply_delta(inner_delta);
-                            reported
-                                .insert(key.clone(), new_val.into_partial_reported(inner_delta));
+                            reported.insert(
+                                key.clone(),
+                                Patch::Set(new_val.into_partial_reported(inner_delta)),
+                            );
                         }
                     }
                     Patch::Unset => {
-                        // Unset entries cannot be represented in ReportedHashMap
-                        // The user must handle explicit null reporting separately
+                        // Acknowledge the removal as `null` so AWS deletes the
+                        // key from the reported document. Without this the
+                        // stale entry lingers, and re-adding an identical
+                        // entry later produces no delta (desired == stale
+                        // reported), so the device would never see the re-add.
+                        reported.insert(key.clone(), Patch::Unset);
                     }
                 }
             }
@@ -478,12 +495,22 @@ where
             let mut has_cleanup = false;
 
             for (key, patch) in patches.iter() {
-                if let Patch::Set(inner_delta) = patch {
-                    if let Some(v) = self.get(key) {
-                        if let Some(inner_cleanup) = v.desired_cleanup(inner_delta) {
-                            result.insert(key.clone(), Patch::Set(inner_cleanup));
-                            has_cleanup = true;
+                match patch {
+                    Patch::Set(inner_delta) => {
+                        if let Some(v) = self.get(key) {
+                            if let Some(inner_cleanup) = v.desired_cleanup(inner_delta) {
+                                result.insert(key.clone(), Patch::Set(inner_cleanup));
+                                has_cleanup = true;
+                            }
                         }
+                    }
+                    Patch::Unset => {
+                        // Null the `"unset"` tombstone in desired alongside the
+                        // reported-side null: otherwise desired keeps a value
+                        // for a key reported no longer has, leaving a pending
+                        // delta that re-fires on every shadow change.
+                        result.insert(key.clone(), Patch::Unset);
+                        has_cleanup = true;
                     }
                 }
             }
@@ -921,8 +948,40 @@ mod flatten_tests {
 
         let reported = state.into_reported();
         assert_eq!(reported.brightness, Some(50));
-        let connector_reported = &reported.connectors.as_ref().unwrap().0["HDMI-A-1"];
+        let connector_reported = match &reported.connectors.as_ref().unwrap().0["HDMI-A-1"] {
+            crate::shadows::Patch::Set(r) => r,
+            crate::shadows::Patch::Unset => panic!("expected Set entry for a present connector"),
+        };
         assert_eq!(connector_reported.enabled, Some(true));
+    }
+
+    #[test]
+    fn test_hash_map_unset_acks_null_in_reported_and_desired() {
+        use crate::shadows::Patch;
+
+        let mut map: HashMap<String, ConnectorConfig> = HashMap::new();
+        map.insert("HDMI-A-1".to_string(), ConnectorConfig { enabled: true });
+
+        let mut patches = HashMap::new();
+        patches.insert("HDMI-A-1".to_string(), Patch::<DeltaConnectorConfig>::Unset);
+        let delta = super::DeltaHashMap(Some(patches));
+        map.apply_delta(&delta);
+        assert!(map.is_empty());
+
+        // Reported ack must null the removed key so AWS deletes it — leaving
+        // it out would keep the stale entry, and a later re-add of an
+        // identical entry would produce no delta.
+        let reported = map.into_partial_reported(&delta);
+        let json = serde_json::to_string(&reported).unwrap();
+        assert_eq!(json, r#"{"HDMI-A-1":null}"#);
+
+        // Desired cleanup must null the "unset" tombstone, or it lingers as a
+        // permanent pending delta.
+        let cleanup = map
+            .desired_cleanup(&delta)
+            .expect("unset must produce desired cleanup");
+        let json = serde_json::to_string(&cleanup).unwrap();
+        assert_eq!(json, r#"{"HDMI-A-1":null}"#);
     }
 
     #[test]

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -2078,6 +2078,38 @@ struct MapShadow {
     ports: heapless::LinearMap<heapless::String<4>, u32, 4>,
 }
 
+/// Regression: acknowledging a map-entry `"unset"` delta must null the key in
+/// BOTH sections of the update — `reported` (so AWS deletes the stale entry;
+/// otherwise re-adding an identical entry later produces no delta and the
+/// device never sees it) and `desired` (so the `"unset"` tombstone doesn't
+/// linger as a permanent pending delta). These are exactly the two values
+/// `apply_delta_and_ack` passes to `update_shadow`.
+#[tokio::test]
+async fn test_map_unset_ack_nulls_reported_and_desired() {
+    use crate::shadows::NullResolver;
+
+    let mut state = MapShadow::default();
+    let _ = state
+        .ports
+        .insert(heapless::String::try_from("p1").unwrap(), 100u32);
+
+    let delta = MapShadow::parse_delta(br#"{"ports":{"p1":"unset"}}"#, "", &NullResolver)
+        .await
+        .unwrap();
+    state.apply_delta(&delta);
+    assert!(state.ports.is_empty(), "entry must be removed locally");
+
+    let reported = state.into_partial_reported(&delta);
+    let json = serde_json_core::to_string::<_, 256>(&reported).unwrap();
+    assert_eq!(json.as_str(), r#"{"ports":{"p1":null}}"#);
+
+    let cleanup = state
+        .desired_cleanup(&delta)
+        .expect("unset tombstone must be cleaned from desired");
+    let json = serde_json_core::to_string::<_, 256>(&cleanup).unwrap();
+    assert_eq!(json.as_str(), r#"{"ports":{"p1":null}}"#);
+}
+
 #[tokio::test]
 async fn test_commit_preserves_map_entries_and_removes_orphans() {
     // Populate a LinearMap with two entries plus an orphaned key from old schema


### PR DESCRIPTION
## Summary

Applying a map delta with `Patch::Unset` removed the entry locally but the acknowledgment could not express the removal: `ReportedLinearMap` / `ReportedHashMap` held plain `K -> R` entries, so `into_partial_reported` silently skipped unset keys (the ack sent `{}`), and `desired_cleanup` ignored them. After the ack, the cloud document kept the stale entry in `reported` and the `"unset"` tombstone in `desired`.

Empirically (replicating `apply_delta_and_ack`'s two outputs before this change):

```
delta in:        {"ports":{"p1":"unset"}}
ack reported:    {"ports":{}}     <- merge no-op, stale entry survives
desired cleanup: None             <- tombstone survives
```

### Consequences fixed

1. **Re-add never reaches the device**: re-adding an entry identical to the stale reported value produces NO delta (desired == reported field-for-field). Concretely for `wifi.known_networks`: remove a network, later re-add the same network - the device never reconnects, with no error anywhere.
2. **Permanent pending delta**: the `"unset"` tombstone in desired keeps the delta document non-empty forever; the device reprocesses it as a no-op on every boot/GET.

### Fix

Reported map entries are now `Patch<R>`:

- `Patch::Set` serializes transparently, so present entries keep the exact same wire format - no change for existing consumers' shadow documents.
- `Patch::Unset` serializes as `null`, which AWS treats as key deletion. The unset arm of `into_partial_reported` now emits it, and `desired_cleanup` mirrors the removal, so the single `apply_delta_and_ack` update nulls the key in **both** sections:

```
ack reported:    {"ports":{"p1":null}}
desired cleanup: {"ports":{"p1":null}}
```

- `ReportedDiff` always retains `Unset` entries (a removal must reach the cloud regardless of what was previously reported).

Both the heapless `LinearMap` and std `HashMap` implementations are updated symmetrically.

### Compatibility

- Wire format for present entries: unchanged (transparent `Set`).
- `SCHEMA_HASH` / KV persistence: untouched - no flash migration for KV consumers.
- API: `ReportedLinearMap.0` / `ReportedHashMap.0` now hold `Patch<R>` values; the `From<Map<K, R>>` impls wrap entries in `Patch::Set`, so construction sites keep compiling.

### Tests

- `test_linear_map_unset_acks_null_in_reported_and_desired` / `test_hash_map_unset_acks_null_in_reported_and_desired` - serialized ack payloads are `{"k":null}` on both sides.
- `test_reported_linear_map_diff_retains_unset` - diff keeps removals, still prunes unchanged `Set` entries.
- `test_map_unset_ack_nulls_reported_and_desired` (shadow level) - full `parse_delta` -> `apply_delta` -> ack pipeline on a `shadow_root` fixture.

### Changelog

#### Fixed

- Map-entry removals (`Patch::Unset`) are now acknowledged as `null` in both `reported` and `desired`, so AWS deletes the key instead of keeping a stale entry + tombstone (which silently swallowed any later re-add of an identical entry)
