### PR TITLE
fix(shadows): bound delta ack so a lost ack can't strand an applied delta

### DIFF
--- a/src/shadows/shadow/cloud.rs
+++ b/src/shadows/shadow/cloud.rs
@@ -22,6 +22,17 @@ use crate::shadows::{
 
 use super::Shadow;
 
+/// Upper bound on how long `apply_delta_and_ack` waits for the cloud to accept
+/// the reported ack after a delta has already been applied to local storage.
+///
+/// The delta is persisted before the ack is published, so a link drop right
+/// after publish (the `UpdateAccepted`/`Rejected` response is lost and AWS does
+/// not re-send it) would otherwise park the ack wait forever and strand the
+/// applied delta — the caller never learns the state changed. On timeout we
+/// keep the applied state and let the reported side reconcile on a later
+/// sync/reconnect.
+const DELTA_ACK_TIMEOUT: embassy_time::Duration = embassy_time::Duration::from_secs(30);
+
 /// Drop-guard that clears `Shadow::subscription` unless explicitly disarmed.
 ///
 /// `handle_delta`'s lazy-subscribe path installs the delta-topic subscription
@@ -117,7 +128,27 @@ where
             .map_err(|_| Error::DaoWrite)?;
         let reported = state.into_partial_reported(delta);
         let cleanup = state.desired_cleanup(delta);
-        self.update_shadow(cleanup, Some(reported)).await?;
+        // The delta is already committed to local storage above. Bound the cloud
+        // ack so a link drop right after the update is published can't park the
+        // wait indefinitely and strand the applied delta (see DELTA_ACK_TIMEOUT).
+        // On timeout keep the applied state; the reported side reconciles on the
+        // next sync (the delta stays pending cloud-side until reported).
+        match embassy_time::with_timeout(
+            DELTA_ACK_TIMEOUT,
+            self.update_shadow(cleanup, Some(reported)),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_timeout) => {
+                warn!(
+                    "[{:?}] delta ack timed out after {}s; state applied locally, reported ack deferred",
+                    S::NAME.unwrap_or(CLASSIC_SHADOW),
+                    DELTA_ACK_TIMEOUT.as_secs(),
+                );
+            }
+        }
         Ok(state)
     }
 


### PR DESCRIPTION
`apply_delta_and_ack` persists the delta to local storage before publishing the reported ack. If the link drops right after the publish, the `UpdateAccepted`/`Rejected` response is lost and AWS does not re-send it — so the wait parked forever and `wait_delta` never returned. The caller never learned the delta applied.

Observed on hardware over a flaky cellular link: a device applied a shadow-driven config change, never reported it, and kept acting on the superseded config.

Bounds the ack at `DELTA_ACK_TIMEOUT` (30s). On timeout the applied state is kept and the reported side reconciles on a later sync. Genuine errors still propagate; only the timeout is swallowed, with a warning.

Known limitations (deliberate, to keep this small):
- The timeout wraps all of `update_shadow`, including the `wait_connected()` that precedes the publish — so a timeout cannot distinguish "never published" from "published, ack lost" from "published, rejected, rejection missed".
- Reconciliation depends on `sync_shadow`, which only runs on a resubscribe (first call or clean-session reconnect). If the session survives, reported stays diverged until the next reconnect.
- The precise fix is to abort on disconnect rather than on a wall-clock timeout, but `MqttClient` exposes only `wait_connected()` — adding a disconnect signal means touching all four backends. Worth a follow-up issue.
- No test for the timeout path yet; the mock client could drive it.
