### PR TITLE
fix(shadows): support bare-string unit variants + surface dropped MQTT errors

### DIFF
--- a/rustot_derive/src/codegen/enum_codegen.rs
+++ b/rustot_derive/src/codegen/enum_codegen.rs
@@ -118,6 +118,10 @@ pub(crate) fn generate_simple_enum_code(
     // Track if we have any newtype variants (requires special parse_delta)
     let mut has_newtype_variants = false;
     let mut parse_delta_arms: Vec<TokenStream> = Vec::new();
+    // Externally-tagged enums serialize UNIT variants as a bare JSON string
+    // (e.g. "custom"), but the object FieldScanner used for newtype variants
+    // cannot match a bare string. These arms match the string form first.
+    let mut unit_string_arms: Vec<TokenStream> = Vec::new();
 
     // Collect variant info
     let mut delta_variants = Vec::new();
@@ -193,7 +197,14 @@ pub(crate) fn generate_simple_enum_code(
                         #serde_name => Ok(Self::Delta::#variant_ident),
                     });
                 } else {
-                    // Externally-tagged: check if variant name is a key
+                    // Externally-tagged: check if variant name is a key. serde
+                    // also permits the bare-string form for a unit variant (and
+                    // in fact serializes it that way), so match that first.
+                    unit_string_arms.push(quote! {
+                        if __inner == #serde_name.as_bytes() {
+                            return Ok(Self::Delta::#variant_ident);
+                        }
+                    });
                     parse_delta_arms.push(quote! {
                         if scanner.field_bytes(#serde_name).is_some() {
                             return Ok(Self::Delta::#variant_ident);
@@ -528,7 +539,25 @@ pub(crate) fn generate_simple_enum_code(
         } else {
             // Externally-tagged enum: variant name is the object key
             // JSON: { "Wpa": { "ssid": "...", "password": "..." } }
+            //
+            // serde serializes UNIT variants as a bare JSON string (e.g.
+            // "custom") but newtype variants as an object ({"Wpa": {...}}).
+            // `FieldScanner::scan` below expects an object and errors on a bare
+            // string, so first handle the bare-string unit-variant form.
+            let unit_string_prelude = if unit_string_arms.is_empty() {
+                TokenStream::new()
+            } else {
+                quote! {
+                    let __t = json.trim_ascii();
+                    if let [b'"', __inner @ .., b'"'] = __t {
+                        #(#unit_string_arms)*
+                        return Err(#krate::shadows::ParseError::UnknownVariant);
+                    }
+                }
+            };
             quote! {
+                #unit_string_prelude
+
                 // Scan for variant names as keys
                 let scanner = #krate::shadows::tag_scanner::FieldScanner::scan(json, &[#(#variant_name_strs),*])
                     .map_err(#krate::shadows::ParseError::Scan)?;

--- a/src/mqtt/greengrass.rs
+++ b/src/mqtt/greengrass.rs
@@ -27,7 +27,7 @@ use std::task::Poll;
 use bytes::Bytes;
 use tokio::sync::mpsc;
 
-use crate::mqtt::{MqttMessage, MqttSubscription, PublishOptions, QoS, ToPayload};
+use crate::mqtt::{MqttMessage, MqttSubscription, PayloadError, PublishOptions, QoS, ToPayload};
 
 type TopicChannel = mpsc::UnboundedSender<greengrass_ipc_rust::MqttMessage>;
 
@@ -175,12 +175,15 @@ impl crate::mqtt::MqttClient for GreengrassClient {
         let client = self.client.clone();
         let topic = topic.to_string();
         async move {
-            // Encode payload to Bytes
-            let mut buf = vec![0u8; payload.max_size()];
-            let len = payload.encode(&mut buf).map_err(|_| {
-                greengrass_ipc_rust::Error::SerializationError(
-                    "Payload encoding failed".to_string(),
-                )
+            // Preserve which PayloadError occurred so a too-small buffer (the common
+            // cause) stays distinguishable from a real serialization failure.
+            let cap = payload.max_size();
+            let mut buf = vec![0u8; cap];
+            let len = payload.encode(&mut buf).map_err(|e| {
+                greengrass_ipc_rust::Error::SerializationError(match e {
+                    PayloadError::BufferSize => format!("payload exceeds {cap}-byte encode buffer"),
+                    PayloadError::EncodingFailed => "payload serialization failed".to_string(),
+                })
             })?;
             buf.truncate(len);
 

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -103,11 +103,20 @@ where
                     S::NAME,
                 )?;
 
-                let sub = self
+                // match + early return, not `.map_err(|e| ..)`: binding `e` in a closure
+                // under the downstream `generic_const_exprs` build trips a normalization
+                // ICE on this impl's const-generic bounds. Same at the publish sites.
+                let sub = match self
                     .mqtt
                     .subscribe(&[(topic.as_str(), QoS::AtLeastOnce)])
                     .await
-                    .map_err(|_| Error::Mqtt)?;
+                {
+                    Ok(sub) => sub,
+                    Err(e) => {
+                        warn!("Shadow delta subscribe failed for {}: {:?}", topic.as_str(), e);
+                        return Err(Error::Mqtt);
+                    }
+                };
 
                 let _ = sub_ref.insert(sub);
 
@@ -329,14 +338,26 @@ where
             S::NAME,
         )?;
 
-        let sub = self
+        // match, not `.map_err(|e| ..)`: closure-binding `e` trips an ICE — see handle_delta.
+        let sub = match self
             .mqtt
             .subscribe(&[
                 (accepted_topic.as_str(), QoS::AtLeastOnce),
                 (rejected_topic.as_str(), QoS::AtLeastOnce),
             ])
             .await
-            .map_err(|_| Error::Mqtt)?;
+        {
+            Ok(sub) => sub,
+            Err(e) => {
+                warn!(
+                    "Shadow subscribe failed for {} / {}: {:?}",
+                    accepted_topic.as_str(),
+                    rejected_topic.as_str(),
+                    e
+                );
+                return Err(Error::Mqtt);
+            }
+        };
 
         //*** PUBLISH REQUEST ***/
         let topic_name = topic.format::<{ max_topic_len(S::PREFIX, S::NAME) }>(
@@ -344,14 +365,18 @@ where
             self.mqtt.client_id(),
             S::NAME,
         )?;
-        self.mqtt
+        if let Err(e) = self
+            .mqtt
             .publish_with_options(
                 topic_name.as_str(),
                 payload,
                 PublishOptions::new().qos(QoS::AtLeastOnce),
             )
             .await
-            .map_err(|_| Error::Mqtt)?;
+        {
+            warn!("Shadow publish failed for {}: {:?}", topic_name.as_str(), e);
+            return Err(Error::Mqtt);
+        }
 
         Ok(sub)
     }

--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -194,7 +194,9 @@ where
 
         let payload = DeferredPayload::new(
             |buf: &mut [u8]| {
-                serde_json_core::to_slice(&request, buf).map_err(|_| PayloadError::EncodingFailed)
+                // serde_json_core only returns BufferFull, so failure here means the
+                // request outgrew MAX_PAYLOAD_SIZE — report BufferSize, not EncodingFailed.
+                serde_json_core::to_slice(&request, buf).map_err(|_| PayloadError::BufferSize)
             },
             S::MAX_PAYLOAD_SIZE + PARTIAL_REQUEST_OVERHEAD,
         );

--- a/tests/externally_tagged_enum.rs
+++ b/tests/externally_tagged_enum.rs
@@ -1,0 +1,59 @@
+//! Regression test for externally-tagged enums that mix a unit variant with a
+//! newtype variant (the `FlowMode { Custom, Managed(..) }` shape used by
+//! factbird-edge flow-manager).
+//!
+//! serde serializes the UNIT variant as a bare JSON string (`"custom"`) but the
+//! newtype variant as an object (`{"managed": {..}}`). The generated
+//! `parse_delta` scans for object keys, so before this fix a bare-string unit
+//! variant failed with `ParseError::Scan(Expected '{' ...)` — breaking every
+//! delta / accepted-response that carried `mode:"custom"`.
+
+#![cfg(all(feature = "std", feature = "shadows_kv_persist"))]
+#![allow(async_fn_in_trait)]
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+
+use postcard::experimental::max_size::MaxSize;
+use rustot::shadows::{NullResolver, ShadowNode};
+use rustot_derive::shadow_node;
+use serde::{Deserialize, Serialize};
+
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+pub struct Template {
+    pub id: u32,
+    pub version: u32,
+}
+
+/// Mirror of flow-manager's `FlowMode`: externally-tagged, `rename_all`, a unit
+/// default variant plus a newtype variant.
+#[shadow_node]
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, MaxSize)]
+#[serde(rename_all = "lowercase")]
+pub enum Mode {
+    #[default]
+    Custom,
+    Managed(Template),
+}
+
+#[tokio::test]
+async fn unit_variant_parses_from_bare_string() {
+    let r = NullResolver;
+
+    // The form serde actually emits for the unit variant. Regressed before fix.
+    <Mode as ShadowNode>::parse_delta(b"\"custom\"", "", &r)
+        .await
+        .expect("bare-string unit variant must parse");
+
+    // Newtype variant (object form) must still parse.
+    <Mode as ShadowNode>::parse_delta(br#"{"managed":{"id":1,"version":2}}"#, "", &r)
+        .await
+        .expect("newtype variant object form must parse");
+
+    // Unknown bare string is a clean error, not a panic or Scan failure.
+    assert!(
+        <Mode as ShadowNode>::parse_delta(b"\"bogus\"", "", &r)
+            .await
+            .is_err()
+    );
+}


### PR DESCRIPTION
Two related shadow fixes, found while debugging a flow-manager custom-mode flow that never applied.

- **Bare-string unit variant parsing** - serde serializes an externally-tagged unit variant as a bare JSON string (`"custom"`) but a newtype variant as an object (`{"managed":{..}}`). The generated `parse_delta` only scans for object keys, so a mixed enum like `FlowMode { Custom, Managed(..) }` failed on a `mode:"custom"` delta with `ParseError::Scan(Expected '{')` - breaking every custom-mode update. The bare-string form is now matched before the object scanner runs. Regression test in `tests/externally_tagged_enum.rs`.

- **Surface dropped MQTT errors** - the shadow subscribe/publish helpers collapsed every failure into a contentless `Error::Mqtt`, so a caller only ever saw "Mqtt" and the real cause was gone. That masked a live buffer-sizing bug. Log the underlying error (with the topic) before collapsing.

- **Preserve the real payload-encode error** - `serde_json_core` only fails with `BufferFull`, but the encode closure relabeled it `EncodingFailed` and the Greengrass client flattened both `PayloadError` variants to "Payload encoding failed", hiding that the payload had outgrown `MAX_PAYLOAD_SIZE`. Now maps to `BufferSize` and reports the buffer size, so an oversized shadow payload is diagnosable straight from the log.

## Notes

- The logging uses `match` + early return instead of `.map_err(|e| ..)`. Binding the generic error in a closure under a downstream `generic_const_exprs` build trips a `NormalizationChecker` ICE on the impl's const-generic bounds. Call-site comments flag it.
- The same `.map_err(|_| EncodingFailed)` mislabel exists in the jobs/commands/provisioning publish paths. Left for a follow-up sweep.
