### PR TITLE
feat(shadows): decompose nested report_only(persist) fields to KV

### DIFF
--- a/rustot_derive/src/codegen/adjacently_tagged.rs
+++ b/rustot_derive/src/codegen/adjacently_tagged.rs
@@ -1131,6 +1131,64 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
     // =========================================================================
     // 6. Generate ReportedFields Implementation
     // =========================================================================
+    // Must mirror the State enum's `persist_to_kv` layout (`/_variant` + active
+    // variant) so a nested adjacently-tagged `report_only(persist)` enum round-trips
+    // against `load_from_kv` — otherwise a whole-enum blob, which can't.
+    #[cfg(not(feature = "kv_persist"))]
+    let persist_reported_kv_method = quote! {};
+    #[cfg(feature = "kv_persist")]
+    let persist_reported_kv_method = {
+        let mut variant_name_arms = Vec::new();
+        let mut inner_persist_arms = Vec::new();
+        for (variant, serde_name) in variants.iter().zip(variant_names.iter()) {
+            let variant_ident = &variant.ident;
+            match &variant.fields {
+                Fields::Unit => {
+                    variant_name_arms
+                        .push(quote! { #reported_name::#variant_ident => #serde_name, });
+                    inner_persist_arms.push(quote! { #reported_name::#variant_ident => {} });
+                }
+                Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+                    let variant_path = format!("/{}", serde_name);
+                    variant_name_arms
+                        .push(quote! { #reported_name::#variant_ident(_) => #serde_name, });
+                    inner_persist_arms.push(quote! {
+                        #reported_name::#variant_ident(ref __inner) => {
+                            let __saved_len = __key_buf.len();
+                            let _ = __key_buf.push_str(#variant_path);
+                            #krate::shadows::ReportedFields::persist_reported_kv(__inner, __key_buf, __kv).await?;
+                            __key_buf.truncate(__saved_len);
+                        }
+                    });
+                }
+                _ => {}
+            }
+        }
+        quote! {
+            fn persist_reported_kv<__K: #krate::shadows::KVStore, const KEY_LEN: usize>(
+                &self,
+                __key_buf: &mut #krate::__macro_support::heapless::String<KEY_LEN>,
+                __kv: &__K,
+            ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<__K::Error>>> {
+                async move {
+                    let __saved_len = __key_buf.len();
+                    let _ = __key_buf.push_str(#VARIANT_KEY_PATH);
+                    let __variant_name: &str = match self {
+                        #(#variant_name_arms)*
+                    };
+                    __kv.store(__key_buf.as_str(), __variant_name.as_bytes())
+                        .await
+                        .map_err(#krate::shadows::KvError::Kv)?;
+                    __key_buf.truncate(__saved_len);
+                    match self {
+                        #(#inner_persist_arms)*
+                    }
+                    Ok(())
+                }
+            }
+        }
+    };
+
     let reported_union_fields_impl = quote! {
         impl #krate::shadows::ReportedFields for #reported_name {
             const FIELD_NAMES: &'static [&'static str] = &[#tag_key];
@@ -1142,6 +1200,8 @@ pub(crate) fn generate_adjacently_tagged_enum_code(
                 // Adjacently-tagged enums serialize via their custom Serialize impl
                 Ok(())
             }
+
+            #persist_reported_kv_method
         }
 
         impl #krate::shadows::ReportedDiff for #reported_name {

--- a/rustot_derive/src/codegen/struct_codegen.rs
+++ b/rustot_derive/src/codegen/struct_codegen.rs
@@ -105,6 +105,8 @@ struct FieldCodegen {
 
     /// persist_report_only() arm for report_only(persist) fields (None otherwise)
     persist_report_only_arm: Option<TokenStream>,
+    /// persist_reported_kv() arm — every field in the KV layout (None for transient report_only)
+    persist_reported_kv_arm: Option<TokenStream>,
 
     /// Whether this field is flattened
     is_flatten: bool,
@@ -123,6 +125,49 @@ struct FieldCodegen {
 /// Leaf fields are serialized directly as their type. Nested fields delegate
 /// to their inner ShadowNode implementation for Delta/Reported types and
 /// KV operations.
+/// A skip-`None` KV-persist arm for one `Reported` field. Must mirror the State
+/// `persist_to_kv` key layout exactly, or `load_from_kv` can't read it back.
+/// Expects `self` = the `Reported` struct, with `__key_buf`/`__kv` in scope.
+fn reported_persist_arm(
+    krate: &TokenStream,
+    serde_name: &str,
+    field_name: &syn::Ident,
+    field_ty: &syn::Type,
+    is_leaf: bool,
+    attrs: &FieldAttrs,
+) -> TokenStream {
+    let field_kv_path = format!("/{}", serde_name);
+    if is_leaf {
+        let buf_size = if let Some(explicit_size) = attrs.opaque_max_size() {
+            quote! { #explicit_size }
+        } else {
+            quote! {
+                <#field_ty as #krate::__macro_support::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE
+            }
+        };
+        quote! {
+            if let Some(ref val) = self.#field_name {
+                let __saved_len = __key_buf.len();
+                let _ = __key_buf.push_str(#field_kv_path);
+                let mut __buf = [0u8; #buf_size];
+                let bytes = #krate::__macro_support::postcard::to_slice(val, &mut __buf)
+                    .map_err(|_| #krate::shadows::KvError::Serialization)?;
+                __kv.store(__key_buf.as_str(), bytes).await.map_err(#krate::shadows::KvError::Kv)?;
+                __key_buf.truncate(__saved_len);
+            }
+        }
+    } else {
+        quote! {
+            if let Some(ref val) = self.#field_name {
+                let __saved_len = __key_buf.len();
+                let _ = __key_buf.push_str(#field_kv_path);
+                #krate::shadows::ReportedFields::persist_reported_kv(val, __key_buf, __kv).await?;
+                __key_buf.truncate(__saved_len);
+            }
+        }
+    }
+}
+
 fn process_field(field: &syn::Field, krate: &TokenStream) -> syn::Result<FieldCodegen> {
     let field_name = field.ident.as_ref().unwrap();
     let field_ty = &field.ty;
@@ -465,34 +510,23 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> syn::Result<FieldCo
         })
     };
 
-    // --- persist_report_only arm (only for report_only(persist) leaf fields) ---
+    // Skip-`None` persist over the partial `Reported`: a `None` field keeps its
+    // prior KV value, so a partial report merges with prior state at load. Replaces
+    // the old whole-value blob, which couldn't round-trip a nested `#[shadow_node]`
+    // against the decomposed `load_from_kv`.
+    let reported_persist_arm =
+        reported_persist_arm(krate, &serde_name, field_name, field_ty, is_leaf, &attrs);
+    // Entry point: only `report_only(persist)` fields.
     let persist_report_only_arm = if attrs.is_report_only_persist() {
-        let field_kv_path = format!("/{}", serde_name);
-        // Honor an explicit `opaque(max_size = N)` bound; only fall back to the
-        // `MaxSize` trait when no explicit size is given (mirrors the ValueBuf
-        // sizing below). This lets `report_only(persist)` hold types that don't
-        // implement `MaxSize` (e.g. `String`-carrying enums) as long as the field
-        // is `opaque(max_size = N)`.
-        let buf_size = if let Some(explicit_size) = attrs.opaque_max_size() {
-            quote! { #explicit_size }
-        } else {
-            quote! {
-                <#field_ty as #krate::__macro_support::postcard::experimental::max_size::MaxSize>::POSTCARD_MAX_SIZE
-            }
-        };
-        Some(quote! {
-            if let Some(ref val) = self.#field_name {
-                let __saved_len = __key_buf.len();
-                let _ = __key_buf.push_str(#field_kv_path);
-                let mut __buf = [0u8; #buf_size];
-                let bytes = #krate::__macro_support::postcard::to_slice(val, &mut __buf)
-                    .map_err(|_| #krate::shadows::KvError::Serialization)?;
-                __kv.store(__key_buf.as_str(), bytes).await.map_err(#krate::shadows::KvError::Kv)?;
-                __key_buf.truncate(__saved_len);
-            }
-        })
+        Some(reported_persist_arm.clone())
     } else {
         None
+    };
+    // Recursive walker: every field in the KV layout (all but transient report_only).
+    let persist_reported_kv_arm = if attrs.is_report_only() && !attrs.is_report_only_persist() {
+        None
+    } else {
+        Some(reported_persist_arm)
     };
 
     Ok(FieldCodegen {
@@ -515,6 +549,7 @@ fn process_field(field: &syn::Field, krate: &TokenStream) -> syn::Result<FieldCo
         reported_builder_assign,
         reported_diff_arm,
         persist_report_only_arm,
+        persist_reported_kv_arm,
         is_flatten,
         parse_delta_match_arm,
     })
@@ -622,6 +657,10 @@ pub(crate) fn generate_struct_code(
     let persist_report_only_arms: Vec<_> = field_codegens
         .iter()
         .filter_map(|f| f.persist_report_only_arm.clone())
+        .collect();
+    let persist_reported_kv_arms: Vec<_> = field_codegens
+        .iter()
+        .filter_map(|f| f.persist_reported_kv_arm.clone())
         .collect();
 
     // Generate Delta type - always use FieldScanner, no Deserialize needed
@@ -1109,23 +1148,39 @@ pub(crate) fn generate_struct_code(
         #kv_persist_impl
     };
 
-    // Generate persist_report_only override if there are report_only(persist) fields
     #[cfg(not(feature = "kv_persist"))]
     let persist_report_only_method = quote! {};
     #[cfg(feature = "kv_persist")]
-    let persist_report_only_method = if persist_report_only_arms.is_empty() {
-        quote! {}
-    } else {
+    let persist_report_only_method = {
+        let persist_report_only_entry = if persist_report_only_arms.is_empty() {
+            quote! {}
+        } else {
+            quote! {
+                fn persist_report_only<__K: #krate::shadows::KVStore>(
+                    &self,
+                    __prefix: &str,
+                    __kv: &__K,
+                ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<__K::Error>>> {
+                    async move {
+                        let mut __key_buf_owned = #krate::__macro_support::heapless::String::<64>::new();
+                        let _ = __key_buf_owned.push_str(__prefix);
+                        let __key_buf = &mut __key_buf_owned;
+                        #(#persist_report_only_arms)*
+                        Ok(())
+                    }
+                }
+            }
+        };
         quote! {
-            fn persist_report_only<__K: #krate::shadows::KVStore>(
+            #persist_report_only_entry
+
+            fn persist_reported_kv<__K: #krate::shadows::KVStore, const KEY_LEN: usize>(
                 &self,
-                __prefix: &str,
+                __key_buf: &mut #krate::__macro_support::heapless::String<KEY_LEN>,
                 __kv: &__K,
             ) -> impl ::core::future::Future<Output = Result<(), #krate::shadows::KvError<__K::Error>>> {
                 async move {
-                    let mut __key_buf = #krate::__macro_support::heapless::String::<64>::new();
-                    let _ = __key_buf.push_str(__prefix);
-                    #(#persist_report_only_arms)*
+                    #(#persist_reported_kv_arms)*
                     Ok(())
                 }
             }

--- a/src/shadows/error.rs
+++ b/src/shadows/error.rs
@@ -47,6 +47,12 @@ pub enum KvError<E: Debug> {
     /// Invalid stored variant data
     InvalidVariant,
 
+    /// A non-`opaque` type nested in a `report_only(persist)` value has no
+    /// decomposed KV persist — `heapless::Vec`/`LinearMap`/arrays (would force
+    /// `T: MaxSize` onto `ShadowNode`), maps, and non-adjacently-tagged enums.
+    /// Mark the field `opaque` to store it as a whole-value blob instead.
+    Unsupported,
+
     /// Migration error
     Migration(super::migration::MigrationError),
 }
@@ -67,6 +73,7 @@ impl<E: Debug> core::fmt::Display for KvError<E> {
             KvError::VariantMismatch => write!(f, "variant mismatch"),
             KvError::UnknownVariant => write!(f, "unknown variant"),
             KvError::InvalidVariant => write!(f, "invalid variant"),
+            KvError::Unsupported => write!(f, "unsupported report_only(persist) nested type"),
             KvError::Migration(e) => write!(f, "migration error: {:?}", e),
         }
     }

--- a/src/shadows/impls/heapless_impls.rs
+++ b/src/shadows/impls/heapless_impls.rs
@@ -22,7 +22,10 @@ use crate::shadows::data_types::Patch;
 // heapless::String<N>
 // =============================================================================
 
-impl<const N: usize> ShadowNode for heapless::String<N> {
+impl<const N: usize> ShadowNode for heapless::String<N>
+where
+    [(); N + 5]:,
+{
     type Delta = heapless::String<N>;
     type Reported = heapless::String<N>;
 
@@ -55,11 +58,26 @@ impl<const N: usize> ShadowNode for heapless::String<N> {
     }
 }
 
-impl<const N: usize> ReportedFields for heapless::String<N> {
+#[cfg_attr(feature = "shadows_kv_persist", allow(incomplete_features))]
+impl<const N: usize> ReportedFields for heapless::String<N>
+where
+    [(); N + 5]:,
+{
     const FIELD_NAMES: &'static [&'static str] = &[];
 
     fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
         Ok(())
+    }
+
+    // `Reported == Self`; reuse the exact-sized State write. The `[(); N + 5]:`
+    // bound is the same one the `KVPersist` impl already carries.
+    #[cfg(feature = "shadows_kv_persist")]
+    fn persist_reported_kv<K: KVStore, const KEY_LEN: usize>(
+        &self,
+        key_buf: &mut heapless::String<KEY_LEN>,
+        kv: &K,
+    ) -> impl core::future::Future<Output = Result<(), KvError<K::Error>>> {
+        <Self as KVPersist>::persist_to_kv::<K, KEY_LEN>(self, key_buf, kv)
     }
 }
 

--- a/src/shadows/impls/opaque.rs
+++ b/src/shadows/impls/opaque.rs
@@ -87,6 +87,18 @@ macro_rules! impl_opaque {
             ) -> Result<(), S::Error> {
                 Ok(())
             }
+
+            // Needed because a non-`opaque` scalar (e.g. `u32`) nested in a
+            // `report_only(persist)` value is recursed into, not written inline.
+            // `Reported == Self`, so it's the same write as the State path.
+            #[cfg(feature = "shadows_kv_persist")]
+            fn persist_reported_kv<K: $crate::shadows::KVStore, const KEY_LEN: usize>(
+                &self,
+                key_buf: &mut heapless::String<KEY_LEN>,
+                kv: &K,
+            ) -> impl ::core::future::Future<Output = Result<(), $crate::shadows::KvError<K::Error>>> {
+                <Self as $crate::shadows::KVPersist>::persist_to_kv::<K, KEY_LEN>(self, key_buf, kv)
+            }
         }
 
         impl $crate::shadows::ReportedDiff for $ty {

--- a/src/shadows/impls/std_impls.rs
+++ b/src/shadows/impls/std_impls.rs
@@ -59,6 +59,17 @@ impl ReportedFields for String {
     fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
         Ok(())
     }
+
+    // Covers a bare (non-`opaque`) `String` nested in a `report_only(persist)`
+    // value, which is recursed into rather than written inline.
+    #[cfg(feature = "shadows_kv_persist")]
+    fn persist_reported_kv<K: KVStore, const KEY_LEN: usize>(
+        &self,
+        key_buf: &mut heapless::String<KEY_LEN>,
+        kv: &K,
+    ) -> impl core::future::Future<Output = Result<(), KvError<K::Error>>> {
+        <Self as KVPersist>::persist_to_kv::<K, KEY_LEN>(self, key_buf, kv)
+    }
 }
 
 impl crate::shadows::ReportedDiff for String {
@@ -191,6 +202,16 @@ where
 
     fn serialize_into_map<S: SerializeMap>(&self, _map: &mut S) -> Result<(), S::Error> {
         Ok(())
+    }
+
+    // `Vec` persists as an atomic blob (`Reported == Self`); reuse the State write.
+    #[cfg(feature = "shadows_kv_persist")]
+    fn persist_reported_kv<K: KVStore, const KEY_LEN: usize>(
+        &self,
+        key_buf: &mut heapless::String<KEY_LEN>,
+        kv: &K,
+    ) -> impl core::future::Future<Output = Result<(), KvError<K::Error>>> {
+        <Self as KVPersist>::persist_to_kv::<K, KEY_LEN>(self, key_buf, kv)
     }
 }
 

--- a/src/shadows/mod.rs
+++ b/src/shadows/mod.rs
@@ -280,6 +280,24 @@ pub trait ReportedFields: Serialize {
     ) -> impl core::future::Future<Output = Result<(), KvError<K::Error>>> {
         core::future::ready(Ok(()))
     }
+
+    /// Persist this `Reported` subtree to KV, decomposed and skip-`None`, matching
+    /// the State `KVPersist::persist_to_kv` key layout. A `None` field keeps its
+    /// prior KV value, so a partial report merges with prior state at load.
+    ///
+    /// The default errors with [`KvError::Unsupported`] instead of silently
+    /// dropping data. Types where a decomposed persist would force `T: MaxSize`
+    /// onto their `ShadowNode` impl (`heapless::Vec`/`LinearMap`/arrays), plus maps
+    /// and non-adjacently-tagged enums, keep it — mark such a field `opaque` to
+    /// store it as a whole-value blob instead.
+    #[cfg(feature = "shadows_kv_persist")]
+    fn persist_reported_kv<K: KVStore, const KEY_LEN: usize>(
+        &self,
+        _key_buf: &mut heapless::String<KEY_LEN>,
+        _kv: &K,
+    ) -> impl core::future::Future<Output = Result<(), KvError<K::Error>>> {
+        core::future::ready(Err(KvError::Unsupported))
+    }
 }
 
 /// Trait for diffing Reported types in-place.

--- a/src/shadows/shadow/tests.rs
+++ b/src/shadows/shadow/tests.rs
@@ -715,6 +715,101 @@ struct ReportOnlyPersistOpaqueTest {
     blob: PersistedBlob,
 }
 
+// Round-trip for a nested adjacently-tagged `report_only(persist)` enum, plus the
+// partial-report merge (below).
+#[shadow_node]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+struct ActiveParams {
+    #[shadow_attr(opaque(max_size = 32))]
+    label: String,
+    counter: u32,
+}
+
+#[shadow_node]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "params", rename_all = "snake_case")]
+enum NodeMode {
+    #[default]
+    Idle,
+    Active(ActiveParams),
+}
+
+#[shadow_root(name = "node_persist")]
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct NodeShadow {
+    threshold: String,
+    #[shadow_attr(report_only(persist))]
+    mode: NodeMode,
+}
+
+#[tokio::test]
+async fn test_report_only_persist_nested_enum_roundtrips_and_merges() {
+    use crate::shadows::{KVPersist, ReportedFields, ShadowNode};
+
+    let kv = FileKVStore::temp().unwrap();
+    let prefix = "node_persist";
+
+    async fn load(kv: &FileKVStore, prefix: &str) -> NodeMode {
+        let mut state = NodeShadow::default();
+        let mut kb = heapless::String::<64>::new();
+        kb.push_str(prefix).unwrap();
+        state.load_from_kv(&mut kb, kv).await.unwrap();
+        state.mode
+    }
+
+    // 1. Full report of the data variant → decomposed persist → load round-trips.
+    let full = ReportedNodeShadow {
+        mode: Some(
+            NodeMode::Active(ActiveParams {
+                label: "alpha".into(),
+                counter: 2,
+            })
+            .into_reported(),
+        ),
+        ..Default::default()
+    };
+    full.persist_report_only(prefix, &kv).await.unwrap();
+
+    match load(&kv, prefix).await {
+        NodeMode::Active(p) => {
+            assert_eq!(p.label, "alpha");
+            assert_eq!(p.counter, 2);
+        }
+        other => panic!("expected Active, got {other:?}"),
+    }
+
+    // 2. Partial report (counter only) must PRESERVE label — the merge happens at
+    //    load because the unreported (`None`) key keeps its prior value.
+    let partial = ReportedNodeShadow {
+        mode: Some(ReportedNodeMode::Active(ReportedActiveParams {
+            label: None,
+            counter: Some(3),
+        })),
+        ..Default::default()
+    };
+    partial.persist_report_only(prefix, &kv).await.unwrap();
+
+    match load(&kv, prefix).await {
+        NodeMode::Active(p) => {
+            assert_eq!(
+                p.label, "alpha",
+                "partial report must not clobber unreported field"
+            );
+            assert_eq!(p.counter, 3);
+        }
+        other => panic!("expected Active, got {other:?}"),
+    }
+
+    // 3. Variant switch to a unit variant — tag-driven load ignores the now-stale
+    //    `active/*` keys still in KV.
+    let idle = ReportedNodeShadow {
+        mode: Some(ReportedNodeMode::Idle),
+        ..Default::default()
+    };
+    idle.persist_report_only(prefix, &kv).await.unwrap();
+    assert_eq!(load(&kv, prefix).await, NodeMode::Idle);
+}
+
 #[shadow_root(name = "wifi")]
 #[derive(Clone, Default, Serialize, Deserialize)]
 struct WifiCfg {


### PR DESCRIPTION
## Summary

`report_only(persist)` persisted each field as one whole-value postcard blob via a separate `ReportedFields::persist_report_only` path. That couldn't round-trip a nested `#[shadow_node]` (struct or adjacently-tagged enum) against the decomposed `load_from_kv`, and demanded `MaxSize` on the whole type — so a nested persisted enum didn't even compile.

This persists the `Reported` side **decomposed**, mirroring the State `persist_to_kv` key layout so `load_from_kv` reads it back. Since a `Reported` is a partial projection, unreported (`None`) fields keep their prior KV value — a partial report **merges with prior state at load**, with no read-modify-write. The shape parallels `persist_delta` (the same skip-`None` decomposed walk over `Delta`).

## ⚠️ Migration

**The KV layout for a non-`opaque` `report_only(persist)` field changes.** A nested `#[shadow_node]` value now persists as **decomposed keys** (`/field/...`) instead of a single whole-value blob at `/field`. A device that previously persisted such a field as a blob will not find the decomposed keys on upgrade, so **the value resets to its default on first boot after the update**.

**To keep the previous blob layout (and avoid the reset), add `opaque` to every `report_only(persist)` attribute you want unchanged:**

```rust
// now decomposes (new default)
#[shadow_attr(report_only(persist))]

// keeps the old whole-value blob layout
#[shadow_attr(report_only(persist), opaque(max_size = N))]
```

Notes:
- Leaf and scalar fields already persisted as a single key and are **unaffected** either way.
- Adjacently-tagged enums can't be postcard-blobbed, so they **must** use the new decomposed form (they didn't compile as `report_only(persist)` before this PR).

## Coverage

- Terminal leaf types whose `Reported == Self` — primitives, std `String`/`Vec`, `heapless::String` — delegate to their existing `persist_to_kv`.
- The default `persist_reported_kv` errors with `KvError::Unsupported` (not a silent drop) for types that can't be decomposed without narrowing `ShadowNode` (`heapless::Vec`/`LinearMap`/arrays would force `T: MaxSize` onto their `ShadowNode` impl), need a per-entry walker (maps), or are non-adjacently-tagged enums. Mark such a field `opaque` to store it as a whole-value blob instead.

## Notes

- The old whole-value blob path and its `MaxSize` demand are removed; the leaf `opaque(max_size)` sizing from #133 is preserved for leaf fields.
- Adds a round-trip test covering full report, partial-report merge (unreported field preserved), and variant switch (tag-driven load ignoring stale keys).