### PR TITLE
fix(shadows): honor opaque(max_size) for report_only(persist) KV buffer

### DIFF
--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -468,11 +468,23 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> syn::Result<FieldCo
     // --- persist_report_only arm (only for report_only(persist) leaf fields) ---
     let persist_report_only_arm = if attrs.is_report_only_persist() {
         let field_kv_path = format!("/{}", serde_name);
+        // Honor an explicit `opaque(max_size = N)` bound; only fall back to the
+        // `MaxSize` trait when no explicit size is given (mirrors the ValueBuf
+        // sizing below). This lets `report_only(persist)` hold types that don't
+        // implement `MaxSize` (e.g. `String`-carrying enums) as long as the field
+        // is `opaque(max_size = N)`.
+        let buf_size = if let Some(explicit_size) = attrs.opaque_max_size() {
+            quote! { #explicit_size }
+        } else {
+            quote! {
+                <#field_ty as #krate::__macro_support::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE
+            }
+        };
         Some(quote! {
             if let Some(ref val) = self.#field_name {
                 let __saved_len = __key_buf.len();
                 let _ = __key_buf.push_str(#field_kv_path);
-                let mut __buf = [0u8; <#field_ty as #krate::__macro_support::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE];
+                let mut __buf = [0u8; #buf_size];
                 let bytes = #krate::__macro_support::postcard::to_slice(val, &mut __buf)
                     .map_err(|_| #krate::shadows::KvError::Serialization)?;
                 __kv.store(__key_buf.as_str(), bytes).await.map_err(#krate::shadows::KvError::Kv)?;

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -696,6 +696,25 @@ struct ReportOnlyStaticTest {
     status: &'static str,
 }
 
+// Regression (compile-guard): `report_only(persist)` must honor an explicit
+// `opaque(max_size = N)` and NOT require the field type to implement `MaxSize`.
+// `PersistedBlob` deliberately does not derive `MaxSize`; before the fix the
+// generated `persist_report_only` arm referenced `<PersistedBlob as MaxSize>`
+// and this failed to compile.
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq)]
+struct PersistedBlob {
+    value: heapless::String<16>,
+}
+
+#[allow(dead_code)]
+#[shadow_root(name = "persist_opaque")]
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct ReportOnlyPersistOpaqueTest {
+    normal: u32,
+    #[shadow_attr(report_only(persist), opaque(max_size = 64))]
+    blob: PersistedBlob,
+}
+
 #[shadow_root(name = "wifi")]
 #[derive(Clone, Default, Serialize, Deserialize)]
 struct WifiCfg {


### PR DESCRIPTION
## Summary

`report_only(persist)` fields hardcoded `<T as MaxSize>::POSTCARD_MAX_SIZE` for their KV buffer, so the field type had to implement `MaxSize` even when it declared an explicit `opaque(max_size = N)`. The parallel ValueBuf-sizing path already honored the explicit size; this makes the `persist_report_only` codegen do the same.

Effect: `report_only(persist), opaque(max_size = N)` now works for types that don't implement `MaxSize` (e.g. `String`-carrying enums), which is what lets a device persist a small state-machine field in its shadow across reboots.

Includes a compile-guard test (`ReportOnlyPersistOpaqueTest`) whose field type intentionally lacks `MaxSize`.