### PR TITLE
chore(deps): bump mqttrust to 6bc92de

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ sequential-storage = { version = "7.0", features = [
 serde-json-core = { version = "0.6" }
 rustot-derive = { path = "rustot_derive", version = "0.2.1" }
 embedded-storage-async = { version = "0.4", optional = true }
-mqttrust = { git = "https://github.com/FactbirdHQ/mqttrust", rev = "04e4a0c", optional = true }
+mqttrust = { git = "https://github.com/FactbirdHQ/mqttrust", rev = "6bc92de", optional = true }
 
 embassy-time = { version = "0.5.0" }
 embassy-sync = "0.8"


### PR DESCRIPTION
## Summary

Bumps rustot's `mqttrust` dependency from `04e4a0c` to `6bc92de`, which consumes the CONNECT encode-buffer fix (mqttrust #82) plus the intervening embassy-sync 0.8 bump (#80) and clean-session reconnect detection (#81).

Downstream firmware pins mqttrust directly at `6bc92de`. With rustot still on `04e4a0c`, the dependency graph carries two mqttrust versions, so `rustot::mqtt::MqttClient` is implemented for a different `mqttrust::MqttClient` type than the consumer instantiates and the trait bound fails to resolve (E0277). This bump keeps rustot and firmware on a single mqttrust version.

Verified: `cargo check --no-default-features --features mqtt_mqttrust,provision_cbor` compiles clean.