### PR TITLE
fix(provisioning): size RegisterThing publish topic buffer to 150

### DIFF
--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -238,7 +238,7 @@ impl FleetProvisioner {
             .await
             .map_err(|_| Error::Mqtt)?;
 
-        let publish_topic = Topic::RegisterThing(template_name, payload_format).format::<69>()?;
+        let publish_topic = Topic::RegisterThing(template_name, payload_format).format::<150>()?;
         mqtt.publish_with_options(
             publish_topic.as_str(),
             payload,


### PR DESCRIPTION
## Summary

The `RegisterThing` publish topic is formatted into a 69-byte buffer (`provisioning/mod.rs:241`, `format::<69>()`), while its sibling accepted/rejected topics use `format::<150>()`.

The publish topic `$aws/provisioning-templates/{template}/provision/{fmt}` is **71 bytes** for a 28-char template name:

| segment | len |
|---------|-----|
| `$aws/provisioning-templates` | 27 |
| `/` | 1 |
| `fleetDuoProvisioningTemplate` | 28 |
| `/provision/` | 11 |
| `cbor` | 4 |
| **total** | **71** |

71 > 69, so `Topic::format` overflows and `RegisterThing` fails with `Error::Overflow` after the accepted/rejected subscribe and before the publish. Any provisioning template name longer than 26 characters hits this.

The publish topic is always shorter than its accepted/rejected variants (no `/accepted` or `/rejected` suffix), so sizing it at 150 matches them and is safely sufficient.